### PR TITLE
Prevent from error getting thrown for flagging word + Infinitely Logged In

### DIFF
--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { omit } from 'lodash';
 import { Record } from 'react-admin';
+import { getAuth } from 'firebase/auth';
 import IndexedDBAPI from 'src/utils/IndexedDBAPI';
 import { EmptyResponse } from './server-validation';
 import { useCallable } from '../hooks/useCallable';
@@ -9,21 +10,25 @@ import network from '../Core/Dashboard/network';
 import type { Poll } from '../backend/shared/types/Poll';
 import Collection from './constants/Collections';
 
+const auth = getAuth();
 const handleAssignUserToEditingGroup = (
   useCallable<{ groupNumber: string, uid: string }, EmptyResponse>('assignUserToEditingGroup')
 );
 
-const createAuthorizationHeader = () => {
-  const accessToken = localStorage.getItem('igbo-api-admin-access') || '';
+export const createAuthorizationHeader = async (): Promise<string> => {
+  const { currentUser } = auth;
+  const accessToken = currentUser
+    ? await currentUser.getIdToken()
+    : localStorage.getItem('igbo-api-admin-access') || '';
   return `Bearer ${accessToken}`;
 };
 
-const createHeaders = () => ({
-  Authorization: createAuthorizationHeader(),
+const createHeaders = async () => ({
+  Authorization: await createAuthorizationHeader(),
 });
 
-const request = (requestObject) => {
-  const headers = createHeaders();
+const request = async (requestObject) => {
+  const headers = await createHeaders();
   return axios({ ...requestObject, headers });
 };
 

--- a/src/shared/utils/flagHeadword.ts
+++ b/src/shared/utils/flagHeadword.ts
@@ -51,7 +51,7 @@ const accents = [GRAVE_ACCENT, ACUTE_ACCENT, MACRON_ACCENT];
 const invalidPrefixedDash = (
   { word: wordDocument, flags } : { word: Word, flags: FlagsType },
 ): { word: Word, flags: FlagsType } => {
-  const { word, definitions } = wordDocument;
+  const { word, definitions = [{ wordClass: '', definitions: [] }] } = wordDocument;
   const { wordClass } = definitions[0];
   if (word && word.startsWith('-') && wordClass !== WordClass.ESUF.value) {
     flags.dashPrefix = 'There is an invalid prefixed dash that shouldn\'t be present for this word. '

--- a/src/utils/dataProvider.ts
+++ b/src/utils/dataProvider.ts
@@ -2,6 +2,7 @@ import { fetchUtils } from 'react-admin';
 import restProvider from 'ra-data-simple-rest';
 import { assign } from 'lodash';
 import Collection from 'src/shared/constants/Collections';
+import { createAuthorizationHeader } from 'src/shared/API';
 import { API_ROUTE } from '../shared/constants';
 import authProvider from './authProvider';
 import IndexedDBAPI from './IndexedDBAPI';
@@ -15,8 +16,8 @@ export const httpClient = async (
     if (!updatedOptions.headers) {
       updatedOptions.headers = new Headers({ Accept: 'application/json' });
     }
-    const token = localStorage.getItem('igbo-api-admin-access') || '';
-    updatedOptions.headers.set('Authorization', `Bearer ${token}`);
+    const authToken = await createAuthorizationHeader();
+    updatedOptions.headers.set('Authorization', authToken);
     const res = await fetchUtils.fetchJson(url, updatedOptions).catch((err) => err);
 
     if (res.status === 403) {


### PR DESCRIPTION
## Background
Address the bug where a `wordDocument` that's empty and with no `definitions` throws an error. Additionally, this PR finally allows a user to stay logged into the platform, without getting logged out.