### PR TITLE
Allow for saving exisitng AWS assets

### DIFF
--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -91,6 +91,9 @@ export const updateExampleSuggestion = (
       if (!exampleSuggestion) {
         throw new Error('Example suggestion doesn\'t exist');
       }
+      if (exampleSuggestion.merged) {
+        throw new Error('Unable to edit a merged example suggestion');
+      }
       const updatedExampleSuggestion = assign(exampleSuggestion, data);
       if (
         !updatedExampleSuggestion.associatedDefinitionsSchemas

--- a/src/backend/controllers/utils/MediaAPIs/AudioAPI.ts
+++ b/src/backend/controllers/utils/MediaAPIs/AudioAPI.ts
@@ -83,11 +83,12 @@ export const copyAudioPronunciation = async (
     const copiedAudioPronunciationUri = `${uriPath}/${newAudioId}.${extension}`;
     return copiedAudioPronunciationUri;
   } catch (err) {
-    console.log(
+    console.error(
       `Error occurred while copying audio: ${err.message} with `
       + `ids of oldDocId: ${oldAudioId} and newDocId: ${newAudioId}`,
     );
-    if (oldAudioId.includes('-') || newAudioId.includes('-')) {
+    // If the old and new audio ids are the same we don't want to through an error
+    if ((oldAudioId.includes('-') || newAudioId.includes('-')) && oldAudioId !== newAudioId) {
       throw new Error('Unable to save dialectal audio recording, please re-record dialect audio.');
     }
     return null;

--- a/src/backend/controllers/wordSuggestions.ts
+++ b/src/backend/controllers/wordSuggestions.ts
@@ -129,6 +129,11 @@ export const putWordSuggestion = (
           throw new Error('Word suggestion doesn\'t exist');
         }
 
+        if (wordSuggestion.merged) {
+          res.status(400);
+          throw new Error('Unable to edit a merged word suggestion');
+        }
+
         delete data.authorId;
         data = assignEditorsToDialects({
           clientData: data,


### PR DESCRIPTION
## Background
We were getting this error where we were attempting to copy an AWS audio file back into itself without changing any of its features. This PR addresses this bug by catching this specific error. If this fix doesn't work then we will use the `MetadataDirective => REPLACE` solution which feels more aggressive of a "solution" than what we need right now.

## Error message
<img width="1180" alt="Screen Shot 2022-11-23 at 9 57 41 AM" src="https://user-images.githubusercontent.com/16169291/203616616-3106ee31-8600-46bf-9606-04906dd74cd9.png">
