### PR TITLE
Io/remove antonym as requirement for complete words

### DIFF
--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -24,7 +24,6 @@ export default (record: Word | Record) : {
     nsibidi,
     stems = [],
     synonyms = [],
-    antonyms = [],
     dialects = {},
     tenses = {},
   } = record;
@@ -45,7 +44,6 @@ export default (record: Word | Record) : {
     !nsibidi && 'Nsịbịdị is needed',
     !stems?.length && 'A word stem is needed',
     wordClass === WordClass.NNP.value ? null : !synonyms?.length && 'A synonym is needed',
-    wordClass === WordClass.NNP.value ? null : !antonyms?.length && 'An antonym is needed',
     isVerb(wordClass) && !Object.entries(tenses).every(([key, value]) => (
       value && Object.values(Tense).find(({ value: tenseValue }) => key === tenseValue)
     ))

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -2,8 +2,8 @@ import { compact } from 'lodash';
 import { Record } from 'react-admin';
 import { Word } from 'src/backend/controllers/utils/interfaces';
 import Tense from 'src/backend/shared/constants/Tense';
-import WordClass from 'src/backend/shared/constants/WordClass';
 import isVerb from 'src/backend/shared/utils/isVerb';
+import { invalidNymsWordClass } from './determineIsAsCompleteAsPossible';
 
 export default (record: Word | Record) : {
   sufficientWordRequirements: string[],
@@ -43,7 +43,7 @@ export default (record: Word | Record) : {
     ...sufficientWordRequirements,
     !nsibidi && 'Nsịbịdị is needed',
     !stems?.length && 'A word stem is needed',
-    wordClass === WordClass.NNP.value ? null : !synonyms?.length && 'A synonym is needed',
+    invalidNymsWordClass.includes(wordClass) ? null : !synonyms?.length && 'A synonym is needed',
     isVerb(wordClass) && !Object.entries(tenses).every(([key, value]) => (
       value && Object.values(Tense).find(({ value: tenseValue }) => key === tenseValue)
     ))

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -24,5 +24,4 @@ export default (word: Word | Record): boolean => !!(
   && word.nsibidi
   && Array.isArray(word.stems) && word.stems.length
   && (word.wordClass === WordClass.NNP.value || (Array.isArray(word.synonyms) && word.synonyms.length))
-  && (word.wordClass === WordClass.NNP.value || (Array.isArray(word.antonyms) && word.antonyms.length))
 );

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -2,6 +2,18 @@ import { Record } from 'react-admin';
 import WordClass from 'src/shared/constants/WordClass';
 import { Word } from './interfaces';
 
+export const invalidNymsWordClass = [
+  WordClass.CJN.value,
+  WordClass.DEM.value,
+  WordClass.NM.value,
+  WordClass.NNP.value,
+  WordClass.CD.value,
+  WordClass.PREP.value,
+  WordClass.ISUF.value,
+  WordClass.ESUF.value,
+  WordClass.SYM.value,
+];
+
 export default (word: Word | Record): boolean => !!(
   word.word
   && word.wordClass
@@ -23,5 +35,5 @@ export default (word: Word | Record): boolean => !!(
   && word.attributes.isStandardIgbo
   && word.nsibidi
   && Array.isArray(word.stems) && word.stems.length
-  && (word.wordClass === WordClass.NNP.value || (Array.isArray(word.synonyms) && word.synonyms.length))
+  && (invalidNymsWordClass.includes(word.wordClass) || (Array.isArray(word.synonyms) && word.synonyms.length))
 );

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -21,6 +21,7 @@ import useBeforeWindowUnload from 'src/hooks/useBeforeWindowUnload';
 import { Word, WordDialect } from 'src/backend/controllers/utils/interfaces';
 import isVerb from 'src/backend/shared/utils/isVerb';
 import { handleUpdateDocument } from 'src/shared/constants/actionsMap';
+import { invalidNymsWordClass } from 'src/backend/controllers/utils/determineIsAsCompleteAsPossible';
 import WordEditFormResolver from './WordEditFormResolver';
 import { sanitizeArray, onCancel } from '../utils';
 import DefinitionsForm from './components/DefinitionsForm';
@@ -337,22 +338,26 @@ const WordEditForm = ({
         setVariations={setVariations}
         control={control}
       />
-      <SynonymsForm
-        errors={errors}
-        synonyms={synonyms}
-        setSynonyms={setSynonyms}
-        control={control}
-        setValue={setValue}
-        record={record}
-      />
-      <AntonymsForm
-        errors={errors}
-        antonyms={antonyms}
-        setAntonyms={setAntonyms}
-        control={control}
-        setValue={setValue}
-        record={record}
-      />
+      {!invalidNymsWordClass.includes(watchWordClass.value) ? (
+        <>
+          <SynonymsForm
+            errors={errors}
+            synonyms={synonyms}
+            setSynonyms={setSynonyms}
+            control={control}
+            setValue={setValue}
+            record={record}
+          />
+          <AntonymsForm
+            errors={errors}
+            antonyms={antonyms}
+            setAntonyms={setAntonyms}
+            control={control}
+            setValue={setValue}
+            record={record}
+          />
+        </>
+      ) : null}
       {/*
         * Must use record.dialects in order for all dialects to render on first pain
         * in order for react-hook-form to initialize all their values in the form.


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | No | Closes N/A |

## Background
This PR removes antonyms as a required field for word completeness. Additionally, the synonyms and antonyms categories will be conditionally rendered for specific word classes that don't support those -nyms.

### Conditionally rendering synonyms and antonyms for word class
https://user-images.githubusercontent.com/16169291/183338645-da914c58-ffe9-4d8b-9bde-bfb7ef5ac230.mov

 