### PR TITLE
Increase function timeout to calculate total documents

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -79,7 +79,10 @@ export const sendEditorReminderEmail = functions.pubsub.schedule('0 6 */4 * *')
   .onRun(onSendEditorReminderEmail);
 
 /* Runs at minute 0, 10, 20, 30, 40, and 50 past every hour from 8AM through 10PM WAT */
-export const calculateDashboardStats = functions.pubsub.schedule('0,10,20,30,40,50 8-22 * * *')
+export const calculateDashboardStats = functions
+  .runWith({ timeoutSeconds: 540, memory: '512MB' })
+  .pubsub
+  .schedule('0,10,20,30,40,50 8-22 * * *')
   .timeZone('Africa/Lagos')
   .onRun(onUpdateDashboardStats);
 

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -41,24 +41,24 @@ const updateStat = async ({ statType, authorId = 'SYSTEM', value }) => {
 /* Returns all the WordSuggestions with Headword audio pronunciations */
 const calculateTotalHeadwordsWithAudioPronunciations = async ():
 Promise<{ audioPronunciationWords: number } | void> => {
-  const audioPronunciationWords = await Word.find(searchForAllWordsWithAudioPronunciations())
-    .estimatedDocumentCount();
+  const audioPronunciationWords = await Word
+    .countDocuments(searchForAllWordsWithAudioPronunciations());
   await updateStat({ statType: StatTypes.HEADWORD_AUDIO_PRONUNCIATIONS, value: audioPronunciationWords });
   return { audioPronunciationWords };
 };
 
 /* Returns all the Words that's in Standard Igbo */
 const calculateTotalWordsInStandardIgbo = async (): Promise<{ isStandardIgboWords: number } | void> => {
-  const isStandardIgboWords = await Word.find(searchForAllWordsWithIsStandardIgbo())
-    .estimatedDocumentCount();
+  const isStandardIgboWords = await Word
+    .countDocuments(searchForAllWordsWithIsStandardIgbo());
   await updateStat({ statType: StatTypes.STANDARD_IGBO, value: isStandardIgboWords });
   return { isStandardIgboWords };
 };
 
 /* Returns all Words with Nsịbịdị */
 const calculateTotalWordsWithNsibidi = async () : Promise<{ wordsWithNsibidi: number } | void> => {
-  const wordsWithNsibidi = await Word.find(searchForAllWordsWithNsibidi())
-    .estimatedDocumentCount();
+  const wordsWithNsibidi = await Word
+    .countDocuments(searchForAllWordsWithNsibidi());
   await updateStat({ statType: StatTypes.NSIBIDI_WORDS, value: wordsWithNsibidi });
 
   return { wordsWithNsibidi };
@@ -66,8 +66,8 @@ const calculateTotalWordsWithNsibidi = async () : Promise<{ wordsWithNsibidi: nu
 
 /* Returns all Word Suggestions with Nsịbịdị */
 const calculateTotalWordSuggestionsWithNsibidi = async () : Promise<{ wordSuggestionsWithNsibidi: number } | void> => {
-  const wordSuggestionsWithNsibidi = await WordSuggestion.find({ ...searchForAllWordsWithNsibidi(), merged: null })
-    .estimatedDocumentCount();
+  const wordSuggestionsWithNsibidi = await WordSuggestion
+    .countDocuments({ ...searchForAllWordsWithNsibidi(), merged: null });
   await updateStat({ statType: StatTypes.NSIBIDI_WORD_SUGGESTIONS, value: wordSuggestionsWithNsibidi });
   return { wordSuggestionsWithNsibidi };
 };
@@ -116,7 +116,7 @@ Promise<{ sufficientWordsCount: number, completeWordsCount: number, dialectalVar
   const { sufficientWordsCount, completeWordsCount, dialectalVariationsCount } = await countWords(words);
   await updateStat({ statType: StatTypes.SUFFICIENT_WORDS, value: sufficientWordsCount });
   await updateStat({ statType: StatTypes.COMPLETE_WORDS, value: completeWordsCount });
-  await updateStat({ statType: StatTypes.DIALECTAL_VARIATIONS, value: dialectalVariationsCount });
+  await updateStat({ statType: StatTypes.DIALECTAL_VARIATONS, value: dialectalVariationsCount });
 
   return { sufficientWordsCount, completeWordsCount, dialectalVariationsCount };
 };


### PR DESCRIPTION
## Background
The stats calculation function has been timing out due to its memory limit getting exceeded. This PR increases the function timeout limit and memory usage to 512MB.

<img width="1179" alt="Screen Shot 2022-11-08 at 9 11 18 AM" src="https://user-images.githubusercontent.com/16169291/200586807-ba540476-ed95-4c25-953a-f9a596fd01cd.png">
