### PR TITLE
Avoid overloading native onChange handlers

### DIFF
--- a/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
+++ b/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
@@ -7,7 +7,7 @@ const insertLetter = (inputRef, letter) => {
   const element = inputRef.current;
   const [start, end] = [element.selectionStart, element.selectionEnd];
   element.setRangeText(letter, start, end, 'select');
-  element.dispatchEvent(new Event('change'));
+  element.dispatchEvent(new Event('insertDiacritic'));
 };
 
 const DiacriticsBank = (

--- a/src/shared/primitives/Input.tsx
+++ b/src/shared/primitives/Input.tsx
@@ -90,7 +90,7 @@ const Input = React.forwardRef(({
 
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.addEventListener('change', (e) => {
+      inputRef.current.addEventListener('insertDiacritic', (e) => {
         onChange(e);
         if (searchApi) {
           debounceInput(e.target.value);
@@ -105,6 +105,12 @@ const Input = React.forwardRef(({
         ref={inputRef}
         value={value}
         className={`${className} ${width}`}
+        onChange={(e) => {
+          onChange(e);
+          if (searchApi) {
+            debounceInput(e.target.value);
+          }
+        }}
         {...rest}
       />
       {searchApi && (isAutoCompleteVisible || isSearchingAutoCompleteWords) ? (

--- a/src/shared/primitives/Textarea.tsx
+++ b/src/shared/primitives/Textarea.tsx
@@ -42,7 +42,7 @@ const Textarea = React.forwardRef(({
 
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.addEventListener('change', onChange);
+      inputRef.current.addEventListener('insertDiacritic', onChange);
     }
   }, []);
 
@@ -52,6 +52,7 @@ const Textarea = React.forwardRef(({
         ref={inputRef}
         value={value}
         className={className}
+        onChange={onChange}
         {...rest}
       />
       <DiacriticsBankPopup


### PR DESCRIPTION
## Background
Originally, we were overloading React's native `onChange` handle to be able to handle both inserting regular letters and diacritics. This PR creates a new Synthetic called `insertDiacritic` to run independently from the native `onChange` handler.