### PR TITLE
Address logout warning message by redirecting to login first

### DIFF
--- a/src/Core/Layout/components/Notifications/Notifications.tsx
+++ b/src/Core/Layout/components/Notifications/Notifications.tsx
@@ -52,7 +52,7 @@ const Notifications = (props): ReactElement => {
 
   useEffect(() => {
     if (!auth.currentUser) {
-      return;
+      return null;
     }
     const { uid } = auth.currentUser;
     const q = query(collection(
@@ -68,8 +68,9 @@ const Notifications = (props): ReactElement => {
         }
       });
       setNotifications(allNotifications.reverse());
-      return unsubscribe;
     });
+
+    return unsubscribe;
   }, []);
 
   return (

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -47,8 +47,9 @@ const Login = (): ReactElement => {
     localStorage.setItem(LocalStorageKeys.ACCESS_TOKEN, idTokenResult.token);
     localStorage.setItem(LocalStorageKeys.UID, idTokenResult.claims.user_id);
     localStorage.setItem(LocalStorageKeys.PERMISSIONS, idTokenResult.claims.role);
-    const redirectUrl = localStorage.getItem(LocalStorageKeys.REDIRECT_URL);
-    redirect((redirectUrl || '#/').replace('#/', '') || '/');
+    const rawRedirectUrl = localStorage.getItem(LocalStorageKeys.REDIRECT_URL);
+    const redirectUrl = (rawRedirectUrl || '#/').replace('#/', '') || '/';
+    redirect(redirectUrl);
   };
 
   const uiConfig = {

--- a/src/utils/authProvider.ts
+++ b/src/utils/authProvider.ts
@@ -15,6 +15,7 @@ export default {
     Object.keys(omit(LocalStorageKeys, ['REDIRECT_URL'])).forEach((key) => {
       localStorage.removeItem(LocalStorageKeys[key]);
     });
+    window.location.hash = '#/login';
     return firebaseAuthProvider.logout(args);
   },
 };


### PR DESCRIPTION
## Background
Every time a user has to log out of the platform, they will see an unnecessary warning message appear at the bottom of the screen. This PR removes that warning message so that it's clearer to users when a valid error occurs.