### PR TITLE
Fix word status label and word flagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stop:docker": "docker-compose down",
     "use:staging": "firebase use staging",
     "use:prod": "firebase use default",
-    "kill:project": "fkill :3000 :5000 :5001 :5002 :9199 :5500 :8081 :8085 :4400 :4000 -fs",
+    "kill:project": "fkill :3000 :3030 :5000 :5001 :5002 :9199 :5500 :8081 :8085 :4400 :4000 -fs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome --headless",
     "pretest": "node_modules/.bin/firebase functions:config:set runtime.env=\"cypress\" && yarn functions:env",

--- a/src/shared/components/CompleteWordPreview/determineIsAudioAvailable.ts
+++ b/src/shared/components/CompleteWordPreview/determineIsAudioAvailable.ts
@@ -24,14 +24,10 @@ export default async (record: Word | Record, callback: (value: any) => void): Pr
               ...finalDialectsPronunciationPromises,
               axios.get(dialectValue?.pronunciation)
                 .then(() => ({
-                  dialect: {
-                    [dialectKey]: true,
-                  },
+                  [dialectKey]: true,
                 }))
                 .catch(() => ({
-                  dialect: {
-                    [dialectKey]: false,
-                  },
+                  [dialectKey]: false,
                 })),
             ];
           }

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
@@ -17,7 +17,7 @@ const SuggestedWords = ({ word, id: wordId } : { word: string, id: string }): Re
   const [suggestedWords, setSuggestedWords] = useState([]);
   useEffect(() => {
     (async () => {
-      const words = await getWords(word);
+      const words = await getWords((word || '').normalize('NFD').replace(/[\u0300-\u036f]/g, ''));
       setSuggestedWords(words);
     })();
   }, [word]);


### PR DESCRIPTION
## Fixing Word Status Label
The word status label, responsible for quickly telling editors if a word or example document is sufficient, insufficient, or complete, has been incorrectly labeling words as sufficient or even insufficient.

### Solution
The CORS configuration was outdated and was preventing requests coming from `https://editor.igboapi.com` from coming through. Users of the platform will need to clear out their browser cache to get these changes.

## Fixing Word Flagging
There were a number of headwords that were flagged for incorrect tone markings. Many of these flags were false positives and were generating noise for editors to be able to focus on word documents.

### Solution
Update the logic for checking if words are correctly tone-marked by following [these instructions](https://www.notion.so/Wrong-Flagging-56bdd0a03e88487cbd7c26ea1732aa99#9befbf8b32904413a293ac1bb038b208)