### PR TITLE
Remove the high tone mark from the diacritics bank

### DIFF
--- a/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
+++ b/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Box, Button, Text } from '@chakra-ui/react';
 
-const diacritics = [803, 768, 769, 772, 775, 614];
+const diacritics = [803, 768, 772, 775, 614];
 
 const insertLetter = (inputRef, letter) => {
   inputRef.current.focus();


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Refactor | No | Closes N/A |

## Background
To prevent the usage of high tone marks for future word or example sentence entries, the diacritics pop up bank will no longer include the high tone.