### PR TITLE
Support the new `meaning` and `style` fields for example sentences

### DIFF
--- a/src/backend/models/Example.ts
+++ b/src/backend/models/Example.ts
@@ -1,10 +1,18 @@
 import mongoose from 'mongoose';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
+// @ts-ignore
 const exampleSchema = new Schema({
   igbo: { type: String, default: '' },
   english: { type: String, default: '' },
+  meaning: { type: String, default: '' },
+  style: {
+    type: String,
+    enum: Object.values(ExampleStyle).map(({ value }) => value),
+    default: ExampleStyle.NO_STYLE.value,
+  },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   pronunciation: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -1,13 +1,21 @@
 import mongoose from 'mongoose';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
+import SuggestionSource from 'src/backend/shared/constants/SuggestionSource';
 import { toJSONPlugin, toObjectPlugin } from './plugins/index';
 import { uploadExamplePronunciation } from './plugins/pronunciationHooks';
-import SuggestionSource from '../shared/constants/SuggestionSource';
 
 const { Schema, Types } = mongoose;
+// @ts-ignore
 const exampleSuggestionSchema = new Schema({
   originalExampleId: { type: Types.ObjectId, ref: 'Example', default: null },
   igbo: { type: String, default: '' },
   english: { type: String, default: '' },
+  meaning: { type: String, default: '' },
+  style: {
+    type: String,
+    enum: Object.values(ExampleStyle).map(({ value }) => value),
+    default: ExampleStyle.NO_STYLE.value,
+  },
   associatedWords: { type: [{ type: Types.ObjectId }], default: [] },
   pronunciation: { type: String, default: '' },
   exampleForSuggestion: { type: Boolean, default: false },

--- a/src/backend/shared/constants/ExampleStyle.ts
+++ b/src/backend/shared/constants/ExampleStyle.ts
@@ -1,0 +1,15 @@
+/* Different example sentence styles */
+export default {
+  NO_STYLE: {
+    value: '',
+    label: 'No Style',
+  },
+  STANDARD: {
+    value: 'standard',
+    label: 'Standard',
+  },
+  PROVERB: {
+    value: 'proverb',
+    label: 'Proverb',
+  },
+};

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -7,6 +7,8 @@ import {
 import { Box, Button, useToast } from '@chakra-ui/react';
 import { Record, useNotify, useRedirect } from 'react-admin';
 import { useForm, Controller } from 'react-hook-form';
+import Select from 'react-select';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 import { EditFormProps } from 'src/shared/interfaces';
 import { getExample } from 'src/shared/API';
 import View from 'src/shared/constants/Views';
@@ -134,7 +136,38 @@ const ExampleEditForm = ({
             />
           </>
         ) : null }
-        <Box className="w-full lg:w-1/2 flex flex-col">
+        <Box
+          className="w-full flex flex-col lg:flex-row justify-between
+          items-center space-y-4 lg:space-y-0 lg:space-x-6"
+        >
+          <Box className="flex flex-col w-full">
+            <FormHeader
+              title="Sentence Style"
+              tooltip="Select the style or figure of speech that this sentence is using."
+            />
+            <Box data-test="word-class-input-container">
+              <Controller
+                render={({ onChange, ...rest }) => (
+                  <Select
+                    {...rest}
+                    onChange={(e) => {
+                      onChange(e);
+                      cacheForm();
+                    }}
+                    options={Object.values(ExampleStyle)}
+                  />
+                )}
+                name="style"
+                control={control}
+                defaultValue={Object.values(ExampleStyle).find(({ value }) => (
+                  value === (record.style || getValues().style)
+                ))}
+              />
+            </Box>
+            {errors.wordClass && (
+              <p className="error">Part of speech is required</p>
+            )}
+          </Box>
           <Controller
             render={() => (
               <AudioRecorder
@@ -162,7 +195,7 @@ const ExampleEditForm = ({
             <Input
               {...props}
               className="form-input"
-              placeholder="Please"
+              placeholder="Biko"
               data-test="igbo-input"
             />
           )}
@@ -177,14 +210,14 @@ const ExampleEditForm = ({
       <Box className="flex flex-col">
         <FormHeader
           title="English"
-          tooltip="The example sentence in English"
+          tooltip="The example sentence in English. This is the the literal English translation of the Igbo sentence."
         />
         <Controller
           render={(props) => (
             <Input
               {...props}
               className="form-input"
-              placeholder="Bia"
+              placeholder="Please"
               data-test="english-input"
             />
           )}
@@ -194,6 +227,28 @@ const ExampleEditForm = ({
         />
         {errors.english && (
           <p className="error">English is required</p>
+        )}
+      </Box>
+      <Box className="flex flex-col">
+        <FormHeader
+          title="Meaning"
+          tooltip="This field is for sentences that use figure of speech or where its literal translation isn't clear."
+        />
+        <Controller
+          render={(props) => (
+            <Input
+              {...props}
+              className="form-input"
+              placeholder="Asking politely"
+              data-test="meaning-input"
+            />
+          )}
+          name="meaning"
+          control={control}
+          defaultValue={record.meaning || getValues().meaning}
+        />
+        {errors.english && (
+          <p className="error">{errors.english}</p>
         )}
       </Box>
       <Box className="mt-2">
@@ -228,12 +283,13 @@ const ExampleEditForm = ({
           control={control}
         />
       </Box>
-      <Box className="flex flex-row items-center form-buttons-container space-y-4 lg:space-x-4">
+      <Box className="flex flex-row items-center form-buttons-container space-y-4 lg:space-y-0 lg:space-x-4">
         <Button
           className="mt-3 lg:my-0"
           backgroundColor="gray.300"
           onClick={() => onCancel({ view, resource, history })}
           disabled={isSubmitting}
+          width="full"
         >
           Cancel
         </Button>
@@ -244,6 +300,7 @@ const ExampleEditForm = ({
           className="m-0"
           isLoading={isSubmitting}
           loadingText={view === View.CREATE ? 'Submitting' : 'Updating'}
+          width="full"
         >
           {view === View.CREATE ? 'Submit' : 'Update'}
         </Button>

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
@@ -1,9 +1,14 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 
 export const ExampleEditFormSchema = yup.object().shape({
   igbo: yup.string(),
   english: yup.string(),
+  meaning: yup.string().optional(),
+  style: yup.mixed()
+    .oneOf(Object.values(ExampleStyle).map(({ value }) => value))
+    .default(ExampleStyle.NO_STYLE.value),
   associatedWords: yup.array().min(0).of(yup.string()),
   id: yup.string().optional(),
   originalExampleId: yup.string().nullable().optional(),

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -376,6 +376,7 @@ const WordEditForm = ({
           backgroundColor="gray.300"
           onClick={() => onCancel({ view, resource, history })}
           disabled={isSubmitting}
+          width="full"
         >
           Cancel
         </Button>
@@ -385,6 +386,7 @@ const WordEditForm = ({
           variant="solid"
           isLoading={isSubmitting}
           loadingText={view === View.CREATE ? 'Submitting' : 'Updating'}
+          width="full"
         >
           {view === View.CREATE ? 'Submit' : 'Update'}
         </Button>


### PR DESCRIPTION
## Background
This PR supports the new `meaning` and `style` fields introduced in the Igbo API: https://github.com/nkowaokwu/igbo_api/pull/456