### PR TITLE
Move dialectal variations near the top of the suggestions form

### DIFF
--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -259,6 +259,23 @@ const WordEditForm = ({
               options={options}
               record={record}
             />
+            <Box className="flex flex-col lg:flex-row space-x-0 lg:space-x-6 lg:mt-3">
+              <Box className="w-full">
+                <DefinitionsForm
+                  definitions={definitions}
+                  setDefinitions={setDefinitions}
+                  errors={errors}
+                  control={control}
+                />
+                {isVerb(watchWordClass.value) ? (
+                  <TensesForm
+                    record={record}
+                    errors={errors}
+                    control={control}
+                  />
+                ) : null}
+              </Box>
+            </Box>
           </Box>
           <Box className="w-full lg:w-1/2 flex flex-col">
             <Controller
@@ -275,54 +292,31 @@ const WordEditForm = ({
               name="pronunciation"
               control={control}
             />
-          </Box>
-        </Box>
-        <Box className="flex flex-col lg:flex-row space-x-0 lg:space-x-6 lg:mt-3">
-          <Box className="w-full lg:w-1/2">
-            <DefinitionsForm
-              definitions={definitions}
-              setDefinitions={setDefinitions}
-              errors={errors}
-              control={control}
-            />
-            {isVerb(watchWordClass.value) ? (
-              <TensesForm
-                record={record}
-                errors={errors}
-                control={control}
+            <Box className="flex flex-row justify-between items-center">
+              <FormHeader
+                title="Dialectal Variations"
+                tooltip="These are the dialectal (sound) variations with the current word."
               />
-            ) : null}
-          </Box>
-          <Box className="flex flex-col w-full lg:w-1/2">
-            <VariationsForm
-              variations={variations}
-              setVariations={setVariations}
-              control={control}
-            />
-            <StemsForm
-              errors={errors}
-              stems={stems}
-              setStems={setStems}
-              control={control}
-              setValue={setValue}
+            </Box>
+            <CurrentDialectsForms
               record={record}
-            />
-            <SynonymsForm
-              errors={errors}
-              synonyms={synonyms}
-              setSynonyms={setSynonyms}
+              originalRecord={originalRecord}
               control={control}
+              getValues={getValues}
               setValue={setValue}
-              record={record}
+              setDialects={setDialects}
+              dialects={dialects}
             />
-            <AntonymsForm
-              errors={errors}
-              antonyms={antonyms}
-              setAntonyms={setAntonyms}
-              control={control}
-              setValue={setValue}
-              record={record}
-            />
+            <Box className="flex flex-col w-full">
+              <StemsForm
+                errors={errors}
+                stems={stems}
+                setStems={setStems}
+                control={control}
+                setValue={setValue}
+                record={record}
+              />
+            </Box>
           </Box>
         </Box>
       </Box>
@@ -333,25 +327,31 @@ const WordEditForm = ({
         setValue={setValue}
         control={control}
       />
+      <VariationsForm
+        variations={variations}
+        setVariations={setVariations}
+        control={control}
+      />
+      <SynonymsForm
+        errors={errors}
+        synonyms={synonyms}
+        setSynonyms={setSynonyms}
+        control={control}
+        setValue={setValue}
+        record={record}
+      />
+      <AntonymsForm
+        errors={errors}
+        antonyms={antonyms}
+        setAntonyms={setAntonyms}
+        control={control}
+        setValue={setValue}
+        record={record}
+      />
       {/*
         * Must use record.dialects in order for all dialects to render on first pain
         * in order for react-hook-form to initialize all their values in the form.
         */}
-      <Box className="flex flex-row justify-between items-center">
-        <FormHeader
-          title="Current Dialects"
-          tooltip="These are the dialectal (sound) variations with the current word."
-        />
-      </Box>
-      <CurrentDialectsForms
-        record={record}
-        originalRecord={originalRecord}
-        control={control}
-        getValues={getValues}
-        setValue={setValue}
-        setDialects={setDialects}
-        dialects={dialects}
-      />
       <Box className="flex flex-col">
         <FormHeader
           title="Editor Comments"

--- a/src/shared/components/views/components/WordEditForm/components/AntonymsForm/AntonymsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/AntonymsForm/AntonymsForm.tsx
@@ -66,7 +66,7 @@ const Antonyms = (
     </Box>
   ) : (
     <Box className="flex w-full justify-center">
-      <p className="text-gray-600">No antonyms</p>
+      <p className="text-gray-600 mb-4">No antonyms</p>
     </Box>
   );
 };

--- a/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectsForms.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectsForms.tsx
@@ -13,7 +13,7 @@ const CurrentDialectsForms = ({
   setDialects,
   dialects,
 }: CurrentDialectFormsInterface): ReactElement => (
-  <Box>
+  <Box className="mb-4">
     <Button
       onClick={() => {
         setDialects([
@@ -33,7 +33,7 @@ const CurrentDialectsForms = ({
     </Button>
     <Box
       className={'grid grid-flow-row grid-cols-1 '
-      + `${dialects.length !== 1 ? 'lg:grid-cols-2' : 'lg:grid-cols-1'} gap-4`}
+      + `${dialects.length !== 1 ? 'xl:grid-cols-2' : 'xl:grid-cols-1'} gap-4`}
     >
       {dialects.map((dialect, index) => (
         <Box key={`dialectal-variation-${dialect.word}`}>

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
@@ -76,7 +76,7 @@ const Stems = (
     </Box>
   ) : (
     <Box className="flex w-full justify-center">
-      <p className="text-gray-600">No synonyms</p>
+      <p className="text-gray-600 mb-4">No stems</p>
     </Box>
   );
 };

--- a/src/shared/components/views/components/WordEditForm/components/SynonymsForm/SynonymsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/SynonymsForm/SynonymsForm.tsx
@@ -66,7 +66,7 @@ const Synonyms = (
     </Box>
   ) : (
     <Box className="flex w-full justify-center">
-      <p className="text-gray-600">No synonyms</p>
+      <p className="text-gray-600 mb-4">No synonyms</p>
     </Box>
   );
 };

--- a/src/shared/components/views/components/WordEditForm/components/VariationsForm/VariationsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/VariationsForm/VariationsForm.tsx
@@ -54,7 +54,7 @@ const VariationsForm = (
       </Box>
     )) : (
       <Box className="flex w-full justify-center">
-        <p className="text-gray-600">No spelling variations</p>
+        <p className="text-gray-600 mb-4">No spelling variations</p>
       </Box>
     )}
   </Box>


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | No | Closes N/A |

## Background
Move the Dialectal Variations section near the top to encourage editors to place dialectal variations and spelling variations in the right spot

### Dialectal Variations near the top
<img width="1502" alt="Screen Shot 2022-08-07 at 2 00 44 PM" src="https://user-images.githubusercontent.com/16169291/183310938-02a8ebae-bf85-4d25-a604-dbd50821853a.png">

