### PR TITLE
Io/calculate sufficient tags

### DIFF
--- a/src/__tests__/__mocks__/documentData.ts
+++ b/src/__tests__/__mocks__/documentData.ts
@@ -11,7 +11,7 @@ export const wordSuggestionData = {
     wordClass: WordClass.NNC.value,
     definitions: ['first'],
   }],
-  dialects: {},
+  dialects: [],
 };
 
 export const wordSuggestionApprovedData = {

--- a/src/__tests__/words.test.ts
+++ b/src/__tests__/words.test.ts
@@ -228,8 +228,12 @@ describe('MongoDB Words', () => {
       expect(isEqual(definitions, uniqBy(definitions, (definition) => definition))).toEqual(true);
       expect(isEqual(variations, uniqBy(variations, (variation) => variation))).toEqual(true);
       expect(isEqual(stems, uniqBy(stems, (stem) => stem))).toEqual(true);
-      firstWord.definitions[0].definitions.forEach((definition) => {
-        expect(definitions.includes(definition)).toBeTruthy();
+      combinedWordRes.body.definitions.forEach((definitionGroup) => {
+        if (definitionGroup.wordClass === firstWord.definitions[0].wordClass) {
+          firstWord.definitions[0].definitions.forEach((definition) => {
+            expect(definitionGroup.definitions.includes(definition)).toBeTruthy();
+          });
+        }
       });
       wordWithNullStems.definitions[0].definitions.forEach((definition) => {
         expect(definitions.includes(definition)).toBeTruthy();

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -41,24 +41,24 @@ const updateStat = async ({ statType, authorId = 'SYSTEM', value }) => {
 /* Returns all the WordSuggestions with Headword audio pronunciations */
 const calculateTotalHeadwordsWithAudioPronunciations = async ():
 Promise<{ audioPronunciationWords: number } | void> => {
-  const audioPronunciationWords = await Word
-    .estimatedDocumentCount(searchForAllWordsWithAudioPronunciations());
+  const audioPronunciationWords = await Word.find(searchForAllWordsWithAudioPronunciations())
+    .estimatedDocumentCount();
   await updateStat({ statType: StatTypes.HEADWORD_AUDIO_PRONUNCIATIONS, value: audioPronunciationWords });
   return { audioPronunciationWords };
 };
 
 /* Returns all the Words that's in Standard Igbo */
 const calculateTotalWordsInStandardIgbo = async (): Promise<{ isStandardIgboWords: number } | void> => {
-  const isStandardIgboWords = await Word
-    .estimatedDocumentCount(searchForAllWordsWithIsStandardIgbo());
+  const isStandardIgboWords = await Word.find(searchForAllWordsWithIsStandardIgbo())
+    .estimatedDocumentCount();
   await updateStat({ statType: StatTypes.STANDARD_IGBO, value: isStandardIgboWords });
   return { isStandardIgboWords };
 };
 
 /* Returns all Words with Nsịbịdị */
 const calculateTotalWordsWithNsibidi = async () : Promise<{ wordsWithNsibidi: number } | void> => {
-  const wordsWithNsibidi = await Word
-    .estimatedDocumentCount(searchForAllWordsWithNsibidi());
+  const wordsWithNsibidi = await Word.find(searchForAllWordsWithNsibidi())
+    .estimatedDocumentCount();
   await updateStat({ statType: StatTypes.NSIBIDI_WORDS, value: wordsWithNsibidi });
 
   return { wordsWithNsibidi };
@@ -66,8 +66,8 @@ const calculateTotalWordsWithNsibidi = async () : Promise<{ wordsWithNsibidi: nu
 
 /* Returns all Word Suggestions with Nsịbịdị */
 const calculateTotalWordSuggestionsWithNsibidi = async () : Promise<{ wordSuggestionsWithNsibidi: number } | void> => {
-  const wordSuggestionsWithNsibidi = await WordSuggestion
-    .estimatedDocumentCount({ ...searchForAllWordsWithNsibidi(), merged: null });
+  const wordSuggestionsWithNsibidi = await WordSuggestion.find({ ...searchForAllWordsWithNsibidi(), merged: null })
+    .estimatedDocumentCount();
   await updateStat({ statType: StatTypes.NSIBIDI_WORD_SUGGESTIONS, value: wordSuggestionsWithNsibidi });
   return { wordSuggestionsWithNsibidi };
 };

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -71,9 +71,9 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
       && examples.some(({ pronunciation }) => !pronunciation)
       && 'All example sentences need pronunciations'
     ),
-    Object.entries(dialects) && !Object.entries(dialects).length && 'A dialectal variation is needed',
-    (Object.entries(dialects)
-      && Object.values(dialects).some(({ dialects, pronunciation }) => !dialects?.length || !pronunciation)
+    Array.isArray(dialects) && !dialects.length && 'A dialectal variation is needed',
+    (Array.isArray(dialects)
+      && dialects.some(({ dialects, pronunciation }) => !dialects?.length || !pronunciation)
       && 'All dialect variations need all fields filled'
     ),
   ]);

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -28,8 +28,8 @@ export default (word: Word | Record): boolean => !!(
   )
   && (
     word.dialects && typeof word.dialects === 'object'
-    && Object.entries(word.dialects)
-    && Object.entries(word.dialects).length
+    && Array.isArray(word.dialects)
+    && word.dialects.length
     && Object.values(word.dialects).every(({ dialects, pronunciation }) => (
       dialects.length && pronunciation
     ))

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -32,6 +32,9 @@ export interface WordDialect {
   dialects: string[],
   variations: string[],
   pronunciation: string,
+  word: string,
+  _id?: Types.ObjectId,
+  id?: string,
 }
 
 export interface DefinitionSchema {
@@ -44,9 +47,7 @@ export interface Word extends Document<any>, LeanDocument<any> {
   id: Types.ObjectId,
   word: string,
   definitions: [DefinitionSchema],
-  dialects: {
-    [key: string]: WordDialect,
-  },
+  dialects: WordDialect[],
   pronunciation: string,
   variations: string[],
   normalized: string,

--- a/src/backend/middleware/validateWordBody.ts
+++ b/src/backend/middleware/validateWordBody.ts
@@ -32,13 +32,12 @@ export const wordDataSchema = Joi.object().keys({
   stems: Joi.array().min(0).items(Joi.string()).allow(null)
     .optional(),
   relatedTerms: Joi.array().min(0).items(Joi.string()).optional(),
-  dialects: Joi.object().keys({
-    dialectalWord: Joi.object({
-      variations: Joi.array().min(0).items(Joi.string()).required(),
-      dialects: Joi.array().min(0).items(Joi.string().valid(...Object.keys(Dialects))).required(),
-      pronunciation: Joi.string().allow('').required(),
-    }),
-  }).unknown(true),
+  dialects: Joi.array().min(0).items(Joi.object().keys({
+    variations: Joi.array().min(0).items(Joi.string()).optional(),
+    dialects: Joi.array().min(0).items(Joi.string().valid(...Object.keys(Dialects))).required(),
+    pronunciation: Joi.string().allow('').required(),
+    word: Joi.string().allow('').required(),
+  })),
   tags: Joi.array().items(Joi.string().valid(...Object.values(WordTags).map(({ value }) => value))),
   tenses: Joi.object().keys(Object.values(Tense).reduce((finalSchema, { value }) => ({
     ...finalSchema,

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -1,15 +1,11 @@
 import mongoose from 'mongoose';
-import { every, has, partial } from 'lodash';
+import { every } from 'lodash';
 import Dialects from '../shared/constants/Dialects';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
 import Tense from '../shared/constants/Tense';
 import WordClass from '../shared/constants/WordClass';
 import WordAttributes from '../shared/constants/WordAttributes';
 import WordTags from '../shared/constants/WordTags';
-import * as Interfaces from '../controllers/utils/interfaces';
-
-const REQUIRED_DIALECT_KEYS = ['variations', 'dialects', 'pronunciation'];
-const REQUIRED_DIALECT_CONSTANT_KEYS = ['code', 'value', 'label'];
 
 const { Schema, Types } = mongoose;
 
@@ -23,6 +19,13 @@ const definitionSchema = new Schema({
   definitions: { type: [{ type: String }], default: [] },
 }, { toObject: toObjectPlugin });
 
+const dialectSchema = new Schema({
+  word: { type: String, required: true },
+  variations: { type: [{ type: String }], default: [] },
+  dialects: { type: [{ type: String }], validate: (v) => every(v, (dialect) => Dialects[dialect].value), default: [] },
+  pronunciation: { type: String, default: '' },
+}, { toObject: toObjectPlugin });
+
 const wordSchema = new Schema({
   word: { type: String, required: true },
   definitions: [{
@@ -32,24 +35,7 @@ const wordSchema = new Schema({
       && definitions.length > 0
     ),
   }],
-  dialects: {
-    type: Object,
-    validate: (v) => {
-      const dialectValues = Object.values(v) as Interfaces.WordDialect[];
-      return dialectValues.every((dialectValue) => (
-        every(REQUIRED_DIALECT_KEYS, partial(has, dialectValue))
-        && every(dialectValue.dialects, (dialect) => (
-          every(REQUIRED_DIALECT_CONSTANT_KEYS, partial(has, Dialects[dialect]))
-        ))
-        && Array.isArray(dialectValue.dialects)
-        && every(dialectValue.dialects, (dialect) => Dialects[dialect].value)
-        && typeof dialectValue.pronunciation === 'string'
-        && Array.isArray(dialectValue.variations)
-      ));
-    },
-    required: false,
-    default: {},
-  },
+  dialects: { type: [dialectSchema] },
   tags: {
     type: [String],
     default: [],

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -35,7 +35,7 @@ const wordSchema = new Schema({
       && definitions.length > 0
     ),
   }],
-  dialects: { type: [dialectSchema] },
+  dialects: { type: [dialectSchema], default: [] },
   tags: {
     type: [String],
     default: [],

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -41,7 +41,7 @@ const wordSuggestionSchema = new Schema(
         && definitions.length > 0
       ),
     }],
-    dialects: { type: [dialectSchema] },
+    dialects: { type: [dialectSchema], default: [] },
     tags: {
       type: [String],
       default: [],

--- a/src/backend/models/plugins/pronunciationHooks.ts
+++ b/src/backend/models/plugins/pronunciationHooks.ts
@@ -45,13 +45,12 @@ export const uploadWordPronunciation = (schema: mongoose.Schema<Interfaces.WordS
         /**
          * Steps through each dialect and checks to see if it has audio data to be saved in AWS
          */
-        await Promise.all(Object.entries(this.dialects).map(async ([rawDialectalWord, { pronunciation }]) => {
+        await Promise.all(this.dialects.map(async ({ pronunciation, word: rawDialectalWord, _id: dialectalWordId }) => {
           /**
            * Since dialectal words, which include spaces are used as the unique keys for these audio files,
            * the spaces need to be replaced with dashes (-) to avoid any unexpected escaped character edge cases.
            */
           const dialectalWord = removeAccents.remove(kebabCase(rawDialectalWord));
-          // If the dialect doesn't exist in the document, the create a fallback object
           if (!this.dialects[rawDialectalWord]) {
             this.dialects[rawDialectalWord] = {
               dialects: [],
@@ -62,34 +61,41 @@ export const uploadWordPronunciation = (schema: mongoose.Schema<Interfaces.WordS
           if (isCypress && pronunciation) {
             // Going to mock creating and saving audio pronunciation while testing in Cypress (ref. !isCypress check)
             this.dialects[rawDialectalWord].pronunciation = (
-              await createAudioPronunciation(`${id}-${dialectalWord}`, pronunciation)
+              await createAudioPronunciation(`${id}-${dialectalWordId}`, pronunciation)
             );
           } else if (pronunciation.startsWith('data:audio/mp3')) {
             this.dialects[rawDialectalWord].pronunciation = (
-              await createAudioPronunciation(`${id}-${dialectalWord}`, pronunciation)
+              await createAudioPronunciation(`${id}-${dialectalWordId}`, pronunciation)
             );
           } else if (!isCypress && isDevelopment && this.dialects[rawDialectalWord].pronunciation) {
             this.dialects[rawDialectalWord].pronunciation = (
-              await createAudioPronunciation(`${id}-${dialectalWord}`, pronunciation)
+              await createAudioPronunciation(`${id}-${dialectalWordId}`, pronunciation)
             );
-          } else if (pronunciation.startsWith('https://') && !pronunciation.includes(`${id}-${dialectalWord}`)) {
+          } else if (pronunciation.startsWith('https://') && !pronunciation.includes(`${id}-${dialectalWordId}`)) {
             // If the pronunciation data in the current dialect is a uri, we will duplicate the uri
             // so that the new uri will only be associated with the suggestion
             const isMp3 = pronunciation.includes('mp3');
             const oldId: string = last(compact(pronunciation.split(/.mp3|.webm/).join('').split('/')));
-            const newId = `${id}-${dialectalWord}`;
+            const newWordId = `${id}-${dialectalWord}`;
+            const newId = `${id}-${dialectalWordId}`;
 
             /* If we are saving a new word suggestion, then we want to copy all the original audio files */
             this.dialects[rawDialectalWord].pronunciation = await (this.isNew
-              ? copyAudioPronunciation(oldId, newId, isMp3)
-              : renameAudioPronunciation(oldId, newId, isMp3));
+              ? (() => {
+                copyAudioPronunciation(oldId, newId, isMp3);
+                copyAudioPronunciation(oldId, newWordId, isMp3);
+              })()
+              : (() => {
+                renameAudioPronunciation(oldId, newId, isMp3);
+                renameAudioPronunciation(oldId, newWordId, isMp3);
+              })());
           }
         }));
       }
       next();
       return this;
     } catch (err) {
-      console.log('Error caught in pre save Word shcema hook', err.message);
+      console.log('Error caught in pre save Word schema hook', err.message);
       this.invalidate('pronunciation', err.message);
       return null;
     }

--- a/src/shared/components/CompleteWordPreview/determineIsAudioAvailable.ts
+++ b/src/shared/components/CompleteWordPreview/determineIsAudioAvailable.ts
@@ -14,7 +14,7 @@ export default async (record: Word | Record, callback: (value: any) => void): Pr
       ];
     }
     if (key === 'dialects') {
-      const dialectsPronunciationsPromises = Object.entries(record.dialects)
+      const dialectsPronunciationsPromises = record.dialects
         .reduce((
           finalDialectsPronunciationPromises: any[],
           [dialectKey, dialectValue] : [string, { pronunciation: string }],

--- a/src/shared/components/WordPanel.tsx
+++ b/src/shared/components/WordPanel.tsx
@@ -59,21 +59,28 @@ const WordPanel = ({ record }: { record?: Record }): ReactElement => (
           {get(record, 'nsibidi') || 'No Nsịbịdị'}
         </Text>
       </Box>
-      <Box>
-        <Text fontSize="xl" className="font-bold">Part of Speech</Text>
-        <Text>{get(WordClass[record.wordClass], 'label')}</Text>
-      </Box>
     </Box>
     <Box className="flex flex-row items-start space-x-8">
       <Box className="space-y-2">
         <Box>
-          <Text fontSize="lg" className="font-bold">Definitions</Text>
-          {get(record, 'definitions.length') ? record.definitions.map((definition, index) => (
-            <Box key={definition} className="flex flex-row space-x-1">
-              <Text className="font-bold text-gray-600">{`${index + 1}.`}</Text>
-              <Text>{definition}</Text>
-            </Box>
-          )) : <Text className="text-gray-500 italic">No definitions</Text>}
+          <Text fontSize="xl" className="font-bold">Definition Groups</Text>
+          <Box>
+            {(get(record, 'definitions') || []).map(({ wordClass, definitions, id }) => (
+              <Box key={id}>
+                <Box>
+                  <Text fontSize="lg" className="font-bold">Part of Speech</Text>
+                  <Text>{get(WordClass[wordClass], 'label')}</Text>
+                </Box>
+                <Text fontSize="lg" className="font-bold">Definitions</Text>
+                {definitions?.length ? definitions.map((definition, index) => (
+                  <Box key={definition} className="flex flex-row space-x-1">
+                    <Text className="font-bold text-gray-600">{`${index + 1}.`}</Text>
+                    <Text>{definition}</Text>
+                  </Box>
+                )) : <Text className="text-gray-500 italic">No definitions</Text>}
+              </Box>
+            ))}
+          </Box>
         </Box>
         <Box>
           <Text fontSize="lg" className="font-bold">Spelling Variations</Text>
@@ -106,15 +113,14 @@ const WordPanel = ({ record }: { record?: Record }): ReactElement => (
       <Box>
         <Box>
           <Text fontSize="lg" className="font-bold">Dialectal Variations</Text>
-          {Object.entries(get(record, 'dialects') || {}).length ? (
-            // @ts-expect-error
-            Object.entries(record.dialects).map(([dialect, { dialects }], index) => (
-              <Box className="space-y-1">
-                <Box key={dialect} className="flex flex-row space-x-1">
+          {(get(record, 'dialects') || []).length ? (
+            get(record, 'dialects').map(({ word, dialects, _id }, index) => (
+              <Box key={_id} className="space-y-1">
+                <Box className="flex flex-row space-x-1">
                   <Text className="font-bold text-gray-600">{`${index + 1}.`}</Text>
-                  <Text>{dialect}</Text>
+                  <Text>{word}</Text>
                 </Box>
-                <AudioRecordingPreview record={record} audioPath={`dialects.${dialect}.pronunciation`} />
+                <AudioRecordingPreview record={record} audioPath={`dialects.${index}.pronunciation`} />
                 <Text>
                   {dialects.map((regionalDialect) => (
                     get(Dialects[regionalDialect], 'label')

--- a/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
@@ -40,12 +40,12 @@ const AudioRecorder = ({
     ? 'pronunciation'
     : path.startsWith('examples')
       ? 'pronunciation'
-      : `dialects.${path}.pronunciation`;
+      : `${path}.pronunciation`;
   const formValuePath = path === 'headword'
     ? 'pronunciation'
     : path.startsWith('examples') // Handles path for nested examples
       ? `${path}.pronunciation`
-      : `dialects.${path}.pronunciation`;
+      : `${path}.pronunciation`;
   const [pronunciationValue, setPronunciationValue] = useState(null);
   const [audioBlob, isRecording, startRecording, stopRecording] = useRecorder();
   const toast = useToast();

--- a/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef } from 'react';
+import React, { ReactElement } from 'react';
 import { Box, IconButton, Tooltip } from '@chakra-ui/react';
 import { DeleteIcon } from '@chakra-ui/icons';
 import Select from 'react-select';
@@ -19,7 +19,6 @@ const DialectForm = ({
   originalRecord,
 }: DialectFormInterface) : ReactElement => {
   const dialect = dialects[index];
-  const dialectalWordRef = useRef(dialect.word);
   const defaultDialectsValue = (dialect.dialects || []).map((value) => (
     { label: Dialects[value].label, value }
   ));
@@ -27,7 +26,7 @@ const DialectForm = ({
   return (
     <Box
       className="my-3 bg-gray-200 rounded p-3"
-      key={`dialects.${dialect.word}.word`}
+      key={`dialects.${dialect.id}.word`}
     >
       <Box className="flex flex-col justify-center items-center space-y-3 lg:space-y-0 space-x-3">
         <Box flex={3} className="w-full">
@@ -46,40 +45,30 @@ const DialectForm = ({
               />
             </Tooltip>
           </Box>
-          <Input
-            onChange={(e) => {
-              dialectalWordRef.current = e.target.value;
-            }}
-            onBlur={(e) => {
-              if (e.relatedTarget?.closest?.('[data-test="accented-letter-popup"]')) {
-                return;
-              }
-              const updatedDialects = [...dialects];
-              updatedDialects[index].word = dialectalWordRef.current;
-              setDialects(updatedDialects);
-              /**
-               * We are calling React Hook Form's setValue to update the current dialect's object.
-               * This step is necessary so we can have access to the latest updated dialect in React
-               * Hook Form when preparing our payload to send to the backend.
-               */
-              setValue(`dialects['${dialectalWordRef.current}']`, dialect);
-            }}
-            className="form-input"
-            placeholder="Dialectal variation"
-            data-test={`dialects-${dialect.word}-word-input`}
-            defaultValue={dialect.word || ''}
+          <Controller
+            render={({ onChange }) => (
+              <Input
+                onChange={onChange}
+                className="form-input"
+                placeholder="Dialectal variation"
+                data-test={`dialects-${index}-word-input`}
+                defaultValue={dialect.word || ''}
+              />
+            )}
+            name={`dialects.${index}.word`}
+            defaultValue={dialect?.word}
+            control={control}
           />
         </Box>
         <Box flex={2} className="w-full">
           <Controller
             render={() => (
               <AudioRecorder
-                path={dialect.word}
+                path={`dialects.${index}`}
                 getFormValues={getValues}
                 setPronunciation={(path, value) => {
                   const updatedDialects = [...dialects];
-                  const pathWithoutDialectsPrefix = path.split('dialects.')[1];
-                  updatedDialects[index][pathWithoutDialectsPrefix] = value;
+                  updatedDialects[index].pronunciation = value;
                   setDialects(updatedDialects);
                   /**
                    * We are calling React Hook Form's setValue to update the current dialect's pronunciation.
@@ -92,7 +81,7 @@ const DialectForm = ({
                 originalRecord={originalRecord}
               />
             )}
-            name={`dialects.${dialect.word}.pronunciation`}
+            name={`dialects.${index}.pronunciation`}
             defaultValue={dialect.pronunciation}
             control={control}
           />
@@ -118,7 +107,7 @@ const DialectForm = ({
                 defaultValue={defaultDialectsValue}
               />
             )}
-            name={`dialects.${dialect.word}.dialects`}
+            name={`dialects.${index}.dialects`}
             defaultValue={defaultDialectsValue}
             control={control}
           />

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -30,11 +30,12 @@ const schema = yup.object().shape({
     }),
   })),
   variations: yup.array().min(0).of(yup.string()),
-  dialects: yup.object().shape({
-    dialect: yup.string().optional(),
+  dialects: yup.array().min(0).of(yup.object().shape({
+    dialects: yup.array().min(1).of(yup.string()),
     variations: yup.array().min(0).of(yup.string()).optional(),
     pronunciation: yup.string().optional(),
-  }),
+    word: yup.string(),
+  })),
   tenses: yup.object().shape(Object.values(Tense).reduce((finalSchema, tenseValue) => ({
     ...finalSchema,
     [tenseValue.value]: yup.string().optional(),

--- a/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
@@ -38,6 +38,25 @@ describe('Word Edit', () => {
     await findByText('Editor\'s Comments');
   });
 
+  it('render dialectal variations', async () => {
+    const { findByText, findByTestId } = render(
+      <TestContext>
+        <WordEditForm
+          view={Views.EDIT}
+          resource={Collections.WORD_SUGGESTIONS}
+          record={{ id: '123' }}
+          save={() => {}}
+          history={{}}
+        />
+      </TestContext>,
+    );
+    await findByText('Dialectal Variations');
+    userEvent.click(await findByText('Add Dialectal Variation'));
+    await findByTestId('dialects-0-word-input');
+    userEvent.click(await findByText('Add Dialectal Variation'));
+    await findByTestId('dialects-1-word-input');
+  });
+
   it('add a definition group to word suggestion', async () => {
     const { findByText } = render(
       <TestContext>

--- a/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectFormsInterface.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectFormsInterface.tsx
@@ -3,6 +3,7 @@ import { Control } from 'react-hook-form';
 import { WordDialect } from 'src/backend/controllers/utils/interfaces';
 
 interface CurrentDialectForms {
+  errors: any,
   record: Record,
   originalRecord: Record,
   control: Control,

--- a/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectsForms.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectsForms.tsx
@@ -5,6 +5,7 @@ import DialectForm from '../../DialectForm/DialectForm';
 import CurrentDialectFormsInterface from './CurrentDialectFormsInterface';
 
 const CurrentDialectsForms = ({
+  errors,
   record,
   originalRecord,
   control,
@@ -29,15 +30,17 @@ const CurrentDialectsForms = ({
       colorScheme="green"
       leftIcon={<AddIcon color="white" boxSize={5} />}
     >
-      Add dialectal variation
+      Add Dialectal Variation
     </Button>
     <Box
       className={'grid grid-flow-row grid-cols-1 '
       + `${dialects.length !== 1 ? 'xl:grid-cols-2' : 'xl:grid-cols-1'} gap-4`}
     >
       {dialects.map((dialect, index) => (
-        <Box key={`dialectal-variation-${dialect.word}`}>
+        // eslint-disable-next-line
+        <Box key={`dialectal-variation-${dialect.word}-${dialect.id || ''}-${index}`}>
           <DialectForm
+            errors={errors}
             index={index}
             record={record}
             control={control}
@@ -49,6 +52,9 @@ const CurrentDialectsForms = ({
           />
         </Box>
       ))}
+      {errors.dialects ? (
+        <p className="error">{errors.dialects.message}</p>
+      ) : null}
     </Box>
   </Box>
 );

--- a/src/shared/components/views/shows/WordShow/__tests__/WordShow.test.tsx
+++ b/src/shared/components/views/shows/WordShow/__tests__/WordShow.test.tsx
@@ -28,7 +28,7 @@ const record = {
   pronunciation: '1234',
   stems: [],
   relatedTerms: [],
-  dialects: {},
+  dialects: [],
   attributes: {
     isStandardIgbo: true,
   },
@@ -46,13 +46,12 @@ const completeRecord = {
   pronunciation: 'word-pronunciation',
   stems: ['stemId'],
   relatedTerms: ['relatedTermId'],
-  dialects: {
-    word: {
-      variations: [],
-      dialects: ['NSA'],
-      pronunciation: 'dialect-pronunciation',
-    },
-  },
+  dialects: [{
+    variations: [],
+    dialects: ['NSA'],
+    pronunciation: 'dialect-pronunciation',
+    word: 'word',
+  }],
   nsibidi: 'nsibidi',
 };
 
@@ -88,6 +87,7 @@ describe('Word Show', () => {
     await findByText('Is Slang');
     await findByText('Is Constructed Term');
     await findByText('Nsịbịdị');
+    await findByText('Definition Groups');
     await findByText('Part of Speech');
     await findByText('Definitions');
     await findByText('Variations');
@@ -119,7 +119,6 @@ describe('Word Show', () => {
     await findByText('Nsịbịdị');
     await findByText('Part of Speech');
     await findByText('Definition Groups');
-    await findByText('Part of Speech');
     await findByText(WordClass[record.definitions[0].wordClass].label);
     await findByText('Definitions');
     await findByText(record.definitions[0].definitions[0]);

--- a/src/shared/components/views/shows/diffFields/DialectDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/DialectDiff.tsx
@@ -65,14 +65,12 @@ const DialectDiff = (
           defaultIndex={[0]}
           allowMultiple
         >
-          {Object.entries(record.dialects as Interfaces.WordDialect).map(([
-            dialectalWord,
-            {
-              variations = [],
-              dialects,
-              pronunciation,
-            },
-          ]) => (
+          {(record.dialects as Interfaces.WordDialect[]).map(({
+            variations = [],
+            dialects,
+            pronunciation,
+            word: dialectalWord,
+          }) => (
             <AccordionItem key={dialectalWord}>
               <AccordionButton>
                 <Heading as="h2" size="sm" className="text-left">

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -8,7 +8,7 @@ export const DEFAULT_WORD_RECORD = {
   word: '',
   wordClass: '',
   definitions: [],
-  dialects: {},
+  dialects: [],
   variations: [],
   approvals: [],
   denials: [],


### PR DESCRIPTION
## Background
This PR addresses the following bugs on the platform:
* The sufficient tag wasn't rendering correctly, therefore misleading users of the platform with the status of word and example documents
* The platform now handles dialects differently under the hood to allow editors to be able to have identical dialectal variations without object clashing
* Jest tests have been updated to reflect these changes