### PR TITLE
Fallback when there is no next next letter

### DIFF
--- a/src/shared/utils/flagHeadword.ts
+++ b/src/shared/utils/flagHeadword.ts
@@ -132,13 +132,15 @@ const invalidToneMarkPairings = (
     }
     // If the current letter is a consonant, the next letter is a diacritic, and the letter after that is another
     // consonant, then we have a marked double consonant
+    const nextNextLetter = word[firstPointer + 2] || '';
     if (
       !vowels.includes(letter)
       && MorN.includes(letter)
       && !accents.includes(letter.charCodeAt(0))
       && accents.includes(nextLetter.charCodeAt(0))
-      && !vowels.includes(word[firstPointer + 2])
-      && !accents.includes(word[firstPointer + 2].charCodeAt(0))
+      && nextNextLetter
+      && !vowels.includes(nextNextLetter)
+      && !accents.includes(nextNextLetter.charCodeAt(0))
     ) {
       hasMarkedDoubleConsonant = true;
 


### PR DESCRIPTION
## Background
There's an edge case where the "next next" letter to be checked for a double consonant can be undefined, which throws an error breaking the word list view on page 97. This PR fixes that issue by falling back on an empty string to be able to call the string `charCodeAt` function.