### PR TITLE
Return stats for non-admins

### DIFF
--- a/src/backend/routers/adminRouter.tsx
+++ b/src/backend/routers/adminRouter.tsx
@@ -1,10 +1,8 @@
 import express from 'express';
 import { getUser, getUsers, testGetUsers } from '../controllers/users';
-import { getUserStats, getUserMergeStats } from '../controllers/stats';
 import { onSubmitConstructedTermPoll } from '../controllers/polls';
 import authentication from '../middleware/authentication';
 import authorization from '../middleware/authorization';
-import cacheControl from '../middleware/cacheControl';
 import UserRoles from '../shared/constants/UserRoles';
 
 const adminRouter = express.Router();
@@ -12,8 +10,6 @@ const adminRouter = express.Router();
 adminRouter.use(authentication, authorization([UserRoles.ADMIN]));
 adminRouter.get('/users', process.env.NODE_ENV === 'test' ? testGetUsers : getUsers);
 adminRouter.get('/users/:uid', getUser);
-adminRouter.get('/stats/users/:uid/merge', getUserMergeStats);
-adminRouter.get('/stats/users/:uid', cacheControl, getUserStats);
 adminRouter.post('/twitter_poll', onSubmitConstructedTermPoll);
 
 export default adminRouter;

--- a/src/backend/routers/editorRouter.tsx
+++ b/src/backend/routers/editorRouter.tsx
@@ -20,7 +20,7 @@ import {
   putExampleSuggestion,
   postExampleSuggestion,
 } from '../controllers/exampleSuggestions';
-import { getStats, getUserStats } from '../controllers/stats';
+import { getStats, getUserStats, getUserMergeStats } from '../controllers/stats';
 import {
   deleteGenericWord,
   getGenericWords,
@@ -83,6 +83,8 @@ editorRouter.delete(
 
 editorRouter.get('/stats/full', getStats);
 editorRouter.get('/stats/user', cacheControl, getUserStats);
+editorRouter.get('/stats/users/:uid/merge', getUserMergeStats);
+editorRouter.get('/stats/users/:uid', cacheControl, getUserStats);
 
 editorRouter.put('/genericWords/:id', validId, putGenericWord);
 editorRouter.get('/genericWords', getGenericWords);


### PR DESCRIPTION
## Background
Non-admins were unable to log into the platform due to 403 network errors kicking them out. 

## Solution
The routes to request user stats were placed in the Admin Router which will return a 403 error if the requester is not an Admin (Merger or Editor). These routes were moved out from the Admin router to the Editor router