### PR TITLE
Handle non-existant dialects

### DIFF
--- a/src/backend/controllers/examples.ts
+++ b/src/backend/controllers/examples.ts
@@ -116,8 +116,8 @@ const createExampleFromSuggestion = (exampleSuggestion, mergedBy): Promise<Inter
       await updateDocumentMerge(exampleSuggestion, example.id, mergedBy);
       return example;
     })
-    .catch(() => {
-      throw new Error('An error occurred while saving the new example.');
+    .catch((error) => {
+      throw new Error(`An error occurred while saving the new example: ${error.message}`);
     })
 );
 

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -3,6 +3,7 @@ import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 import SuggestionSource from 'src/backend/shared/constants/SuggestionSource';
 import { toJSONPlugin, toObjectPlugin } from './plugins/index';
 import { uploadExamplePronunciation } from './plugins/pronunciationHooks';
+import { normalizeIgbo } from './plugins/normalizationHooks';
 
 const { Schema, Types } = mongoose;
 // @ts-ignore
@@ -33,5 +34,6 @@ const exampleSuggestionSchema = new Schema({
 
 toJSONPlugin(exampleSuggestionSchema);
 uploadExamplePronunciation(exampleSuggestionSchema);
+normalizeIgbo(exampleSuggestionSchema);
 
 export default mongoose.model('ExampleSuggestion', exampleSuggestionSchema);

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -4,6 +4,7 @@ import { every, has, partial } from 'lodash';
 import Dialects from '../shared/constants/Dialects';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
 import { uploadWordPronunciation } from './plugins/pronunciationHooks';
+import { normalizeHeadword } from './plugins/normalizationHooks';
 import * as Interfaces from '../controllers/utils/interfaces';
 import Tense from '../shared/constants/Tense';
 import WordClass from '../shared/constants/WordClass';
@@ -88,6 +89,7 @@ const wordSuggestionSchema = new Schema(
 
 toJSONPlugin(wordSuggestionSchema);
 uploadWordPronunciation(wordSuggestionSchema);
+normalizeHeadword(wordSuggestionSchema);
 
 wordSuggestionSchema.pre('findOneAndDelete', async function (next) {
   const wordSuggestionId = this.getQuery()._id;

--- a/src/backend/models/plugins/normalizationHooks.ts
+++ b/src/backend/models/plugins/normalizationHooks.ts
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+import * as Interfaces from 'src/backend/controllers/utils/interfaces';
+
+/* Decomposes the headword for improved search */
+export const normalizeHeadword = (schema: mongoose.Schema<Interfaces.WordSuggestion>): void => {
+  schema.pre('save', async function (next) {
+    this.word = (this.word || '').normalize('NFD');
+    next();
+    return this;
+  });
+};
+
+export const normalizeIgbo = (schema: mongoose.Schema<Interfaces.ExampleSuggestion>): void => {
+  schema.pre('save', async function (next) {
+    this.igbo = (this.igbo || '').normalize('NFD');
+    next();
+    return this;
+  });
+};

--- a/src/backend/models/plugins/pronunciationHooks.ts
+++ b/src/backend/models/plugins/pronunciationHooks.ts
@@ -47,6 +47,14 @@ export const uploadWordPronunciation = (schema: mongoose.Schema<Interfaces.WordS
          * the spaces need to be replaced with dashes (-) to avoid any unexpected escaped character edge cases.
          */
         const dialectalWord = kebabCase(rawDialectalWord);
+        // If the dialect doesn't exist in the document, the create a fallback object
+        if (!this.dialects[rawDialectalWord]) {
+          this.dialects[rawDialectalWord] = {
+            dialects: [],
+            variations: [],
+            pronunciation: '',
+          };
+        }
         if (isCypress && pronunciation) {
           // Going to mock creating and saving audio pronunciation while testing in Cypress (ref. !isCypress check)
           this.dialects[rawDialectalWord].pronunciation = (

--- a/src/shared/components/Filter/Filter.tsx
+++ b/src/shared/components/Filter/Filter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Box, InputGroup, InputLeftElement } from '@chakra-ui/react';
 import { Search2Icon } from '@chakra-ui/icons';
 import { useListFilterContext } from 'react-admin';
@@ -19,6 +19,10 @@ const CustomFilter = (props: FilterInterface): ReactElement => {
     : resource === Collection.WORDS || resource === Collection.WORD_SUGGESTIONS
       ? 'word'
       : 'name or email';
+  const [searchValue, setSearchValue] = useState(
+    typeof filterValues?.[filterKey] === 'string' ? filterValues[filterKey].normalize('NFD') : '',
+  );
+
   return (
     <Box className="flex items-end lg:ml-4">
       <InputGroup>
@@ -30,9 +34,13 @@ const CustomFilter = (props: FilterInterface): ReactElement => {
         <Input
           data-test="search-bar"
           className="h-10 w-full lg:w-64 bg-gray-300 px-4 rounded-lg border border-solid border-gray-400"
-          onChange={(e) => setFilters({ ...filterValues, [filterKey]: e.target.value }, null)}
+          onChange={(e) => {
+            const value = e.target.value.normalize('NFD');
+            setFilters({ ...filterValues, [filterKey]: value }, null);
+            setSearchValue(value);
+          }}
           placeholder={`Search by ${placeholderText}`}
-          defaultValue={typeof filterValues?.[filterKey] === 'string' ? filterValues[filterKey] : ''}
+          value={searchValue}
           style={{ paddingLeft: 34 }}
         />
       </InputGroup>


### PR DESCRIPTION
## Background
Editors have been unable to merge Word Suggestions into Words that have newly added dialectal objects. There is no data loss with this bug. Instead, it's preventing mergers, specifically, from completing their task of merging suggestions into words.

## Solution
When merging a Word Suggestion into a Word document, it's possible that the new Word Suggestion document has a newly created `dialects` object that doesn't exist on the `Word` document. Since the original Word document doesn't have the same `dialects` object, the process of moving the dialectal audio from the Suggestion to the Word document fails because of an `undefined at pronunciation` error. Creating a newly empty `dialects` object with the key of the new dialect addresses this bug.