### PR TITLE
Stop overwriting dialects object

### DIFF
--- a/src/backend/controllers/words/index.ts
+++ b/src/backend/controllers/words/index.ts
@@ -170,7 +170,7 @@ export const createWord = async (
     definitions,
     variations,
     stems,
-    dialects,
+    dialects = {},
     isStandardIgbo,
     ...rest
   } = data;
@@ -184,7 +184,7 @@ export const createWord = async (
     attributes: {
       isStandardIgbo,
     },
-    dialects: {},
+    dialects,
     ...rest,
   };
 

--- a/src/backend/shared/constants/WordTags.ts
+++ b/src/backend/shared/constants/WordTags.ts
@@ -3,6 +3,10 @@ export default {
     value: 'agriculture',
     label: 'Agriculture',
   },
+  ARTS: {
+    value: 'arts',
+    label: 'Arts',
+  },
   BOTANY: {
     value: 'botany',
     label: 'Botany',

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -283,12 +283,10 @@ const WordShow = (props: ShowProps): ReactElement => {
             ) : null}
           </Box>
           <Box className="mb-10 lg:mb-0 space-y-3 flex flex-col items-start">
+            <CompleteWordPreview record={record} showFull={false} className="my-5 lg:my-0" />
             {resource !== Collection.WORDS && (
               <>
-                <Box className="flex flex-row justify-start items-center space-x-3">
-                  <SourceField record={record} source="source" />
-                  <CompleteWordPreview record={record} showFull={false} className="my-5 lg:my-0" />
-                </Box>
+                <SourceField record={record} source="source" />
                 <ShowDocumentStats
                   approvals={approvals}
                   denials={denials}

--- a/src/shared/components/views/shows/diffFields/DialectDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/DialectDiff.tsx
@@ -87,12 +87,16 @@ const DialectDiff = (
                     <li>{Dialects[dialect].label}</li>
                   ))}
                 </ul>
-                <Heading as="h2" size="sm" className="text-left">
-                  <chakra.span className="mr-2">Variations:</chakra.span>
-                  <chakra.span fontWeight="normal" className="mr-2">
-                    {variations.length ? variations.join(', ') : 'No variations'}
-                  </chakra.span>
-                </Heading>
+                {variations.length ? (
+                  <>
+                    <Heading as="h2" size="sm" className="text-left">
+                      <chakra.span className="mr-2">Variations:</chakra.span>
+                      <chakra.span fontWeight="normal" className="mr-2">
+                        {variations.length ? variations.join(', ') : 'No variations'}
+                      </chakra.span>
+                    </Heading>
+                  </>
+                ) : null}
                 <ReactAudioPlayer
                   src={pronunciation}
                   style={{ height: 40, width: 250 }}


### PR DESCRIPTION
## Background
The `dialects` object was mistakenly getting overwritten when creating fresh word suggestions.