### PR TITLE
Load Larger Stats and Remove Nsịbịdị Complete Word Requirement

### DIFF
--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -104,7 +104,11 @@ const calculateWordStats = async ():
 Promise<{ sufficientWordsCount: number, completeWordsCount: number, dialectalVariationsCount: number } | void> => {
   const INCLUDE_ALL_WORDS_LIMIT = 100000;
   const words = await findWordsWithMatch({
-    match: { word: { $regex: /./ }, 'attributes.isStandardIgbo': { $eq: true } },
+    match: {
+      word: { $regex: /./ },
+      'attributes.isStandardIgbo': { $eq: true },
+      'attributes.isAccented': { $eq: true },
+    },
     examples: true,
     limit: INCLUDE_ALL_WORDS_LIMIT,
   });

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -22,14 +22,13 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
       isAccented,
       isComplete,
     } = {},
-    nsibidi,
     stems = [],
     relatedTerms = [],
     dialects = {},
     tenses = {},
   } = record;
 
-  const isAudioAvailable = await new Promise((resolve) => {
+  const isAudioAvailable = !skipAudioCheck && await new Promise((resolve) => {
     axios.get(pronunciation)
       .then(() => resolve(true))
       .catch(() => {
@@ -53,7 +52,6 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
 
   const completeWordRequirements = compact([
     ...sufficientWordRequirements,
-    !nsibidi && 'Nsịbịdị is needed',
     !stems?.length && 'A word stem is needed',
     invalidRelatedTermsWordClasses.includes(wordClass) ? null : !relatedTerms?.length && 'A related term is needed',
     isVerb(wordClass) && !Object.entries(tenses).every(([key, value]) => (

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -36,7 +36,6 @@ export default (word: Word | Record): boolean => !!(
   )
   && word.pronunciation
   && word.attributes.isStandardIgbo
-  && word.nsibidi
   && Array.isArray(word.stems) && word.stems.length
   && (invalidRelatedTermsWordClasses.includes(word.wordClass)
     || (Array.isArray(word.relatedTerms) && word.relatedTerms.length))


### PR DESCRIPTION
## Background
The dashboard was slow to load the larger stats for all the words in the database. This PR improves the load time for those stats. Additionally, Nsịbịdị is not longer considered a requirement for a complete word.