### PR TITLE
Reduce response size to render merge stats

### DIFF
--- a/src/Core/Dashboard/components/UserStat/UserStat.tsx
+++ b/src/Core/Dashboard/components/UserStat/UserStat.tsx
@@ -108,7 +108,7 @@ const UserStat = ({
               label: 'Word Suggestion Merges',
               data: Object.entries(wordSuggestionMerges).reduce((finalData, [isoWeek, wordSuggestions]) => {
                 const position = parseInt(isoWeek, 10) - threeMonthsAgoWeek;
-                finalData[position] = wordSuggestions.length;
+                finalData[position] = wordSuggestions;
                 return finalData;
               }, new Array(THREE_MONTH_WEEKS_COUNT).fill(0)),
               backgroundColor: '#48825D',
@@ -125,7 +125,7 @@ const UserStat = ({
               label: 'Example Suggestion Merges',
               data: Object.entries(exampleSuggestionMerges).reduce((finalData, [isoWeek, exampleSuggestions]) => {
                 const position = parseInt(isoWeek, 10) - threeMonthsAgoWeek;
-                finalData[position] = exampleSuggestions.length;
+                finalData[position] = exampleSuggestions;
                 return finalData;
               }, new Array(THREE_MONTH_WEEKS_COUNT).fill(0)),
               backgroundColor: '#3C83FF',
@@ -142,7 +142,7 @@ const UserStat = ({
               label: 'Dialectal Variation Merges',
               data: Object.entries(dialectalVariationMerges).reduce((finalData, [isoWeek, dialectalVariations]) => {
                 const position = parseInt(isoWeek, 10) - threeMonthsAgoWeek;
-                finalData[position] = dialectalVariations.length;
+                finalData[position] = dialectalVariations;
                 return finalData;
               }, new Array(THREE_MONTH_WEEKS_COUNT).fill(0)),
               backgroundColor: '#FF5733',


### PR DESCRIPTION
## Background
The `merge` endpoint was sending too much data back to the client. This PR only returns back an object that has the number of merges per week so that the client doesn't take on the burden of an increased number of documents that can become larger than 10MB