### PR TITLE
Support up to four poll options

### DIFF
--- a/src/Core/Collections/Polls.tsx
+++ b/src/Core/Collections/Polls.tsx
@@ -6,7 +6,6 @@ import {
   List,
   Datagrid,
   TextField,
-  Responsive,
 } from 'react-admin';
 import {
   TweetField,
@@ -29,23 +28,10 @@ export const PollsList = (props: ListProps): ReactElement => {
       empty={<Empty showCreate={permissions.role === Role.ADMIN} />}
       sort={{ field: 'approvals', order: 'DESC' }}
     >
-      <Responsive
-        small={(
-          <Datagrid>
-            <TextField label="Word" source="word" />
-            <TweetField label="Constructed Term" source="constructedTerm" />
-            <TweetField label="Definition" source="definition" />
-          </Datagrid>
-        )}
-        medium={(
-          <Datagrid>
-            <TextField label="Constructed Term" source="constructedTerm" />
-            <TextField label="English Term" source="englishTerm" />
-            <TextField label="Definitions" source="definition" />
-            <TweetField label="Tweet Link" source="id" />
-          </Datagrid>
-        )}
-      />
+      <Datagrid>
+        <TextField label="Tweet body" source="text" />
+        <TweetField label="Tweet Link" source="id" />
+      </Datagrid>
     </List>
   );
 };

--- a/src/backend/controllers/polls.ts
+++ b/src/backend/controllers/polls.ts
@@ -73,9 +73,7 @@ export const onSubmitConstructedTermPoll = async (req: Request, res: Response): 
     await dbPollsRef.doc(tweets[0].data.id).set({
       created_at: moment().unix(),
       id: tweets[0].data.id,
-      constructedTerm: body.constructedTerm,
-      englishTerm: body.englishTerm,
-      definition: body.definition,
+      text: body.text,
       thread: tweets.map(({ data }) => data.id).slice(1, 4),
     });
 

--- a/src/backend/shared/constants/ConstructedPollThread.ts
+++ b/src/backend/shared/constants/ConstructedPollThread.ts
@@ -1,6 +1,6 @@
 export default [
   {
-    text: `We are creating new Igbo words and we need your feedback!\nThe first word that we created is {constructedTerm} which means {englishTerm}. We wanted to get Igbo speakers' thoughts on whether it means {englishTerm} to you, as in {definition}` // eslint-disable-line
+    text: 'We are creating new Igbo words and we need your feedback!\n',
   },
   {
     text: `Why do we care to create new Igbo words?\nIgbo is officially a threatened language and is on track to becoming extinct. One of our goals at @nkowaokwu is not only to preserve the Igbo language but also to expand it, which includes creating new words.` // eslint-disable-line

--- a/src/backend/shared/types/Poll.ts
+++ b/src/backend/shared/types/Poll.ts
@@ -1,7 +1,4 @@
 export type Poll = {
-  constructedTerm: string,
-  englishTerm: string,
-  definition: string,
   text: string,
   poll: {
     options: string[],

--- a/src/shared/components/views/creates/PollsCreate.tsx
+++ b/src/shared/components/views/creates/PollsCreate.tsx
@@ -1,47 +1,99 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ChangeEvent, ReactElement, useState } from 'react';
 import {
   Box,
   Button,
   Heading,
+  IconButton,
   Input,
   Link,
   Text,
   chakra,
   Tooltip,
+  Textarea,
+  useToast,
 } from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
 import ConstructedPollThread from 'src/backend/shared/constants/ConstructedPollThread';
 import { submitConstructedTermPoll } from 'src/shared/API';
 import { CONSTRUCTED_TERMS_REVIEW_DOC } from 'src/Core/constants';
 import Tweet from './components/Tweet';
 
+const MINIMUM_POLL_OPTIONS = 2;
+const MAXIMUM_POLL_OPTIONS = 4;
 const PollsCreate = (): ReactElement => {
-  const [constructedTerm, setConstructedTerm] = useState('');
-  const [englishTerm, setEnglishTerm] = useState('');
-  const [definition, setDefinition] = useState('');
+  const [tweetBody, setTweetBody] = useState('');
+  const [pollOptions, setPollOptions] = useState(['Yes', 'No']);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const toast = useToast();
 
-  const handlePostingPoll = (e) => {
+  const determinePollPosition = (index: number) => {
+    if (index === 0) {
+      return 'First';
+    }
+    if (index === 1) {
+      return 'Second';
+    }
+    if (index === 2) {
+      return 'Third';
+    }
+    if (index === 3) {
+      return 'Fourth';
+    }
+    return null;
+  };
+
+  const handlePostingPoll = async (e) => {
     e.preventDefault();
     try {
       setIsSubmitting(true);
-      const initialTweet = ConstructedPollThread[0].text
-        .replaceAll('{constructedTerm}', constructedTerm)
-        .replaceAll('{englishTerm}', englishTerm)
-        .replaceAll('{definition}', definition);
+      if (pollOptions.some((pollOption) => !pollOption)) {
+        throw new Error('Unable to send poll with empty options');
+      }
+      const initialTweet = `${ConstructedPollThread[0].text} ${tweetBody}`;
       const poll = {
-        constructedTerm,
-        englishTerm,
-        definition,
         text: initialTweet,
         poll: {
-          options: ['Yes', 'No'],
+          options: pollOptions,
           duration_minutes: 4320,
         },
       };
-      submitConstructedTermPoll(poll);
+      await submitConstructedTermPoll(poll);
+      toast({
+        title: 'Success',
+        description: 'Sent the Twitter poll',
+        status: 'success',
+        duration: 4000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: err.message,
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleAddPollOption = () => {
+    if (pollOptions.length < MAXIMUM_POLL_OPTIONS) {
+      setPollOptions(pollOptions.concat(['']));
+    }
+  };
+
+  const handleDeletePollOption = (index: number) => () => {
+    const updatedPollOptions = [...pollOptions];
+    updatedPollOptions.splice(index, 1);
+    setPollOptions(updatedPollOptions);
+  };
+
+  const handleUpdatePollOption = (index: number) => (e: ChangeEvent) => {
+    const updatedPollOptions = [...pollOptions];
+    updatedPollOptions[index] = e.target.value;
+    setPollOptions(updatedPollOptions);
   };
 
   const handleAccountAuthorization = () => {
@@ -92,40 +144,61 @@ const PollsCreate = (): ReactElement => {
         >
           <Box flex={2} className="w-full space-y-4">
             <Box>
-              <Heading as="h3" fontSize="md" mb={4}>Constructed Term</Heading>
-              <Input
+              <Heading as="h3" fontSize="md" mb={4}>Tweet Body</Heading>
+              <Textarea
                 required
-                name="constructedTerm"
-                placeholder="Newly constructed Igbo term"
-                defaultValue={constructedTerm}
-                onChange={(e) => setConstructedTerm(e.target.value)}
+                name="tweetBody"
+                placeholder="Body of the main Tweet"
+                defaultValue={tweetBody}
+                onChange={(e) => setTweetBody(e.target.value)}
               />
             </Box>
             <Box>
-              <Heading as="h3" fontSize="md" mb={4}>English equivalent</Heading>
-              <Input
-                required
-                name="englishTerm"
-                placeholder="Constructed term's English equivalent"
-                defaultValue={englishTerm}
-                onChange={(e) => setEnglishTerm(e.target.value)}
-              />
-            </Box>
-            <Box>
-              <Heading as="h3" fontSize="md" mb={4}>Definition</Heading>
-              <Input
-                required
-                name="definition"
-                placeholder="Constructed term definition"
-                defaultValue={definition}
-                onChange={(e) => setDefinition(e.target.value)}
-              />
+              <Box className="flex flex-row justify-between items-center" mb={4}>
+                <Heading as="h3" fontSize="md">Poll Options</Heading>
+                {pollOptions.length < MAXIMUM_POLL_OPTIONS ? (
+                  <IconButton
+                    colorScheme="green"
+                    aria-label="Add poll option"
+                    icon={<AddIcon />}
+                    onClick={handleAddPollOption}
+                  />
+                ) : null}
+              </Box>
+              {pollOptions.map((option, index) => (
+                <Box mb={3}>
+                  <Text fontWeight="bold">{`${determinePollPosition(index)} option:`}</Text>
+                  <Box className="flex flex-row justify-between items-center">
+                    <Input
+                      placeholder={`${determinePollPosition(index)} option`}
+                      value={option}
+                      onChange={handleUpdatePollOption(index)}
+                    />
+                    {pollOptions.length > MINIMUM_POLL_OPTIONS ? (
+                      <Tooltip label="Delete poll option">
+                        <IconButton
+                          ml={4}
+                          color="red"
+                          aria-label="Delete poll option"
+                          icon={<DeleteIcon />}
+                          onClick={handleDeletePollOption(index)}
+                        />
+                      </Tooltip>
+                    ) : null}
+                  </Box>
+                </Box>
+              ))}
+
             </Box>
           </Box>
           <Box flex={3} className="w-full">
             <Heading as="h3" fontSize="md" mb={4}>Final Twitter thread</Heading>
-            {ConstructedPollThread.map(({ text }) => (
-              <Tweet text={text} constructedTerm={constructedTerm} englishTerm={englishTerm} definition={definition} />
+            {ConstructedPollThread.map(({ text }, index) => (
+              <Tweet
+                text={text}
+                {...(index === 0 ? { tweetBody } : {})}
+                {...(index === 0 ? { pollOptions } : {})}
+              />
             ))}
           </Box>
         </Box>

--- a/src/shared/components/views/creates/components/Tweet.tsx
+++ b/src/shared/components/views/creates/components/Tweet.tsx
@@ -1,34 +1,50 @@
 import React, { ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import { Avatar, Box, Text } from '@chakra-ui/react';
+import {
+  Avatar,
+  Box,
+  Text,
+  chakra,
+} from '@chakra-ui/react';
 
 const twitterImage = 'https://pbs.twimg.com/profile_images/1529669157259816960/3Olb8jLG_400x400.jpg';
 const CHARACTER_LIMIT = 280;
 
 const Tweet = ({
   text,
-  constructedTerm,
-  englishTerm,
-  definition,
+  tweetBody,
+  pollOptions,
 } : {
   text: string,
-  constructedTerm?: string,
-  englishTerm?: string,
-  definition?: string,
+  tweetBody?: string,
+  pollOptions?: string[],
 }): ReactElement => {
-  const finalText = text
-    .replaceAll('{constructedTerm}', constructedTerm)
-    .replaceAll('{englishTerm}', englishTerm)
-    .replaceAll('{definition}', definition);
+  const totalText = `${text} ${tweetBody}`;
+
   return (
     <Box maxWidth="96">
       <Box my={4} className="flex flex-row space-x-4">
         <Avatar name="nkowaokwu" src={twitterImage} />
-        <Text overflowWrap="anywhere">{finalText}</Text>
+        <chakra.span overflow="overlay">
+          <Text overflowWrap="anywhere">{text}</Text>
+          {tweetBody ? <Text color="blue.700">{tweetBody}</Text> : null}
+        </chakra.span>
       </Box>
+      {pollOptions?.length ? pollOptions.map((pollOption) => (
+        <Box
+          width="full"
+          className="rounded-md"
+          backgroundColor="green.200"
+          py={2}
+          px={4}
+          mb={2}
+        >
+          <Text color="white">{pollOption}</Text>
+        </Box>
+      )) : null}
       <Box className="flex flex-row justify-end items-center">
-        <Text fontSize="xs" color={finalText.length >= CHARACTER_LIMIT ? 'red' : 'gray.400'}>
-          {`${finalText.length} / ${CHARACTER_LIMIT}`}
+        <Text fontSize="xs" color={totalText.length >= CHARACTER_LIMIT ? 'red' : 'gray.400'}>
+          {`${totalText.length} / ${CHARACTER_LIMIT}`}
         </Text>
       </Box>
     </Box>
@@ -36,15 +52,13 @@ const Tweet = ({
 };
 
 Tweet.propTypes = {
-  constructedTerm: PropTypes.string,
-  englishTerm: PropTypes.string,
-  definition: PropTypes.string,
+  tweetBody: PropTypes.string,
+  pollOptions: PropTypes.arrayOf(PropTypes.string),
 };
 
 Tweet.defaultProps = {
-  constructedTerm: '',
-  englishTerm: '',
-  definition: '',
+  tweetBody: '',
+  pollOptions: null,
 };
 
 export default Tweet;


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | Closes N/A |

## Problem
Translators want to have more freedom with how they create the newly constructed word polls.

## Solution
This PR enables project admins to be able to create polls that have at least 2 and up to 4 poll options.


## Before & After Screenshots

https://user-images.githubusercontent.com/16169291/174461819-f2b5de08-5f04-47be-9af7-15681c23be7c.mov