### PR TITLE
Io/calculate sufficient tags

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -29,6 +29,7 @@
     "firebase-admin": "10.3.0",
     "firebase-functions": "3.19.0",
     "google-gax": "^2.9.2",
+    "joi": "^17.7.0",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.20",
     "moment": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "firebase-tools": "11.1.0",
     "framer-motion": "^4",
     "functions": "^1.0.9",
+    "joi": "^17.7.0",
     "kill-port": "^1.6.1",
     "lodash": "^4.17.20",
     "mic-recorder-to-mp3": "^2.2.2",

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -116,7 +116,7 @@ Promise<{ sufficientWordsCount: number, completeWordsCount: number, dialectalVar
   const { sufficientWordsCount, completeWordsCount, dialectalVariationsCount } = await countWords(words);
   await updateStat({ statType: StatTypes.SUFFICIENT_WORDS, value: sufficientWordsCount });
   await updateStat({ statType: StatTypes.COMPLETE_WORDS, value: completeWordsCount });
-  await updateStat({ statType: StatTypes.DIALECTAL_VARIATONS, value: dialectalVariationsCount });
+  await updateStat({ statType: StatTypes.DIALECTAL_VARIATIONS, value: dialectalVariationsCount });
 
   return { sufficientWordsCount, completeWordsCount, dialectalVariationsCount };
 };

--- a/src/backend/shared/constants/StatTypes.ts
+++ b/src/backend/shared/constants/StatTypes.ts
@@ -3,7 +3,7 @@ export default {
   COMPLETE_WORDS: 'complete_words',
   SUFFICIENT_EXAMPLES: 'sufficient_examples',
   COMPLETE_EXAMPLES: 'complete_examples',
-  DIALECTAL_VARIATONS: 'dialectal_variations',
+  DIALECTAL_VARIATIONS: 'dialectal_variations',
   HEADWORD_AUDIO_PRONUNCIATIONS: 'headword_audio_pronunciations',
   STANDARD_IGBO: 'standard_igbo',
   NSIBIDI_WORDS: 'nsibidi_words',

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
@@ -65,7 +65,6 @@ const SuggestedWords = ({ word, id: wordId } : { word: string, id: string }): Re
             {filteredWords.map(({
               word,
               nsibidi,
-              wordClass,
               definitions,
               id,
             }) => (
@@ -94,10 +93,11 @@ const SuggestedWords = ({ word, id: wordId } : { word: string, id: string }): Re
                       <Text fontWeight="bold" mr={2}>{word}</Text>
                       {nsibidi ? <Text color="green.500" fontWeight="bold" className="akagu">{nsibidi}</Text> : null}
                     </Box>
-                    <Text fontStyle="italic">{WordClass[wordClass]?.label || wordClass}</Text>
                     <Box>
                       {definitions.map(({ definitions, wordClass, _id }, index) => (
-                        <Text key={_id}>{`${index + 1}. (${wordClass}) ${definitions[0]}`}</Text>
+                        <Text key={_id}>
+                          {`${index + 1}. (${WordClass[wordClass]?.label || wordClass}) ${definitions[0]}`}
+                        </Text>
                       ))}
                     </Box>
                   </PopoverContent>


### PR DESCRIPTION
## Background
This PR accomplishes two things:
* Fixes the Sufficient tag so that it works with multiple parts of speech and definitions
* Fixes the Cloud Function that calculates the total number of documents within the platform