### PR TITLE
Show existing words in word suggestions form

### DIFF
--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -37,6 +37,11 @@ export const getWord = async (id: string, { dialects } = { dialects: true }): Pr
   url: `${API_ROUTE}/words/${id}?dialects=${dialects}`,
 })).data;
 
+export const getWords = async (word: string): Promise<any> => (await request({
+  method: 'GET',
+  url: `${API_ROUTE}/words?keyword=${word}`,
+})).data;
+
 export const getExample = async (id: string): Promise<any> => (await request({
   method: 'GET',
   url: `${API_ROUTE}/examples/${id}`,


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | Closes N/A |

## Background
A translator has suggested making editing word suggestions easier is to show a list of existing word documents with a similar headword. The Word Suggestion edit form will now show a list of similar existing words to help editors know whether or not they should create a new word suggestion or edit an existing word.

<img width="471" alt="Screen Shot 2022-08-02 at 9 48 12 AM" src="https://user-images.githubusercontent.com/16169291/182392593-6c71b6a1-b873-4227-ae28-735b9ae44423.png">

## Bug Report
https://www.notion.so/Same-Word-Edited-in-Word-section-And-Unedited-in-Word-Suggestions-section-e0f8d770214544359eb04ff505c07f4d