### PR TITLE
Create exact form value path for example audio

### DIFF
--- a/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
@@ -38,6 +38,11 @@ const AudioRecorder = ({
       : path;
   const valuePath = path === 'headword'
     ? 'pronunciation'
+    : path.startsWith('examples')
+      ? 'pronunciation'
+      : `dialects.${path}.pronunciation`;
+  const formValuePath = path === 'headword'
+    ? 'pronunciation'
     : path.startsWith('examples') // Handles path for nested examples
       ? `${path}.pronunciation`
       : `dialects.${path}.pronunciation`;
@@ -63,9 +68,7 @@ const AudioRecorder = ({
   };
 
   const shouldRenderNewPronunciationLabel = () => {
-    const currentPronunciationPath = getFormValues(path === 'headword'
-      ? 'pronunciation'
-      : `dialects.${path}.pronunciation`);
+    const currentPronunciationPath = getFormValues(valuePath);
     return currentPronunciationPath && currentPronunciationPath.startsWith('data');
   };
 
@@ -87,7 +90,7 @@ const AudioRecorder = ({
     // @ts-expect-error
     if (has(getFormValues(), 'pronunciation')) {
       setPronunciation(valuePath, base64data);
-      setPronunciationValue(getFormValues(valuePath));
+      setPronunciationValue(getFormValues(formValuePath));
     }
     if (base64data) {
       toast({

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
@@ -73,7 +73,7 @@ const Example = ({
               <Input
                 {...props}
                 className="form-input invisible"
-                placeholder="Example Id"
+                placeholder="Example Pronunciation"
                 data-test={`examples-${index}-pronunciation`}
               />
             )}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready | Bug| No | Closes N/A |

## Problem
Translators have been able to record audio for example sentences since the audio would clear out when they would update the containing Word Suggestion.

## Solution
We weren't actually losing data for the example suggestion audio until we go back to the larger Word Suggestion and update it. This PR updates the value paths used to get the updated example audio.