### PR TITLE
Remove deprecated `execCommand`

### DIFF
--- a/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
+++ b/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
@@ -4,8 +4,10 @@ import { Box, Button, Text } from '@chakra-ui/react';
 const diacritics = [803, 768, 772, 775, 614];
 
 const insertLetter = (inputRef, letter) => {
-  inputRef.current.focus();
-  document.execCommand('insertText', false, letter);
+  const element = inputRef.current;
+  const [start, end] = [element.selectionStart, element.selectionEnd];
+  element.setRangeText(letter, start, end, 'select');
+  element.dispatchEvent(new Event('change'));
 };
 
 const DiacriticsBank = (

--- a/src/shared/primitives/Input.tsx
+++ b/src/shared/primitives/Input.tsx
@@ -88,17 +88,22 @@ const Input = React.forwardRef(({
     }
   }, [isSearchingAutoCompleteWords]);
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.addEventListener('change', (e) => {
+        onChange(e);
+        if (searchApi) {
+          debounceInput(e.target.value);
+        }
+      });
+    }
+  }, []);
+
   return (
     <Box className="relative w-full">
       <ChakraInput
         ref={inputRef}
         value={value}
-        onChange={(e) => {
-          onChange(e);
-          if (searchApi) {
-            debounceInput(e.target.value);
-          }
-        }}
         className={`${className} ${width}`}
         {...rest}
       />

--- a/src/shared/primitives/Textarea.tsx
+++ b/src/shared/primitives/Textarea.tsx
@@ -1,4 +1,9 @@
-import React, { useState, useRef, ReactElement } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  ReactElement,
+} from 'react';
 import { Box, Textarea as ChakraTextarea } from '@chakra-ui/react';
 import { isMobile } from 'react-device-detect';
 import useEventListener from 'src/hooks/useEventListener';
@@ -35,12 +40,17 @@ const Textarea = React.forwardRef(({
   useEventListener('scroll', (e) => handlePosition({ e, ...eventListenerData }));
   useEventListener('resize', (e) => handlePosition({ e, ...eventListenerData }));
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.addEventListener('change', onChange);
+    }
+  }, []);
+
   return (
     <Box className="relative w-full">
       <ChakraTextarea
         ref={inputRef}
         value={value}
-        onChange={onChange}
         className={className}
         {...rest}
       />


### PR DESCRIPTION
## Background
Translators have been unable to add diacritic marks to words that are within the WordEdit or ExampleEdit forms. Other input fields like the search bar were unaffected by this bug

## Bug
The `execCommand` wasn't the source of the problem; however, since it's deprecated it can lead to future problems down the road. The core issue was the `Input` and `Textarea` components' `onChange` handler wasn't getting called whenever a diacritic mark was getting added to the word, and the input values are controlled by `react-hook-form` instead of independently. So if the `onChange` handler that's hooked into `react-hook-form` doesn't get called, then the value won't get updated

## Solution
* Remove `execCommand` and use a modern API to insert text
* Change the `onChange` listener to a `addEventListener.onChange('change')` so we can dispatch a new synthetic Event with type `change`
