### PR TITLE
Preserve audio for example sentences while editing

### DIFF
--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -329,6 +329,7 @@ const WordEditForm = ({
         getValues={getValues}
         setValue={setValue}
         control={control}
+        errors={errors}
       />
       <VariationsForm
         variations={variations}

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
@@ -113,7 +113,14 @@ const Example = ({
               <AudioRecorder
                 path={`examples[${index}]`}
                 getFormValues={getValues}
-                setPronunciation={setValue}
+                setPronunciation={(path, value) => {
+                  // Setting the react-hook-form value
+                  setValue(path, value);
+                  const updatedExamples = [...examples];
+                  updatedExamples[index].pronunciation = value;
+                  // Setting the local WordEditForm value
+                  setExamples(updatedExamples);
+                }}
                 record={example}
                 originalRecord={originalRecord}
                 formTitle="Igbo Sentence Recording"

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -183,14 +183,14 @@ const WordShow = (props: ShowProps): ReactElement => {
                 fallbackValue={pronunciation ? (
                   <ReactAudioPlayer
                     src={pronunciation}
-                    style={{ height: '40', width: 250 }}
+                    style={{ marginTop: 15, height: '40', width: 250 }}
                     controls
                   />
                 ) : <span>No audio pronunciation</span>}
                 renderNestedObject={() => (
                   <ReactAudioPlayer
                     src={pronunciation}
-                    style={{ height: '40', width: 250 }}
+                    style={{ marginTop: 15, height: '40', width: 250 }}
                     controls
                   />
                 )}

--- a/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
+++ b/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
@@ -29,7 +29,7 @@ const ArrayDiffField = (
     <Box
       // eslint-disable-next-line react/no-array-index-key
       key={`array-diff-field-${recordFieldSingular}-${index}`}
-      className="flex flex-row items-center space-x-2"
+      className="flex flex-row items-start space-x-2 mt-4"
       data-test={`${recordFieldSingular}-${index}`}
     >
       <h2 className="text-2xl text-gray-600">{`${index + 1}. `}</h2>

--- a/src/shared/components/views/shows/diffFields/ExampleDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/ExampleDiff.tsx
@@ -15,7 +15,7 @@ const ExampleDiff = ({
   diffRecord: Record,
   resource: string,
 }): ReactElement => (
-  <Box className="flex flex-row items-end space-x-4">
+  <Box className="flex flex-col space-y-2">
     <Box className="flex flex-col">
       <DiffField
         path={`examples.${index}.igbo`}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -25,6 +25,9 @@ html {
   font-family: 'Akagu', 'sans-serif' !important;
 }
 
+.react-audio-player {
+  height: 40px;
+}
 
 body {
   font-size: 16px !important;


### PR DESCRIPTION
## Background
There has been a bug on the platform where if the following steps are followed, the audio for an example sentence is cleared out:
1. Type in text for the Igbo or English field for an Example Sentence
2. Record audio for that Example Sentence
3. Attempt to add a new Spelling Variation or Related Term
4. Witness the Example Sentence audio clear out

## Solution
This issue was caused by the fact that the `WordEditForm`'s internal state was stale, and wasn't updating whenever a new example audio was getting recorded. This PR will now update the `react-hook-form`'s internal state and `WordEditForm`'s internal state

## Styling
I applied a bit of styling to change the height of the audio player and then updated the composition for the `WordEditForm`