### PR TITLE
Extend Tags and Dialects + Delete Polls + Improve Word Search

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -22,7 +22,7 @@ import {
   onUpdatePermissions,
 } from './src/backend/functions/users';
 import { onRequestDeleteDocument, onUpdateDocument } from './src/backend/functions/documents';
-import { onTwitterAuth, onTwitterCallback } from './src/backend/controllers/polls';
+import { onTwitterAuth, onTwitterCallback, onDeleteConstructedTermPoll } from './src/backend/controllers/polls';
 import {
   CORS_CONFIG,
   EXPRESS_PORT,
@@ -60,10 +60,11 @@ server.use(errorHandler);
 
 // Firebase Functions
 export const createUserAccount = onCreateUserAccount;
-export const deleteUser = onDeleteUser;
 export const assignUserToEditingGroup = onAssignUserToEditingGroup;
 export const updatePermissions = onUpdatePermissions;
 export const requestDeleteDocument = onRequestDeleteDocument;
+export const deleteConstructedTermPoll = onDeleteConstructedTermPoll;
+export const deleteUser = onDeleteUser;
 export const updateDocument = onUpdateDocument;
 
 /* Runs every Monday at 6AM PST */

--- a/src/Core/Collections/Polls/PollList.tsx
+++ b/src/Core/Collections/Polls/PollList.tsx
@@ -11,7 +11,7 @@ import {
   Pagination,
   ListActions,
 } from 'src/shared/components';
-import { Role } from 'src/shared/constants/auth-types';
+import { hasAdminPermissions } from 'src/shared/utils/permissions';
 import Empty from '../../Empty';
 
 const PollList = (props: ListProps): ReactElement => {
@@ -24,7 +24,7 @@ const PollList = (props: ListProps): ReactElement => {
       hasCreate
       bulkActionButtons={false}
       pagination={<Pagination />}
-      empty={<Empty showCreate={permissions.role === Role.ADMIN} />}
+      empty={<Empty showCreate={hasAdminPermissions(permissions, true)} />}
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Datagrid>

--- a/src/backend/controllers/utils/HandleQueriesType.ts
+++ b/src/backend/controllers/utils/HandleQueriesType.ts
@@ -1,6 +1,8 @@
+import { SearchRegExp } from 'src/backend/controllers/utils/interfaces';
+
 type HandledQueries = {
   searchWords: '',
-  regexKeyword: RegExp,
+  regexKeyword: SearchRegExp,
   page: number,
   sort: { key: string, direction: string } | null,
   skip: number,

--- a/src/backend/controllers/utils/index.ts
+++ b/src/backend/controllers/utils/index.ts
@@ -37,7 +37,7 @@ const constructRegexQuery = (
       ? createQueryRegex(queryValue)
       : queryValue
         ? createQueryRegex(queryValue)
-        : /^[.{0,}\n{0,}]/
+        : { wordReg: /^[.{0,}\n{0,}]/, definitionsReg: /^[.{0,}\n{0,}]/ }
   );
 };
 

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -204,3 +204,8 @@ export interface FormattedUser {
   lastSignInTime: string,
   creationTime: string,
 };
+
+export interface SearchRegExp {
+  wordReg: RegExp,
+  definitionsReg: RegExp,
+};

--- a/src/backend/controllers/words/index.ts
+++ b/src/backend/controllers/words/index.ts
@@ -28,7 +28,6 @@ import {
 import {
   searchIgboTextSearch,
   strictSearchIgboQuery,
-  searchEnglishRegexQuery,
   searchForAllWordsWithAudioPronunciations,
   searchForAllWordsWithIsStandardIgbo,
   searchForAssociatedSuggestions,
@@ -102,7 +101,7 @@ export const getWords = async (
       dialects,
       examples: true,
     };
-    let query: {
+    const query: {
       word?: any,
       text?: any
       definitions?: any
@@ -110,17 +109,6 @@ export const getWords = async (
       ? searchIgboTextSearch(searchWord, regexKeyword, filters)
       : strictSearchIgboQuery(searchWord);
     const words = await searchWordUsingIgbo({ query, ...searchQueries });
-    if (!words.length) {
-      query = searchEnglishRegexQuery(regexKeyword, filters);
-      const englishWords = await searchWordUsingEnglish({ query, ...searchQueries });
-      return await packageResponse({
-        res,
-        docs: englishWords,
-        model: Word,
-        query,
-        ...rest,
-      });
-    }
     return await packageResponse({
       res,
       docs: words,

--- a/src/backend/services/words.ts
+++ b/src/backend/services/words.ts
@@ -15,13 +15,16 @@ const doesVariationMatch = (termInformation, regexWord) => (
 );
 
 /* Provided a dictionary, find the corresponding terms */
-export const resultsFromDictionarySearch = (regexWord, word, dictionary) => (
+export const resultsFromDictionarySearch = (
+  searchRegex: RegExp,
+  dictionary: { [key: string]: any },
+) => (
   keys(dictionary).reduce((matchedResults, key) => {
     const currentMatchedResults = { ...matchedResults };
     const termInformation = dictionary[key];
     const trimmedKey = removePrefix(key);
-    const isTrimmedKeyAndWordSameLength = trimmedKey.match(regexWord);
-    if (isTrimmedKeyAndWordSameLength || doesVariationMatch(termInformation, regexWord)) {
+    const isTrimmedKeyAndWordSameLength = trimmedKey.match(searchRegex);
+    if (isTrimmedKeyAndWordSameLength || doesVariationMatch(termInformation, searchRegex)) {
       currentMatchedResults[key] = termInformation;
     }
     return currentMatchedResults;

--- a/src/backend/shared/constants/Dialects.ts
+++ b/src/backend/shared/constants/Dialects.ts
@@ -39,6 +39,11 @@ export default {
     value: 'EZE',
     label: 'Ezeagu',
   },
+  ISU: {
+    code: 'ibo-isu',
+    value: 'ISU',
+    label: 'Isuama',
+  },
   MBA: {
     code: 'ibo-mba',
     value: 'MBA',
@@ -97,7 +102,7 @@ export default {
   OWE: {
     code: 'ibo-owe',
     value: 'OWE',
-    label: 'Owere; Isuama',
+    label: 'Owere',
   },
   OBO: {
     code: 'ibo-obo',

--- a/src/backend/shared/constants/WordTags.ts
+++ b/src/backend/shared/constants/WordTags.ts
@@ -19,9 +19,17 @@ export default {
     value: 'education',
     label: 'Education',
   },
+  FASHION: {
+    value: 'fashion',
+    label: 'Fashion',
+  },
   FOOD: {
     value: 'food',
     label: 'Food',
+  },
+  GEOGRAPHY: {
+    value: 'geography',
+    label: 'Geography',
   },
   KINSHIP: {
     value: 'kinship',

--- a/src/backend/shared/utils/createQueryRegex.ts
+++ b/src/backend/shared/utils/createQueryRegex.ts
@@ -1,5 +1,8 @@
+import { SearchRegExp } from 'src/backend/controllers/utils/interfaces';
 import createRegExp from './createRegExp';
 
 /* Either creates a regex pattern for provided searchWord
 or fallbacks to matching every word */
-export default (searchWord) => (!searchWord ? /./ : createRegExp(searchWord));
+export default (searchWord: string): SearchRegExp => (
+  !searchWord ? { wordReg: /./, definitionsReg: /./ } : createRegExp(searchWord)
+);

--- a/src/backend/shared/utils/createRegExp.ts
+++ b/src/backend/shared/utils/createRegExp.ts
@@ -1,3 +1,4 @@
+import { SearchRegExp } from 'src/backend/controllers/utils/interfaces';
 import diacriticCodes from '../constants/diacriticCodes';
 
 const getIsLastLetterDuplicated = ({ stringArray, index, letter }) => {
@@ -6,7 +7,7 @@ const getIsLastLetterDuplicated = ({ stringArray, index, letter }) => {
   return isLastLetterDuplicated;
 };
 
-export default (searchWord: string, hardMatch = false): RegExp => {
+export default (searchWord: string, hardMatch = false): SearchRegExp => {
   /* Front and back ensure the regexp will match with whole words */
   const front = '(?:^|[^a-zA-Z\u00c0-\u1ee5])';
   const back = '(?![a-zA-Z\u00c0-\u1ee5]+|,|s[a-zA-Z\u00c0-\u1ee5]+)';
@@ -41,10 +42,19 @@ export default (searchWord: string, hardMatch = false): RegExp => {
   const startWordBoundary = '(\\W|^)';
   const endWordBoundary = '(\\W|$)';
   /* Hard match checks to see if the searchWord is the beginning and end of the line, triggered by strict query */
-  return new RegExp(!hardMatch
+  const wordReg = new RegExp(!hardMatch
     ? `${startWordBoundary}(${front}${regexWordStringNormalizedNFD})${endWordBoundary}`
     + `|${startWordBoundary}(${front}${regexWordStringNormalizedNFC})${endWordBoundary}`
     : `${startWordBoundary}(^${front}${regexWordStringNormalizedNFD}${back}$)${endWordBoundary}`
     + `|${startWordBoundary}(^${front}$${regexWordStringNormalizedNFC}${back}$)${endWordBoundary}`,
   'i');
+
+  const definitionsReg = new RegExp(!hardMatch
+    ? `${startWordBoundary}(${regexWordStringNormalizedNFD})${endWordBoundary}`
+    + `|${startWordBoundary}(${regexWordStringNormalizedNFC})${endWordBoundary}`
+    : `${startWordBoundary}(^${regexWordStringNormalizedNFD}$)${endWordBoundary}`
+    + `|${startWordBoundary}(^$${regexWordStringNormalizedNFC}$)${endWordBoundary}`,
+  'i');
+
+  return { wordReg, definitionsReg };
 };

--- a/src/shared/components/Select/Select.tsx
+++ b/src/shared/components/Select/Select.tsx
@@ -234,6 +234,16 @@ const Select = ({
         window.location.href = `${TWITTER_APP_URL}/${get(record, 'id')}`;
       },
     },
+    {
+      value: 'deletePoll',
+      label: (() => (
+        <span className="text-red-500">
+          <DeleteIcon className="mr-2" />
+          Delete Poll
+        </span>
+      ))(),
+      onSelect: () => setAction(actionsMap[ActionTypes.DELETE_POLL]),
+    },
   ];
 
   const options = resource === Collection.USERS

--- a/src/shared/constants/ActionTypes.ts
+++ b/src/shared/constants/ActionTypes.ts
@@ -18,6 +18,7 @@ enum ActionTypes {
   ASSIGN_EDITING_GROUP = 'AssignEditingGroup',
   CONVERT = 'Convert',
   REQUEST_DELETE = 'Send Delete Request',
+  DELETE_POLL = 'Delete Poll',
   DELETE_USER = 'DeleteUser',
 };
 

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -28,8 +28,9 @@ const prepareRecord = (record) => {
 };
 
 const handleUpdatePermissions = useCallable<string, EmptyResponse>('updatePermissions');
-const handleDeleteUser = useCallable<any, EmptyResponse>('deleteUser');
 const handleRequestDeleteDocument = useCallable<any, EmptyResponse>('requestDeleteDocument');
+const handleDeleteConstructedTermPoll = useCallable<any, EmptyResponse>('deleteConstructedTermPoll');
+const handleDeleteUser = useCallable<any, EmptyResponse>('deleteUser');
 export const handleUpdateDocument = useCallable<any, EmptyResponse>('updateDocument');
 
 export default {
@@ -154,6 +155,19 @@ export default {
       handleRequestDeleteDocument({ note, resource, record })
     ),
     successMessage: 'Your deletion request has been sent to admins 📨',
+  },
+  [ActionTypes.DELETE_POLL]: {
+    type: 'Delete Poll',
+    title: 'Delete Poll',
+    content: 'Deleting a poll is an irreversible action that will delete the poll '
+     + 'in the Igbo API Editor Platform along with associated tweets and Slack bot posts',
+    executeAction: (
+      { pollId }:
+      { pollId: string },
+    ) : Promise<any> => (
+      handleDeleteConstructedTermPoll({ pollId })
+    ),
+    successMessage: 'You have deleted the poll',
   },
   [ActionTypes.DELETE_USER]: {
     type: 'DeleteUser',

--- a/src/tests/shared/commands.ts
+++ b/src/tests/shared/commands.ts
@@ -256,9 +256,9 @@ export const sendEmailJob = () => (
 );
 
 /* Uses data in __mocks__ folder */
-export const searchMockedTerm = (term) => {
-  const regexTerm = createRegExp(term);
-  return resultsFromDictionarySearch(regexTerm, term, mockedData);
+export const searchMockedTerm = (term: string) => {
+  const { wordReg: searchRegex } = createRegExp(term);
+  return resultsFromDictionarySearch(searchRegex, mockedData);
 };
 
 export const sendSendGridEmail = (message) => sendEmail(message);


### PR DESCRIPTION
## Extend Tags and Dialects
New word tags and dialects have been added to the platform

## Delete Polls
There's a new Delete Poll option that performs full cleanup on deleting a Poll from Firestore, the Tweets on Twitter, and the Slack message in Slack.

## Improved Word Search
Editors were noticing that they couldn't search for many words by using English terms for definitions. This PR improves the word search to create custom regular expressions for both headwords (Igbo) and definitions (English)