### PR TITLE
Show that stems are unlinked

### DIFF
--- a/src/shared/components/ResolvedWord.tsx
+++ b/src/shared/components/ResolvedWord.tsx
@@ -15,7 +15,12 @@ const ResolvedWord = ({ wordId }: { wordId: string }): ReactElement => {
   useEffect(() => {
     (async () => {
       const word = await network(`/words/${wordId}`)
-        .then(({ json: word }) => word)
+        .then(({ json: word, status, body }) => {
+          if (status === 404) {
+            throw new Error(body.error);
+          }
+          return word;
+        })
         .catch(() => {
           setIsLinked(false);
           return { word: wordId };


### PR DESCRIPTION
## Background
Before, unlinked word stems would show an infinitely loading spinner. This PR fixes this PR to show that the stem has been unlinked by rendering the id.

## Screenshot
<img width="835" alt="Screen Shot 2022-10-16 at 9 25 07 PM" src="https://user-images.githubusercontent.com/16169291/196070164-722efcec-6a70-4c9e-baec-39dbe4efddab.png">
