### PR TITLE
Compact resolved words before indexing

### DIFF
--- a/src/shared/components/views/components/ExampleEditForm/components/AssociatedWordsForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/components/AssociatedWordsForm.tsx
@@ -25,10 +25,12 @@ const AssociatedWords = (
     (async () => {
       setIsLoadingAssociatedWords(true);
       try {
-        const associatedWordPromises = await Promise.all(compact(associatedWordIds).map(async (associatedWordId) => {
-          const associatedWord = await resolveWord(associatedWordId);
-          return associatedWord;
-        }));
+        const associatedWordPromises = compact(
+          await Promise.all(compact(associatedWordIds).map(async (associatedWordId) => {
+            const associatedWord = await resolveWord(associatedWordId).catch(() => null);
+            return associatedWord;
+          })),
+        );
         setResolvedAssociatedWords(associatedWordPromises);
       } finally {
         setIsLoadingAssociatedWords(false);

--- a/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
@@ -23,10 +23,10 @@ const RelatedTerms = (
     (async () => {
       setIsLoadingRelatedTerms(true);
       try {
-        setResolvedRelatedTerms(await Promise.all(relatedTermIds.map(async (relatedTermId) => {
-          const word = await resolveWord(relatedTermId);
+        setResolvedRelatedTerms(compact(await Promise.all(relatedTermIds.map(async (relatedTermId) => {
+          const word = await resolveWord(relatedTermId).catch(() => null);
           return word;
-        })));
+        }))));
       } finally {
         setIsLoadingRelatedTerms(false);
       }

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
@@ -30,7 +30,7 @@ const Stems = (
          * to save the Word Suggestion, omitting the unwanted word.
          */
         const compactedResolvedStems = compact(await Promise.all(stemIds.map(async (stemId) => {
-          const word = await resolveWord(stemId);
+          const word = await resolveWord(stemId).catch(() => null);
           return word;
         })));
         setResolvedStems(compactedResolvedStems);


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Bug | No | [Notion Ticket](https://www.notion.so/Uh-oh-32119fccc4f14cfa9bceb1474f1340fa) |

## Background
When a translator goes to a page that has an associated word that no longer exists, the resolved word result will be `undefined`. We later then attempt to index into `undefined` for the `id` assuming that the word exists. This PR avoids this error my passing the resolved word results through `compact` to ensure that only truthy values are present in the array.