### PR TITLE
Record Audio in Mp3 instead of Webm

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "framer-motion": "^4",
     "functions": "^1.0.9",
     "lodash": "^4.17.20",
+    "mic-recorder-to-mp3": "^2.2.2",
     "moment": "^2.29.1",
     "mongoose": "^5.11.9",
     "npm-run-all": "^4.1.5",

--- a/src/backend/controllers/utils/AWS-API.ts
+++ b/src/backend/controllers/utils/AWS-API.ts
@@ -29,7 +29,7 @@ const s3 = (() => {
 const config = functions.config();
 const isProduction = config?.runtime?.env === 'production';
 const isCypress = config?.runtime?.env === 'cypress';
-/* Puts a new .webm object in the AWS S3 Bucket */
+/* Puts a new .mp3 object in the AWS S3 Bucket */
 export const createAudioPronunciation = async (id: string, pronunciationData: string): Promise<string> => {
   if (!id || !pronunciationData) {
     throw new Error('id and pronunciation must be provided');
@@ -40,11 +40,11 @@ export const createAudioPronunciation = async (id: string, pronunciationData: st
   const base64Data = Buffer.from(pronunciationData.replace(/^data:.+;base64,/, ''), 'base64');
   const params = {
     ...baseParams,
-    Key: `${pronunciationPath}/${id}.webm`,
+    Key: `${pronunciationPath}/${id}.mp3`,
     Body: base64Data,
     ACL: 'public-read',
     ContentEncoding: 'base64',
-    ContentType: 'audio/webm',
+    ContentType: 'audio/mp3',
   };
 
   const { Location } = await s3.upload(params).promise();

--- a/src/backend/controllers/utils/buildDocs.ts
+++ b/src/backend/controllers/utils/buildDocs.ts
@@ -50,7 +50,7 @@ export const findWordsWithMatch = async (
   }:
   {
     match: any,
-    examples?: bool,
+    examples?: boolean,
     skip?: number,
     limit?: number,
   },

--- a/src/backend/models/plugins/pronunciationHooks.ts
+++ b/src/backend/models/plugins/pronunciationHooks.ts
@@ -22,7 +22,7 @@ export const uploadWordPronunciation = (schema: mongoose.Schema<Interfaces.WordS
       if (isCypress && this.pronunciation) {
       // Going to mock creating and saving audio pronunciation while testing in Cypress
         this.pronunciation = await createAudioPronunciation(id, this.pronunciation);
-      } else if (this.pronunciation.startsWith('data:audio/webm')) {
+      } else if (this.pronunciation.startsWith('data:audio/mp3')) {
         this.pronunciation = await createAudioPronunciation(id, this.pronunciation);
       } else if (!isCypress && isDevelopment && this.pronunciation) {
         this.pronunciation = await createAudioPronunciation(id, this.pronunciation);
@@ -52,7 +52,7 @@ export const uploadWordPronunciation = (schema: mongoose.Schema<Interfaces.WordS
           this.dialects[rawDialectalWord].pronunciation = (
             await createAudioPronunciation(`${id}-${dialectalWord}`, pronunciation)
           );
-        } else if (pronunciation.startsWith('data:audio/webm')) {
+        } else if (pronunciation.startsWith('data:audio/mp3')) {
           this.dialects[rawDialectalWord].pronunciation = (
             await createAudioPronunciation(`${id}-${dialectalWord}`, pronunciation)
           );
@@ -89,7 +89,7 @@ export const uploadExamplePronunciation = (schema: mongoose.Schema<Interfaces.Ex
       if (isCypress && this.pronunciation) {
       // Going to mock creating and saving audio pronunciation while testing in Cypress
         this.pronunciation = await createAudioPronunciation(id, this.pronunciation);
-      } else if (this.pronunciation.startsWith('data:audio/webm')) {
+      } else if (this.pronunciation.startsWith('data:audio/mp3')) {
         this.pronunciation = await createAudioPronunciation(id, this.pronunciation);
       } else if (!isCypress && isDevelopment && this.pronunciation) {
         this.pronunciation = await createAudioPronunciation(id, this.pronunciation);

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -1,86 +1,91 @@
 /* From: https://codesandbox.io/s/81zkxw8qnl?file=/src/useRecorder.js:370-385 */
+/* From: https://medium.com/front-end-weekly/recording-audio-in-mp3-using-reactjs-under-5-minutes-5e960defaf10 */
 import { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 import Wave from 'wave-visualizer';
+import MicRecorder from 'mic-recorder-to-mp3';
 
 const MAX_AUDIO_SIZE = 100000;
-const requestRecorder = async (wave) => {
-  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-  try {
-    wave.fromStream(stream, 'canvas', {
-      colors: ['red', 'white', 'blue'],
-    });
-    wave.fromElement('audio', 'canvas');
-  } catch (err) {
-    console.log('An error with Wave occurred:', err.message);
-  }
-  return new window.MediaRecorder(stream);
-};
-
 const useRecorder = (): [string, boolean, () => void, () => void] => {
   const [wave] = useState(new Wave());
   const [audioBlob, setAudioBlob] = useState('');
   const [isRecording, setIsRecording] = useState(false);
+  const [isBlocked, setIsBlocked] = useState(true);
   const [recorder, setRecorder] = useState(null);
   const toast = useToast();
 
   useEffect(() => {
-    // Lazily obtain recorder first time we're recording.
-    if (recorder === null) {
-      if (isRecording) {
-        requestRecorder(wave).then(setRecorder, console.error);
-      }
-      return;
-    }
+    // @ts-expect-error navigator
+    navigator.getUserMedia({ audio: true },
+      () => setIsBlocked(false),
+      () => setIsBlocked(true));
+  }, []);
 
-    // Manage recorder state.
-    if (isRecording) {
-      recorder.start();
-    } else if (!isRecording && recorder.state !== 'inactive') {
-      recorder.stop();
-    }
+  useEffect(() => {
+    if (!isBlocked) {
+      setRecorder(new MicRecorder({ bitRate: 30000 }));
 
-    // Obtain the audio when ready.
-    const handleData = ({ data: audioData }) => {
-      const reader = new FileReader();
-      reader.readAsDataURL(audioData);
-      reader.onloadend = (e) => {
-        if (
-          typeof e.target.result !== 'string'
-          || !e.target.result.includes('data:audio/webm')
-        ) {
-          return toast({
-            title: 'Unable to record',
-            description: 'Invalid file type. Must be .webm',
-            status: 'warning',
-            duration: 9000,
-            isClosable: true,
+      (async () => {
+        // @ts-expect-error navigator
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        try {
+          wave.fromStream(stream, 'canvas', {
+            colors: ['red', 'white', 'blue'],
           });
+          wave.fromElement('audio', 'canvas');
+        } catch (err) {
+          console.log('An error with Wave occurred:', err.message);
         }
-        if (e.target.result?.length > MAX_AUDIO_SIZE) {
-          return toast({
-            title: 'Unable to record',
-            description: 'Audio is too large - 100Kb maximum. Shorten your recording.',
-            status: 'warning',
-            duration: 9000,
-            isClosable: true,
-          });
-        }
-        return setAudioBlob(reader.result);
-      };
-    };
-
-    recorder.addEventListener('dataavailable', handleData);
-    // eslint-disable-next-line consistent-return
-    return () => recorder.removeEventListener('dataavailable', handleData);
-  }, [recorder, isRecording]);
+      })();
+    }
+  }, [isBlocked]);
 
   const startRecording = () => {
-    setIsRecording(true);
+    if (!isBlocked && recorder) {
+      recorder.start().then(() => {
+        setIsRecording(true);
+      });
+    }
   };
 
   const stopRecording = () => {
-    setIsRecording(false);
+    if (!isBlocked && recorder) {
+      recorder.stop().getMp3().then(([buffer, blob]) => {
+        // @ts-expect-error File
+        const file = new File(buffer, 'me-at-thevoice.mp3', {
+          type: blob.type,
+          lastModified: Date.now(),
+        });
+        // @ts-expect-error FileReader
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onloadend = (e): void | React.ReactText => {
+          if (
+            typeof e.target.result !== 'string'
+            || !e.target.result.includes('data:audio/mp3')
+          ) {
+            return toast({
+              title: 'Unable to record',
+              description: 'Invalid file type. Must be .mp3',
+              status: 'warning',
+              duration: 9000,
+              isClosable: true,
+            });
+          }
+          if (e.target.result?.length > MAX_AUDIO_SIZE) {
+            return toast({
+              title: 'Unable to record',
+              description: 'Audio is too large - 100Kb maximum. Shorten your recording.',
+              status: 'warning',
+              duration: 9000,
+              isClosable: true,
+            });
+          }
+          return setAudioBlob(reader.result);
+        };
+        setIsRecording(false);
+      });
+    }
   };
 
   return [audioBlob, isRecording, startRecording, stopRecording];


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Refactor | No | Closes N/A |

## Problem
The platform has recorded all audio with the webm file type. This has been working well on desktop platforms. However, mobile devices are unable to natively playback webm files.


## Solution
This PR changes the recorded audio file type from webm to mp3. That data will be saved in our AWS S3 buckets.

**New dependencies**:

- `mic-recorder-to-mp3` : Enables the frontend to record audio in mp3 file type
