### PR TITLE
Support the new Is Stem checkbox

### DIFF
--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -21,6 +21,7 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
       isStandardIgbo,
       isAccented,
       isComplete,
+      isStem,
     } = {},
     stems = [],
     relatedTerms = [],
@@ -52,7 +53,7 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
 
   const completeWordRequirements = compact([
     ...sufficientWordRequirements,
-    !stems?.length && 'A word stem is needed',
+    !isStem && !stems?.length && 'A word stem is needed',
     invalidRelatedTermsWordClasses.includes(wordClass) ? null : !relatedTerms?.length && 'A related term is needed',
     isVerb(wordClass) && !Object.entries(tenses).every(([key, value]) => (
       value && Object.values(Tense).find(({ value: tenseValue }) => key === tenseValue)

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -36,7 +36,7 @@ export default (word: Word | Record): boolean => !!(
   )
   && word.pronunciation
   && word.attributes.isStandardIgbo
-  && Array.isArray(word.stems) && word.stems.length
+  && ((Array.isArray(word.stems) && word.stems.length) || word.attributes.isStem)
   && (invalidRelatedTermsWordClasses.includes(word.wordClass)
     || (Array.isArray(word.relatedTerms) && word.relatedTerms.length))
   && isVerb(word.wordClass) && !Object.entries(word.tenses || {}).every(([key, value]) => (

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -47,13 +47,17 @@ export interface Word extends Document<any>, LeanDocument<any> {
     isStandardIgbo: boolean,
     isAccented: boolean,
     isComplete: boolean,
+    isSlang: boolean,
+    isConstructedTerm: boolean,
+    isBorrowedTerm: boolean,
+    isStem: boolean,
   }
   nsibidi: string,
   relatedTerms: string[],
   hypernyms: string[],
   hyponyms: string[],
   updatedAt: Date,
-  examples?: Example[],
+  examples?: (Example | ExampleSuggestion)[],
 };
 
 export interface Notification {
@@ -73,31 +77,16 @@ export interface Notification {
   created_at?: number | string,
 }
 
-export interface WordSuggestion extends Document<any>, LeanDocument<any> {
-  id: Types.ObjectId,
+export interface WordSuggestion extends Word {
   originalWordId?: Types.ObjectId,
-  word: string,
-  wordClass: string,
-  definitions: [string],
-  variations?: string[],
   userComments?: string,
   authorEmail?: string,
   authorId: string,
-  pronunciation: string,
-  attributes: {
-    isStandardIgbo: boolean,
-    isAccented: boolean,
-    isComplete: boolean,
-  }
   approvals?: string[],
   denials?: string[],
-  updatedAt: Date,
   merged?: Types.ObjectId,
   mergedBy?: string,
   examples?: ExampleSuggestion[],
-  dialects?: {
-    [key: string]: WordDialect,
-  },
   userInteractions?: string[],
   twitterPollUrl?: string,
 };

--- a/src/backend/shared/constants/WordAttributes.ts
+++ b/src/backend/shared/constants/WordAttributes.ts
@@ -24,4 +24,8 @@ export default {
     value: 'isBorrowedTerm',
     label: 'Is Borrowed Term',
   },
+  IS_STEM: {
+    value: 'isStem',
+    label: 'Is Stem',
+  },
 };

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -167,6 +167,31 @@ const HeadwordForm = ({
               />
             </Box>
           </Tooltip>
+          <Tooltip
+            label="Check this checkbox if this word is a word stem.
+            Checking this box will ignore the Word Stems area on this form."
+          >
+            <Box display="flex">
+              <Controller
+                render={({ onChange, value, ref }) => (
+                  <Checkbox
+                    onChange={(e) => onChange(e.target.checked)}
+                    isChecked={value}
+                    defaultIsChecked={record.attributes?.[WordAttributes.IS_STEM.value]}
+                    ref={ref}
+                    data-test={`${WordAttributes.IS_STEM.label}-checkbox`}
+                    size="lg"
+                  >
+                    <span className="font-bold">{WordAttributes.IS_STEM.label}</span>
+                  </Checkbox>
+                )}
+                defaultValue={record.attribute?.[WordAttributes.IS_STEM.value]
+                  || getValues().attributes?.[WordAttributes.IS_STEM.value]}
+                name={`attributes.${WordAttributes.IS_STEM.value}`}
+                control={control}
+              />
+            </Box>
+          </Tooltip>
         </Box>
       </Box>
       <Controller

--- a/src/shared/components/views/shows/WordShow/Attributes.tsx
+++ b/src/shared/components/views/shows/WordShow/Attributes.tsx
@@ -21,12 +21,14 @@ const Attributes = (
       isSlang,
       isConstructedTerm,
       isBorrowedTerm,
+      isStem,
     } = {
       isStandardIgbo: false,
       isAccented: false,
       isSlang: false,
       isConstructedTerm: false,
       isBorrowedTerm: false,
+      isStem: false,
     },
   } = record;
 
@@ -86,6 +88,17 @@ const Attributes = (
             path={`attributes.${WordAttributes.IS_BORROWED_TERM.value}`}
             diffRecord={diffRecord}
             fallbackValue={isBorrowedTerm}
+            renderNestedObject={(value) => <span>{String(value || false)}</span>}
+          />
+        </Box>
+        <Box>
+          <Heading fontSize="lg" className="text-xl text-gray-600">
+            {WordAttributes.IS_STEM.label}
+          </Heading>
+          <DiffField
+            path={`attributes.${WordAttributes.IS_STEM.value}`}
+            diffRecord={diffRecord}
+            fallbackValue={isStem}
             renderNestedObject={(value) => <span>{String(value || false)}</span>}
           />
         </Box>


### PR DESCRIPTION
## Background
This PR introduces the new Is Stem checkbox that allows editors to be able to check a word as a word stem. By checking the  Is Stem checkbox, the Word Stems section will be ignored while determining if the word is complete or not.

### Is Stem Checkbox
<img width="703" alt="Screen Shot 2022-10-14 at 9 14 43 AM" src="https://user-images.githubusercontent.com/16169291/195855963-9f7c3a04-aa1f-4173-ad4e-5fc8062e4826.png">
