### PR TITLE
Flag words that dont follow editing standards

### DIFF
--- a/src/shared/components/HeadwordField.tsx
+++ b/src/shared/components/HeadwordField.tsx
@@ -1,14 +1,29 @@
 import React, { ReactElement } from 'react';
 import { Record } from 'react-admin';
-import { Text } from '@chakra-ui/react';
+import { Box, Text, Tooltip } from '@chakra-ui/react';
+import { WarningIcon } from '@chakra-ui/icons';
+import generateFlags from 'src/shared/utils/flagHeadword';
 
 const HeadwordField = ({ record, source }: { record?: Record, source: string }): ReactElement => {
   const { nsibidi } = record;
   const headword = record[source];
+  const hasFlags = !!Object.values(generateFlags({ word: record, flags: {} })).length;
   return (
     <>
       {nsibidi ? <Text fontSize="md" className="akagu text-green-800">{nsibidi}</Text> : null}
-      <Text>{headword}</Text>
+      <Tooltip
+        backgroundColor="orange.300"
+        color="gray.800"
+        label={hasFlags
+          ? 'This word has been flagged as invalid due to the headword not '
+            + 'following the Dictionary Editing Standards document. Please edit this word for more details.'
+          : ''}
+      >
+        <Box className="flex flex-row items-center cursor-default">
+          {hasFlags ? <WarningIcon color="orange.600" boxSize={3} mr={2} /> : null}
+          <Text color={hasFlags ? 'orange.600' : ''}>{headword}</Text>
+        </Box>
+      </Tooltip>
     </>
   );
 };

--- a/src/shared/components/views/components/FormHeader.tsx
+++ b/src/shared/components/views/components/FormHeader.tsx
@@ -1,24 +1,38 @@
 import React, { ReactElement } from 'react';
 import { noop } from 'lodash';
-import { Box, Tooltip } from '@chakra-ui/react';
+import { Box, Heading, Tooltip } from '@chakra-ui/react';
 import { InfoOutlineIcon } from '@chakra-ui/icons';
 
 const FormHeader = (
-  { title, tooltip, onClick }
-  : { title: string, tooltip: string, onClick?: () => any },
+  {
+    title,
+    tooltip,
+    color,
+    onClick,
+  }
+  : { title: string, tooltip: string, color?: string, onClick?: () => any },
 ): ReactElement => (
   <Box
     className={`flex flex-row items-center${onClick ? ' cursor-pointer' : ''}`}
     onClick={onClick || noop}
   >
-    <h2 className={`form-header${onClick ? ' hover:underline' : ''}`}>{title}</h2>
+    <Heading
+      as="h2"
+      className={`form-header${onClick ? ' hover:underline' : ''}`}
+      fontSize="xl"
+      fontWeight="normal"
+      color={color}
+    >
+      {title}
+    </Heading>
     <Tooltip label={tooltip}>
-      <InfoOutlineIcon color="gray.600" className="ml-2" />
+      <InfoOutlineIcon color={color} className="ml-2" />
     </Tooltip>
   </Box>
 );
 
 FormHeader.defaultProps = {
+  color: 'gray.700',
   onClick: null,
 };
 

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -1,6 +1,12 @@
 import React, { ReactElement, useState, useEffect } from 'react';
 import { ShowProps, useShowController } from 'react-admin';
-import { Box, Heading, Skeleton } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  Skeleton,
+  Tooltip,
+} from '@chakra-ui/react';
+import { WarningIcon } from '@chakra-ui/icons';
 import diff from 'deep-diff';
 import ReactAudioPlayer from 'react-audio-player';
 import { DEFAULT_WORD_RECORD } from 'src/shared/constants';
@@ -12,6 +18,7 @@ import CompleteWordPreview from 'src/shared/components/CompleteWordPreview';
 import ResolvedWord from 'src/shared/components/ResolvedWord';
 import SourceField from 'src/shared/components/SourceField';
 import WordAttributes from 'src/backend/shared/constants/WordAttributes';
+import generateFlags from 'src/shared/utils/flagHeadword';
 import {
   EditDocumentTopBar,
   ShowDocumentStats,
@@ -52,6 +59,7 @@ const WordShow = (props: ShowProps): ReactElement => {
   const { resource } = showProps;
   let { record } = showProps;
   const { permissions } = props;
+  const hasFlags = !!Object.values(generateFlags({ word: record || {}, flags: {} })).length;
 
   record = record || DEFAULT_WORD_RECORD;
 
@@ -157,7 +165,26 @@ const WordShow = (props: ShowProps): ReactElement => {
                   />
                 </Box>
                 <Box className="flex flex-col">
-                  <Heading fontSize="lg" className="text-xl text-gray-600">Word</Heading>
+                  <Tooltip
+                    placement="top"
+                    backgroundColor="orange.300"
+                    color="gray.800"
+                    label={hasFlags
+                      ? 'This word has been flagged as invalid due to the headword not '
+                        + 'following the Dictionary Editing Standards document. Please edit this word for more details.'
+                      : ''}
+                  >
+                    <Box className="flex flex-row items-center cursor-default">
+                      {hasFlags ? <WarningIcon color="orange.600" boxSize={3} mr={2} /> : null}
+                      <Heading
+                        fontSize="lg"
+                        className="text-xl text-gray-600"
+                        color={hasFlags ? 'orange.600' : ''}
+                      >
+                        Word
+                      </Heading>
+                    </Box>
+                  </Tooltip>
                   <DiffField
                     path="word"
                     diffRecord={diffRecord}

--- a/src/shared/utils/flagHeadword.ts
+++ b/src/shared/utils/flagHeadword.ts
@@ -1,0 +1,98 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-labels */
+import WordClass from 'src/shared/constants/WordClass';
+import { flow } from 'lodash';
+
+type FlagsType = {
+  dashPrefix?: string,
+  accentedPair?: string,
+  highTone?: string,
+};
+
+const vowels = ['a', 'e', 'i', 'ị', 'ị', 'o', 'ọ', 'ọ', 'u', 'ụ', 'ụ'];
+const GRAVE_ACCENT = 768;
+const ACUTE_ACCENT = 769;
+const MACRON_ACCENT = 772;
+const accents = [GRAVE_ACCENT, ACUTE_ACCENT, MACRON_ACCENT];
+
+const invalidPrefixedDash = (
+  { word: wordDocument, flags } : { word: { word: string, wordClass: string }, flags: FlagsType },
+): { word: { word: string, wordClass: string }, flags: FlagsType } => {
+  const { word, wordClass } = wordDocument;
+  if (word && word.startsWith('-') && wordClass !== WordClass.ESUF.value) {
+    flags.dashPrefix = 'There is an invalid prefixed dash that shouldn\'t be present for this word. '
+    + 'Only Extensional suffixes can have prefixed dashes';
+  } else if (word && word.startsWith('-') && wordClass === WordClass.ESUF.value) {
+    delete flags.dashPrefix;
+  }
+  return { word: wordDocument, flags };
+};
+
+const invalidToneMarkPairings = (
+  { word: wordDocument, flags } : { word: { word: string, wordClass: string }, flags: FlagsType },
+): { word: { word: string, wordClass: string }, flags: FlagsType } => {
+  const { word } = wordDocument;
+  if (word) {
+    topLoop:
+    for (let k = 0; k < word.length; k += 1) {
+      const letter = word[k];
+      if (vowels.includes(letter) && word.charCodeAt(k + 1) === MACRON_ACCENT) {
+        let previousVowel = null;
+        if (k === 0) {
+          flags.accentedPair = `In order to have a down step (${String.fromCharCode(MACRON_ACCENT)}) accent `
+          + 'present in this word, the vowel before the macron vowel must be a high tone.';
+          break;
+        }
+        for (let i = k - 1; i >= 0; i -= 1) {
+          const currentLetter = word[i];
+          previousVowel = vowels.includes(currentLetter) ? currentLetter : null;
+          if (vowels.includes(currentLetter) && accents.includes(word.charCodeAt(i + 1))) {
+            flags.accentedPair = `In order to have a down step (${String.fromCharCode(MACRON_ACCENT)}) accent `
+          + 'present in this word, the vowel before the macron vowel must be a high tone.';
+            break topLoop;
+          }
+          if (i === 0 && !previousVowel) {
+            flags.accentedPair = `In order to have a down step (${String.fromCharCode(MACRON_ACCENT)}) accent `
+          + 'present in this word, the vowel before the macron vowel must be a high tone.';
+            break topLoop;
+          }
+          if (i === 0) {
+            delete flags.accentedPair;
+          }
+        }
+        if (k === word.length - 1) {
+          delete flags.accentedPair;
+        }
+      }
+    }
+  }
+  return { word: wordDocument, flags };
+};
+
+const invalidHighTonePresent = (
+  { word: wordDocument, flags } : { word: { word: string, wordClass: string }, flags: FlagsType },
+): { word: { word: string, wordClass: string }, flags: FlagsType } => {
+  const { word } = wordDocument;
+  if (word) {
+    for (let i = 0; i < word.length; i += 1) {
+      const letter = word.charCodeAt(i);
+      if (letter === ACUTE_ACCENT) {
+        flags.highTone = 'There should be no high tone accent mark for this word. '
+        + 'All unmarked accent marks are automatically high toned.';
+        break;
+      }
+      if (i === word.length - 1) {
+        delete flags.highTone;
+      }
+    }
+  }
+  return { word: wordDocument, flags };
+};
+
+const generateFlags = flow([
+  invalidPrefixedDash,
+  invalidToneMarkPairings,
+  invalidHighTonePresent,
+]) as (...any) => { word: { word: string, wordClass: string }, flags: FlagsType };
+
+export default generateFlags;


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | Closes N/A |

## Background
The platform will now flag headwords that don't follow the Dictionary Editing Standards document. Specifically, a word will be flagged if:
* It has a high tone mark
* It doesn't have a high tone before a down step
* It has a prefixed dash for non extensional suffixes

### Screenshots of flagged words
<img width="396" alt="Screen Shot 2022-08-07 at 7 31 14 PM" src="https://user-images.githubusercontent.com/16169291/183326952-d5066afa-5561-469f-83e5-571e873e7ce9.png">
<img width="496" alt="Screen Shot 2022-08-07 at 7 20 47 PM" src="https://user-images.githubusercontent.com/16169291/183326953-40039abf-3116-427b-be37-27f7078251be.png">
<img width="394" alt="Screen Shot 2022-08-07 at 7 20 35 PM" src="https://user-images.githubusercontent.com/16169291/183326954-289f6a9f-98fb-4f57-aba0-98cab31ff35f.png">

