### PR TITLE
Fallback on permissions object

### DIFF
--- a/src/Core/Collections/Polls/PollList.tsx
+++ b/src/Core/Collections/Polls/PollList.tsx
@@ -4,6 +4,7 @@ import {
   List,
   Datagrid,
   TextField,
+  usePermissions,
 } from 'react-admin';
 import {
   Select,
@@ -14,7 +15,7 @@ import { Role } from 'src/shared/constants/auth-types';
 import Empty from '../../Empty';
 
 const PollList = (props: ListProps): ReactElement => {
-  const { permissions } = props;
+  const { permissions = {} } = usePermissions();
   return (
     <List
       {...props}

--- a/src/shared/components/actions/ListActions.tsx
+++ b/src/shared/components/actions/ListActions.tsx
@@ -17,7 +17,7 @@ import {
   sanitizeListRestProps,
   TopToolbar,
   useListContext,
-  useGetPermissions,
+  usePermissions,
 } from 'react-admin';
 import { Role } from 'src/shared/constants/auth-types';
 import queryString from 'query-string';
@@ -63,7 +63,6 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
     ...rest
   } = props;
   const { basePath, filterValues, setFilters } = useListContext();
-  const [permissions, setPermissions] = useState<any[]>([]);
   const [jumpToPage, setJumpToPage] = useState('');
   const [currentFilters, setCurrentFilters] = useState(
     getDefaultFilters(filterValues),
@@ -71,7 +70,7 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
   const [currentPartOfSpeechFilter, setCurrentPartOfSpeechFilter] = useState(
     getDefaultPartOfSpeechFilters(filterValues),
   );
-  const getPermissions = useGetPermissions();
+  const { permissions = {} } = usePermissions();
 
   const selectedFilters = currentFilters.length > 1 || (currentFilters.length === 1 && currentFilters[0] !== 'word');
 
@@ -83,10 +82,6 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
   const isPollResource = resource === Collections.POLLS;
   const isNotificationResource = resource === Collections.NOTIFICATIONS;
   const isUserResource = resource === Collections.USERS;
-
-  useEffect(() => {
-    getPermissions().then((permissions) => setPermissions(permissions));
-  }, []);
 
   /* Insert page value into input whenever window location changes */
   useEffect(() => {
@@ -308,7 +303,6 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
             </Menu>
           </Box>
         ) : null}
-        {/* @ts-expect-error permissions.role */}
         {isSuggestionResource || (isPollResource && permissions?.role === Role.ADMIN) ? (
           <CreateButton basePath={basePath} />
         ) : null}


### PR DESCRIPTION
## Background
The `permission` object was null causing an error blocking the entire platform from work to get thrown.