### PR TITLE
Enable clicking dashboard stat, add currently editing stats, fix typo, and send notifications to editors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "import/no-extraneous-dependencies": "off",
     "import/no-cycle": "off",
     "max-len": ["error", { "code": 120 }],
+    "no-confusing-arrow": "off",
     "no-extra-boolean-cast": "off",
     "no-nested-ternary": "off",
     "no-param-reassign": "off",

--- a/cypress/constants/index.js
+++ b/cypress/constants/index.js
@@ -100,6 +100,7 @@ export const SuggestionSelectOptions = {
   VIEW: 'View',
   APPROVE: /Approve|Approved/,
   DENY: /Deny|Denied/,
+  NOTIFY: 'Notify',
   DELETE: 'Delete',
 };
 

--- a/src/Core/Dashboard/Dashboard.tsx
+++ b/src/Core/Dashboard/Dashboard.tsx
@@ -20,23 +20,35 @@ import MilestoneProgress from './components/MilestoneProgress';
 import network from './network';
 
 const auth = getAuth();
-const userStatsLabel = {
+const userStatBodies = {
   approvedWordSuggestionsCount: {
+    hash: '#/wordSuggestions?displayedFilters=%5B%5D&filter=%7B"approvals"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
     label: 'Total approved word suggestions',
   },
   deniedWordSuggestionsCount: {
+    hash: '#/wordSuggestions?displayedFilters=%5B%5D&filter=%7B"denials"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
     label: 'Total denied word suggestions',
   },
   approvedExampleSuggestionsCount: {
+    hash: '#/exampleSuggestions?displayedFilters=%5B%5D&filter=%7B"approvals"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
     label: 'Total approved example suggestions',
   },
   deniedExampleSuggestionsCount: {
+    hash: '#/exampleSuggestions?displayedFilters=%5B%5D&filter=%7B"denials"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
     label: 'Total denied example suggestions',
   },
   authoredWordSuggestionsCount: {
+    hash: '#/wordSuggestions?displayedFilters=%5B%5D&filter=%7B"authorId"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
     label: 'Total authored word suggestions',
   },
   authoredExampleSuggestionsCount: {
+    hash: '#/exampleSuggestions?displayedFilters=%5B%5D&filter=%7B"authorId"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
     label: 'Total authored exampled suggestions',
   },
   mergedWordSuggestionsCount: {
@@ -44,6 +56,16 @@ const userStatsLabel = {
   },
   mergedExampleSuggestionsCount: {
     label: 'Total merged exampled suggestions',
+  },
+  currentEditingWordSuggestionsCount: {
+    hash: '#/wordSuggestions?displayedFilters=%5B%5D&filter=%7B"userInteractions"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
+    label: 'Total currently editing word suggestions',
+  },
+  currentEditingExampleSuggestionsCount: {
+    hash: '#/exampleSuggestions?displayedFilters=%5B%5D&filter=%7B"userInteractions"'
+    + '%3Atrue%7D&order=DESC&page=1&perPage=10&sort=approvals',
+    label: 'Total currently editing example suggestions',
   },
 };
 
@@ -87,15 +109,25 @@ const Dashboard = (): ReactElement => {
           <Box mt={4}>
             <Text fontSize="3xl" fontWeight="bold" className="text-center">Personal Contributions</Text>
             <Text fontSize="lg" className="text-gray-800 text-center">
-              {'Take a look at how much you\'ve contributed to the community!'}
+              {'Take a look at how much you\'ve contributed to the community! '
+              + 'You can click on each stat to see the associated documents'}
             </Text>
           </Box>
           <Skeleton isLoaded={userStats} minHeight={32}>
-            <Box className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <Box className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
               {Object.entries(userStats || {}).map(([key, value]) => (
-                <Box className="flex justify-center items-center rounded bg-white shadow-sm p-3">
+                <Box
+                  className={`flex justify-center items-center rounded-lg bg-white
+                  shadow-sm p-4 transition-all duration-200 border border-gray-200
+                  ${userStatBodies[key].hash ? 'cursor-pointer hover:bg-blue-100' : ''}`}
+                  onClick={() => {
+                    if (userStatBodies[key].hash) {
+                      window.location.hash = userStatBodies[key].hash;
+                    }
+                  }}
+                >
                   <Text key={key}>
-                    <chakra.span fontWeight="bold">{`${userStatsLabel[key].label}: `}</chakra.span>
+                    <chakra.span fontWeight="bold">{`${userStatBodies[key].label}: `}</chakra.span>
                     {`${value}`}
                   </Text>
                 </Box>

--- a/src/backend/controllers/email.ts
+++ b/src/backend/controllers/email.ts
@@ -145,7 +145,7 @@ export const sendDocumentUpdateNotification = (
     const adminEmails = await findAdminUserEmails() as [string];
     const message = constructMessage({
       from: { email: API_FROM_EMAIL, name: 'Igbo API' },
-      to: [...adminEmails, data.to],
+      to: adminEmails.concat(data.to),
       templateId: DOCUMENT_UPDATE_NOTIFICATION,
       dynamic_template_data: omit(data, ['to']),
     });

--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -135,6 +135,7 @@ export const getExampleSuggestions = (req: Request, res: Response, next: NextFun
       skip,
       limit,
       filters,
+      user,
       ...rest
     } = handleQueries(req);
     const regexMatch = searchExampleSuggestionsRegexQuery(regexKeyword, filters);

--- a/src/backend/controllers/examples.ts
+++ b/src/backend/controllers/examples.ts
@@ -45,12 +45,13 @@ export const getExamples = async (
       skip,
       limit,
       filters,
+      user,
       ...rest
     } = handleQueries(req);
     const regexMatch = searchExamplesRegexQuery(regexKeyword, filters);
     const examples = await searchExamples({ query: regexMatch, skip, limit });
 
-    return packageResponse({
+    return await packageResponse({
       res,
       docs: examples,
       model: Example,

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -157,6 +157,12 @@ export const getUserStats = async (req: Request, res: Response, next: NextFuncti
     const authoredExampleSuggestionsCount = exampleSuggestions.filter(({ author }) => author === user.uid).length;
     const mergedWordSuggestionsCount = wordSuggestions.filter(({ mergedBy }) => mergedBy === user.uid).length;
     const mergedExampleSuggestionsCount = exampleSuggestions.filter(({ mergedBy }) => mergedBy === user.uid).length;
+    const currentEditingWordSuggestionsCount = wordSuggestions.filter(({ mergedBy, userInteractions = [] }) => (
+      !mergedBy && userInteractions.includes(user.uid)
+    )).length;
+    const currentEditingExampleSuggestionsCount = exampleSuggestions.filter(({ mergedBy, userInteractions = [] }) => (
+      !mergedBy && userInteractions.includes(user.uid)
+    )).length;
 
     return res.send({
       approvedWordSuggestionsCount,
@@ -167,6 +173,8 @@ export const getUserStats = async (req: Request, res: Response, next: NextFuncti
       authoredExampleSuggestionsCount,
       mergedWordSuggestionsCount,
       mergedExampleSuggestionsCount,
+      currentEditingWordSuggestionsCount,
+      currentEditingExampleSuggestionsCount,
     });
   } catch (err) {
     return next(err);

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -21,7 +21,7 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
       isStandardIgbo,
       isAccented,
       isComplete,
-    },
+    } = {},
     nsibidi,
     stems = [],
     relatedTerms = [],

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -19,7 +19,7 @@ export const invalidRelatedTermsWordClasses = [
 export default (word: Word | Record): boolean => !!(
   word.word
   && word.wordClass
-  && (word.word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g) || word.attributes.isAccented)
+  && (word.word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g) || (word.attributes || {}).isAccented)
   && Array.isArray(word.definitions) && word.definitions.length
   && (
     Array.isArray(word.examples)

--- a/src/backend/controllers/utils/index.ts
+++ b/src/backend/controllers/utils/index.ts
@@ -162,6 +162,15 @@ const parseFilter = (
     if (parsedFilter.authorId) {
       parsedFilter.authorId = user.uid;
     }
+    if (parsedFilter.userInteractions) {
+      parsedFilter.userInteractions = user.uid;
+    }
+    if (parsedFilter.approvals) {
+      parsedFilter.approvals = user.uid;
+    }
+    if (parsedFilter.denials) {
+      parsedFilter.denials = user.uid;
+    }
     return parsedFilter;
   } catch {
     throw new Error(`Invalid filter query syntax. Expected: {"word":"filter"}, Received: ${filter}`);

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -80,7 +80,8 @@ export interface WordSuggestion extends Document<any>, LeanDocument<any> {
   examples?: ExampleSuggestion[],
   dialects?: {
     [key: string]: WordDialect,
-  }
+  },
+  userInteractions?: string[],
 };
 
 export interface Example extends Document<any>, LeanDocument<any> {
@@ -109,6 +110,7 @@ export interface ExampleSuggestion extends Document<any>, LeanDocument<any> {
   updatedAt: Date,
   merged: Types.ObjectId,
   mergedBy: string,
+  userInteractions?: string[],
 };
 
 export interface ExampleClientData {

--- a/src/backend/controllers/utils/queries.ts
+++ b/src/backend/controllers/utils/queries.ts
@@ -21,6 +21,9 @@ type Filters = {
   authorId?: any,
   style?: any,
   wordClass?: any,
+  userInteractions?: any,
+  approvals?: any,
+  denials?: any,
 };
 
 const generateSearchFilters = (filters: { [key: string]: string }): { [key: string]: any } => {
@@ -64,6 +67,15 @@ const generateSearchFilters = (filters: { [key: string]: string }): { [key: stri
         break;
       case 'wordClass':
         allFilters.wordClass = { $in: value };
+        break;
+      case 'userInteractions':
+        allFilters.userInteractions = { $in: value };
+        break;
+      case 'approvals':
+        allFilters.approvals = { $in: value };
+        break;
+      case 'denials':
+        allFilters.denials = { $in: value };
         break;
       default:
         return allFilters;

--- a/src/backend/controllers/words/index.ts
+++ b/src/backend/controllers/words/index.ts
@@ -89,6 +89,7 @@ export const getWords = async (
       strict,
       dialects,
       filters,
+      user,
       ...rest
     } = handleQueries(req);
     const searchQueries = {
@@ -102,12 +103,14 @@ export const getWords = async (
       word?: any,
       text?: any
       definitions?: any
-    } = !strict ? searchIgboTextSearch(searchWord, regexKeyword, filters) : strictSearchIgboQuery(searchWord);
+    } = !strict
+      ? searchIgboTextSearch(searchWord, regexKeyword, filters)
+      : strictSearchIgboQuery(searchWord);
     const words = await searchWordUsingIgbo({ query, ...searchQueries });
     if (!words.length) {
       query = searchEnglishRegexQuery(regexKeyword, filters);
       const englishWords = await searchWordUsingEnglish({ query, ...searchQueries });
-      return packageResponse({
+      return await packageResponse({
         res,
         docs: englishWords,
         model: Word,
@@ -115,7 +118,7 @@ export const getWords = async (
         ...rest,
       });
     }
-    return packageResponse({
+    return await packageResponse({
       res,
       docs: words,
       model: Word,
@@ -274,7 +277,7 @@ const overwriteWordPronunciation = async (
     await suggestion.save();
     await WordSuggestion.findOneAndUpdate({ _id: suggestion.id }, suggestion.toObject());
     await Word.findOneAndUpdate({ _id: word.id }, word.toObject());
-    return word.save();
+    return await word.save();
   } catch (err) {
     console.log('An error while merging audio pronunciations failed:', err.message);
     console.log(err.stack);

--- a/src/backend/middleware/interactWithSuggsetion.ts
+++ b/src/backend/middleware/interactWithSuggsetion.ts
@@ -1,0 +1,12 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export default (req: Request, res: Response, next: NextFunction): void => {
+  const { body, user: { uid } } = req;
+  if (!body.userInteractions) {
+    body.userInteractions = [];
+  }
+  if (!body.userInteractions.includes(uid)) {
+    body.userInteractions.push(uid);
+  }
+  return next();
+};

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -28,6 +28,7 @@ const exampleSuggestionSchema = new Schema({
   source: { type: String, default: SuggestionSource.INTERNAL },
   merged: { type: Types.ObjectId, ref: 'Example', default: null },
   mergedBy: { type: String, default: null },
+  userInteractions: { type: [{ type: String }], default: [] },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 toJSONPlugin(exampleSuggestionSchema);

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -81,6 +81,7 @@ const wordSuggestionSchema = new Schema(
     source: { type: String, defualt: SuggestionSource.INTERNAL },
     merged: { type: Types.ObjectId, ref: 'Word', default: null },
     mergedBy: { type: String, default: null },
+    userInteractions: { type: [{ type: String }], default: [] },
   },
   { toObject: toObjectPlugin, timestamps: true },
 );

--- a/src/backend/routers/editorRouter.tsx
+++ b/src/backend/routers/editorRouter.tsx
@@ -36,6 +36,7 @@ import validateExampleMerge from '../middleware/validateExampleMerge';
 import validateWordBody from '../middleware/validateWordBody';
 import validateWordMerge from '../middleware/validateWordMerge';
 import cacheControl from '../middleware/cacheControl';
+import interactWithSuggsetion from '../middleware/interactWithSuggsetion';
 import UserRoles from '../shared/constants/UserRoles';
 
 const editorRouter = express.Router();
@@ -52,8 +53,8 @@ editorRouter.put('/examples/:id', authorization([UserRoles.MERGER, UserRoles.ADM
 editorRouter.get('/examples/:id/exampleSuggestions', validId, getAssociatedExampleSuggestions);
 
 editorRouter.get('/wordSuggestions', getWordSuggestions);
-editorRouter.post('/wordSuggestions', authorization([]), validateWordBody, postWordSuggestion);
-editorRouter.put('/wordSuggestions/:id', validId, validateWordBody, putWordSuggestion);
+editorRouter.post('/wordSuggestions', authorization([]), validateWordBody, interactWithSuggsetion, postWordSuggestion);
+editorRouter.put('/wordSuggestions/:id', validId, validateWordBody, interactWithSuggsetion, putWordSuggestion);
 editorRouter.get('/wordSuggestions/:id', validId, getWordSuggestion);
 editorRouter.delete(
   '/wordSuggestions/:id',
@@ -63,8 +64,14 @@ editorRouter.delete(
 );
 
 editorRouter.get('/exampleSuggestions', getExampleSuggestions);
-editorRouter.post('/exampleSuggestions', authorization([]), validateExampleBody, postExampleSuggestion);
-editorRouter.put('/exampleSuggestions/:id', validId, validateExampleBody, putExampleSuggestion);
+editorRouter.post(
+  '/exampleSuggestions',
+  authorization([]),
+  validateExampleBody,
+  interactWithSuggsetion,
+  postExampleSuggestion,
+);
+editorRouter.put('/exampleSuggestions/:id', validId, validateExampleBody, interactWithSuggsetion, putExampleSuggestion);
 editorRouter.get('/exampleSuggestions/:id', validId, getExampleSuggestion);
 editorRouter.delete(
   '/exampleSuggestions/:id',

--- a/src/backend/shared/constants/WordTags.ts
+++ b/src/backend/shared/constants/WordTags.ts
@@ -17,7 +17,7 @@ export default {
   },
   TRANSPORTAION: {
     value: 'transportaion',
-    label: 'Transportaion',
+    label: 'Transportation',
   },
   CULTURE: {
     value: 'culture',

--- a/src/shared/components/Confirmation/Confirmation.tsx
+++ b/src/shared/components/Confirmation/Confirmation.tsx
@@ -148,7 +148,9 @@ const Confirmation = ({
           ? { groupNumber: idValue }
           : action?.type === ActionTypes.REQUEST_DELETE
             ? { note: idValue }
-            : {}),
+            : action?.type === ActionTypes.NOTIFY
+              ? { editorsNotes: `${record?.editorsNotes || ''}\n\n${idValue}` }
+              : {}),
       resource,
       record,
     })
@@ -193,6 +195,7 @@ const Confirmation = ({
       action?.type === ActionTypes.COMBINE
       || action?.type === ActionTypes.ASSIGN_EDITING_GROUP
       || action?.type === ActionTypes.REQUEST_DELETE
+      || action?.type === ActionTypes.NOTIFY
     ) {
       provideInputValueUponSubmit();
     } else {
@@ -258,6 +261,17 @@ const Confirmation = ({
           placeholder="Editing Group Number"
           type="number"
           max={MAX_EDITING_GROUP_NUMBER}
+        />
+      ) : null}
+      {action?.type === ActionTypes.NOTIFY ? (
+        <InputNoteForm
+          onSubmit={handleConfirm}
+          onChange={(e) => setIdValue(e.target.value)}
+          value={idValue}
+          header=""
+          data-test="notify-input"
+          placeholder="Add a message to send to all associated editors"
+          type="text"
         />
       ) : null}
     </ConfirmModal>

--- a/src/shared/components/Select/Select.tsx
+++ b/src/shared/components/Select/Select.tsx
@@ -9,6 +9,7 @@ import {
 } from '@chakra-ui/react';
 import {
   AddIcon,
+  AtSignIcon,
   CheckCircleIcon,
   ChevronDownIcon,
   DeleteIcon,
@@ -118,6 +119,16 @@ const Select = ({
         </span>
       ))(),
       onSelect: () => setAction(actionsMap.Deny),
+    },
+    {
+      value: 'notify',
+      label: (() => (
+        <span>
+          <AtSignIcon className="mr-2" />
+          Notify Editors
+        </span>
+      ))(),
+      onSelect: () => setAction(actionsMap.Notify),
     },
     hasAdminOrMergerPermissions(permissions, (record.merged ? null : [
       {

--- a/src/shared/components/actions/ListActions.tsx
+++ b/src/shared/components/actions/ListActions.tsx
@@ -235,6 +235,9 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
                       <MenuItemOption value={SuggestionSource.INTERNAL}>
                         From Igbo API Editor Platform
                       </MenuItemOption>,
+                      <MenuItemOption value="userInteractions">
+                        Is Currently Editing
+                      </MenuItemOption>,
                     ]
                     : null}
                   {isSuggestionResource

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -271,7 +271,7 @@ const ExampleEditForm = ({
       </Box>
       <Box className="flex flex-col">
         <FormHeader
-          title="Editor Comments"
+          title="Editor's Comments"
           tooltip={`Leave a comment for other editors to read to 
           understand your reasoning behind your change. 
           Leave your name on your comment!`}

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -351,7 +351,7 @@ const WordEditForm = ({
         */}
       <Box className="flex flex-col">
         <FormHeader
-          title="Editor Comments"
+          title="Editor's Comments"
           tooltip={`Leave a comment for other editors to read to 
           understand your reasoning behind your change. 
           Leave your name on your comment!`}
@@ -365,7 +365,7 @@ const WordEditForm = ({
               rows={8}
             />
           )}
-          name="userComments"
+          name="editorsNotes"
           defaultValue={record.userComments || getValues().userComments}
           control={control}
         />

--- a/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
@@ -38,7 +38,7 @@ it('render word edit form', async () => {
   await findByText('Antonyms');
   await findByText('Examples');
   await findByText('Current Dialects');
-  await findByText('Editor Comments');
+  await findByText('Editor\'s Comments');
 });
 
 it('add a word stem to word suggestion', async () => {

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -72,7 +72,8 @@ const HeadwordForm = ({
                   <Checkbox
                     onChange={(e) => onChange(e.target.checked)}
                     isChecked={value}
-                    defaultIsChecked={isHeadwordAccented || record.attributes?.[WordAttributes.IS_ACCENTED.value]}
+                    defaultIsChecked={isHeadwordAccented?.length
+                      || record.attributes?.[WordAttributes.IS_ACCENTED.value]}
                     ref={ref}
                     data-test={`${WordAttributes.IS_ACCENTED.value}-checkbox`}
                     size="lg"
@@ -80,7 +81,7 @@ const HeadwordForm = ({
                     <span className="font-bold">{WordAttributes.IS_ACCENTED.label}</span>
                   </Checkbox>
                 )}
-                defaultValue={isHeadwordAccented
+                defaultValue={isHeadwordAccented?.length
                   || record.attributes?.[WordAttributes.IS_ACCENTED.value]
                   || getValues().attributes?.[WordAttributes.IS_ACCENTED.value]}
                 name={`attributes.${WordAttributes.IS_ACCENTED.value}`}
@@ -113,7 +114,7 @@ const HeadwordForm = ({
               />
             </Box>
           </Tooltip>
-          <Tooltip label="Check this checkbox if this is a newly constructed Igbo word">
+          <Tooltip label="Check this checkbox if this is a newly coined, aka constructed, Igbo word">
             <Box display="flex">
               <Controller
                 render={({ onChange, value, ref }) => (

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
@@ -73,7 +73,7 @@ const SuggestedWords = ({ word, id: wordId } : { word: string, id: string }): Re
                     <Text fontStyle="italic">{WordClass[wordClass]?.label || wordClass}</Text>
                     <Box>
                       {definitions.map((definition, index) => (
-                        <Text>{`${index + 1}. ${definition}`}</Text>
+                        <Text key={definition}>{`${index + 1}. ${definition}`}</Text>
                       ))}
                     </Box>
                   </PopoverContent>

--- a/src/shared/components/views/shows/WordShow/Attributes.tsx
+++ b/src/shared/components/views/shows/WordShow/Attributes.tsx
@@ -21,6 +21,12 @@ const Attributes = (
       isSlang,
       isConstructedTerm,
       isBorrowedTerm,
+    } = {
+      isStandardIgbo: false,
+      isAccented: false,
+      isSlang: false,
+      isConstructedTerm: false,
+      isBorrowedTerm: false,
     },
   } = record;
 

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -88,11 +88,19 @@ const WordShow = (props: ShowProps): ReactElement => {
   /* Grabs the original word if it exists */
   useEffect(() => {
     (async () => {
-      const originalWord = record?.originalWordId ? await getWord(record.originalWordId) : null;
-      const differenceRecord = diff(originalWord, record, (_, key) => DIFF_FILTER_KEYS.indexOf(key) > -1);
-      setOriginalWordRecord(originalWord);
-      setDiffRecord(differenceRecord);
-      setIsLoading(false);
+      try {
+        const originalWord = record?.originalWordId ? await getWord(record.originalWordId).catch((err) => {
+          // Unable to retrieve word
+          console.log(err);
+        }) : null;
+        const differenceRecord = diff(originalWord, record, (_, key) => DIFF_FILTER_KEYS.indexOf(key) > -1);
+        setOriginalWordRecord(originalWord);
+        setDiffRecord(differenceRecord);
+      } catch (err) {
+        console.log(err);
+      } finally {
+        setIsLoading(false);
+      }
     })();
   }, [record]);
 

--- a/src/shared/constants/ActionTypes.ts
+++ b/src/shared/constants/ActionTypes.ts
@@ -11,6 +11,7 @@ enum ActionTypes {
   SUGGEST_EDIT = 'SuggestionEdit',
   APPROVE = 'Approve',
   DENY = 'Deny',
+  NOTIFY = 'Notify',
   MERGE = 'Merge',
   DELETE = 'Delete',
   COMBINE = 'Combine',

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -13,6 +13,20 @@ import {
 import ActionTypes from './ActionTypes';
 import Collections from './Collections';
 
+const prepareRecord = (record) => {
+  const approvals = record?.approvals || [];
+  const denials = record?.denials || [];
+  return {
+    ...record,
+    approvals: approvals.some((approval) => typeof approval === 'string')
+      ? approvals.map((approval) => approval?.uid ? approval.uid : approval)
+      : approvals,
+    denials: denials.some((denial) => typeof denial === 'string')
+      ? denials.map((denial) => denial?.uid ? denial.uid : denial)
+      : denials,
+  };
+};
+
 const handleUpdatePermissions = useCallable<string, EmptyResponse>('updatePermissions');
 const handleDeleteUser = useCallable<any, EmptyResponse>('deleteUser');
 const handleRequestDeleteDocument = useCallable<any, EmptyResponse>('requestDeleteDocument');
@@ -27,7 +41,7 @@ export default {
     title: 'Approve Document',
     content: 'Are you sure you want to approve this document?',
     executeAction: ({ record, resource } : { record: Record, resource: string }) : Promise<any> => {
-      approveDocument({ resource, record });
+      approveDocument({ resource, record: prepareRecord(record) });
       return handleUpdateDocument({ type: ActionTypes.APPROVE, resource, record });
     },
     successMessage: 'Document has been approved 🙌🏾',
@@ -37,10 +51,25 @@ export default {
     title: 'Deny Document',
     content: 'Are you sure you want to deny this document?',
     executeAction: ({ record, resource }: { record: Record, resource: string }) : Promise<any> => {
-      denyDocument({ resource, record });
+      denyDocument({ resource, record: prepareRecord(record) });
       return handleUpdateDocument({ type: ActionTypes.DENY, resource, record });
     },
     successMessage: 'Document has been denied 🙅🏾‍♀️',
+  },
+  [ActionTypes.NOTIFY]: {
+    type: 'Notify',
+    title: 'Directly Notify Editors About Changes',
+    content: 'Are you sure you want to notify editors?',
+    executeAction: ({ editorsNotes, record, resource }:
+    { editorsNotes: string, record: Record, resource: string }) : Promise<any> => (
+      handleUpdateDocument({
+        type: ActionTypes.NOTIFY,
+        resource,
+        record: prepareRecord({ ...record, editorsNotes }),
+        includeEditors: true,
+      })
+    ),
+    successMessage: 'Notification has been sent 📬',
   },
   [ActionTypes.MERGE]: {
     type: 'Merge',


### PR DESCRIPTION
## Background
This is a large PR that addresses the following topics or issues:

### Fix Transportation typo
There was a typo with the word "transportation" for the tags option for suggestions.

### Send Notifications to Associated Suggestion Editors
When a reviewer wants to be able to send a notification about an update to a suggestion, there is a new 'Notify' button that will appear where they can attach a message that will send an email to all associated editors to the current document.

<img width="358" alt="Screen Shot 2022-09-14 at 8 18 59 PM" src="https://user-images.githubusercontent.com/16169291/190284910-faa8ed98-447c-4064-aede-da8653b4bf8e.png">

### Clickable dashboard stats
The stats on the dashboard are now clickable and will take the editor to the right list view.

### Add Currently Editing Stats
For reviewers to know which suggestions they've been working on, there's a new currently editing stats that appears on the homepage

<img width="735" alt="Screen Shot 2022-09-14 at 8 20 35 PM" src="https://user-images.githubusercontent.com/16169291/190285070-8f5ac2ea-6642-4bda-abd1-b8e0894b9e2b.png">
