### PR TITLE
Consider n and m consonant cluster has high tones

### DIFF
--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
@@ -35,7 +35,7 @@ const SuggestedWords = ({ word } : { word: string }): ReactElement => {
       </Tooltip>
 
       <Box className="flex flex-row flex-wrap">
-        {suggestedWords.map(({
+        {suggestedWords.length ? suggestedWords.map(({
           word,
           nsibidi,
           wordClass,
@@ -77,7 +77,7 @@ const SuggestedWords = ({ word } : { word: string }): ReactElement => {
               </PopoverContent>
             </Popover>
           </Box>
-        ))}
+        )) : <Text color="gray.400" fontStyle="italic" fontSize="sm">No similar words</Text>}
       </Box>
     </Box>
   );


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | No | Closes N/A |

## Problem
A translator noticed that words would be flagged for incorrect tone marking even though they were correctly marked. The platform wasn't treating n and m consonant clusters that start a word (i.e. **nn**e and **nt**akiri) as high tones, leading to a false positive flagging of words.

## Solution
This PR checks to see if a word starts with an n or m consonant cluster and treats that as a preceding high tone. This PR also stops short-circuiting by checking for correct tone markings to ensure that the entire word is marked as expected.