### PR TITLE
Delete word document on fail audio save and add more error handling + messaging

### DIFF
--- a/src/backend/utils/removeAccents.ts
+++ b/src/backend/utils/removeAccents.ts
@@ -1,0 +1,6 @@
+const accents = {
+  // Remove all diacritic marks including underdots
+  remove: (string = ''): string => string.normalize('NFD').replace(/[\u0300-\u036f]/g, ''),
+};
+
+export default accents;


### PR DESCRIPTION
## Background
There have been a few word suggestions that have been unable to merge. When merging is "unsuccessful" there's still a new word document that gets created despite it being labeled as Insufficient.

## Solution
We will be calling the `word.delete` function to delete the document when it's unsuccessfully in fully merging. Additionally, the bug in which audio was unable to get saved has been fixed as well by updating the way that we query and create new audio recording ids.