### PR TITLE
Condense tenses and prevent double network requests for UserStats

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -32,6 +32,7 @@ import {
   isProduction,
 } from './src/backend/config';
 
+const config = functions.config();
 const server = express();
 const index = fs.readFileSync(`${__dirname}/index.html`, 'utf-8');
 
@@ -115,7 +116,7 @@ export const app = process.env.NODE_ENV === 'test' ? (() => {
   return expressServer;
 })() : (
   functions
-    .region('europe-west1')
+    .region(config?.runtime?.env !== 'development' ? 'europe-west1' : 'us-central1')
     .runWith({ timeoutSeconds: 540, memory: '1GB' })
     .https
     .onRequest(server)

--- a/src/App/IgboAPIAdmin.tsx
+++ b/src/App/IgboAPIAdmin.tsx
@@ -17,8 +17,7 @@ import dataProvider from 'src/utils/dataProvider';
 import authProvider from 'src/utils/authProvider';
 import { getResourceObjects } from './Resources';
 
-const Resources = memo(() => {
-  const { permissions } = usePermissions();
+const Resources = memo(({ permissions } : { permissions: any }) => {
   const memoizedResources = useMemo(() => getResourceObjects(permissions).map((resource) => (
     <Resource
       name={resource.name}
@@ -41,9 +40,16 @@ const Resources = memo(() => {
       {memoizedResources}
     </AdminUI>
   );
+});
+
+const PermissionsManager = memo(({ children } : { children: any }) => {
+  const { permissions } = usePermissions();
+  return permissions ? React.Children.map(children, (child) => (
+    React.cloneElement(child, { permissions })
+  )) : null;
 }, () => true);
 
-const IgboAPIAdmin = (): ReactElement => (
+const IgboAPIAdmin = memo((): ReactElement => (
   // @ts-expect-error Cypress
   <Box className={!!window.Cypress ? 'testing-app' : ''}>
     <AdminContext
@@ -51,9 +57,12 @@ const IgboAPIAdmin = (): ReactElement => (
       authProvider={authProvider}
       catchAll={NotFound}
     >
-      <Resources />
+      <PermissionsManager>
+        {/* @ts-expect-error permissions */}
+        <Resources />
+      </PermissionsManager>
     </AdminContext>
   </Box>
-);
+), () => true);
 
 export default IgboAPIAdmin;

--- a/src/Core/Dashboard/components/UserStat/UserStat.tsx
+++ b/src/Core/Dashboard/components/UserStat/UserStat.tsx
@@ -11,7 +11,7 @@ import {
   Skeleton,
   chakra,
 } from '@chakra-ui/react';
-import { ShowProps } from 'react-admin';
+import { usePermissions } from 'react-admin';
 import moment from 'moment';
 import {
   Chart as ChartJS,
@@ -68,13 +68,11 @@ const THREE_MONTH_WEEKS_COUNT = 12;
 
 const UserStat = ({
   uid,
-  permissions,
   totalCompletedWords,
   totalCompletedExamples,
   totalDialectalVariations,
 } : {
   uid?: string,
-  permissions: ShowProps['permissions'],
   totalCompletedWords: number,
   totalCompletedExamples: number,
   totalDialectalVariations: number,
@@ -83,6 +81,7 @@ const UserStat = ({
   const [wordSuggestionMergeStats, setWordSuggestionMergeStats] = useState(null);
   const [exampleSuggestionMergeStats, setExampleSuggestionMergeStats] = useState(null);
   const [dialectalVariationMergeStats, setDialectalVariationMergeStats] = useState(null);
+  const { permissions } = usePermissions();
   const showMergeCharts = hasAdminOrMergerPermissions(permissions, true);
 
   useEffect(() => {
@@ -96,7 +95,7 @@ const UserStat = ({
           { json: dialectalVariationMerges },
         ] = await Promise.all([
           network(`/stats/users/${uid}/merge/words`),
-          await network(`/stats/users/${uid}/merge/examples`),
+          network(`/stats/users/${uid}/merge/examples`),
           network(`/stats/users/${uid}/merge/dialectal-variations`),
         ]) as [{ json: WordSuggestion[] }, { json: ExampleSuggestion[] }, { json: WordSuggestion[] }];
         const threeMonthsAgoWeek = moment().subtract(3, 'months').isoWeek() + 1;

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -18,6 +18,8 @@ import determineIsAsCompleteAsPossible from './utils/determineIsAsCompleteAsPoss
 import StatTypes from '../shared/constants/StatTypes';
 import * as Interfaces from './utils/interfaces';
 
+const WORD_SUGGESTION_QUERY_LIMIT = 3000;
+const EXAMPLE_SUGGESTION_QUERY_LIMIT = 5000;
 const findStat = async ({ type, authorId = 'SYSTEM' }) => {
   let stat = await Stat.findOne({ type, authorId });
   if (!stat) {
@@ -228,7 +230,7 @@ export const getUserMergeWordStats = async (
         updatedAt: { $gte: threeMonthsAgo },
       },
       'dialects updatedAt',
-    ) as Interfaces.WordSuggestion[];
+    ).limit(WORD_SUGGESTION_QUERY_LIMIT) as Interfaces.WordSuggestion[];
     const wordSuggestionMerges = wordSuggestions.reduce((finalData, wordSuggestion) => {
       const isoWeek = moment(wordSuggestion.updatedAt).isoWeek();
       if (!finalData[isoWeek]) {
@@ -258,7 +260,7 @@ export const getUserMergeExampleStats = async (
         updatedAt: { $gte: threeMonthsAgo },
       },
       'updatedAt',
-    ) as Interfaces.ExampleSuggestion[];
+    ).limit(EXAMPLE_SUGGESTION_QUERY_LIMIT) as Interfaces.ExampleSuggestion[];
     const exampleSuggestionMerges = exampleSuggestions.reduce((finalData, exampleSuggestion) => {
       const isoWeek = moment(exampleSuggestion.updatedAt).isoWeek();
       if (!finalData[isoWeek]) {
@@ -289,7 +291,7 @@ export const getUserMergeDialectalVariationStats = async (
         'dialects.editor': userId,
       },
       'dialects updatedAt',
-    ) as Interfaces.WordSuggestion[];
+    ).limit(WORD_SUGGESTION_QUERY_LIMIT) as Interfaces.WordSuggestion[];
     const dialectalVariationMerges = dialectalVariationWordSuggestions.reduce((finalData, wordSuggestion) => {
       const isoWeek = moment(wordSuggestion.updatedAt).isoWeek();
       if (!finalData[isoWeek]) {

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -39,7 +39,7 @@ normalizeIgbo(exampleSuggestionSchema);
 
 exampleSuggestionSchema.index({
   mergedBy: 1,
-  updatedAt: 1,
+  updatedAt: -1,
 }, {
   name: 'Merged example suggestion index',
 });

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -117,7 +117,7 @@ wordSuggestionSchema.index({
 
 wordSuggestionSchema.index({
   mergedBy: 1,
-  updatedAt: 1,
+  updatedAt: -1,
 }, {
   name: 'Merged word suggestion index',
 });

--- a/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
@@ -137,7 +137,7 @@ const AudioRecorder = ({
       />
       <Box
         data-test="word-pronunciation-input-container"
-        width="fit-content"
+        width="full"
         backgroundColor="gray.200"
         borderRadius="md"
         p={3}

--- a/src/shared/components/views/components/FormHeader.tsx
+++ b/src/shared/components/views/components/FormHeader.tsx
@@ -1,30 +1,45 @@
 import React, { ReactElement } from 'react';
 import { noop } from 'lodash';
-import { Box, Heading, Tooltip } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react';
 import { InfoOutlineIcon } from '@chakra-ui/icons';
 
 const FormHeader = (
   {
     title,
+    subtitle,
     tooltip,
     color,
     onClick,
   }
-  : { title: string, tooltip?: string, color?: string, onClick?: () => any },
+  : {
+    title: string,
+    subtitle?: string,
+    tooltip?: string,
+    color?: string,
+    onClick?: () => any,
+  },
 ): ReactElement => (
   <Box
     className={`flex flex-row items-center${onClick ? ' cursor-pointer' : ''}`}
     onClick={onClick || noop}
   >
-    <Heading
-      as="h2"
-      className={`form-header${onClick ? ' hover:underline' : ''}`}
-      fontSize="xl"
-      fontWeight="normal"
-      color={color}
-    >
-      {title}
-    </Heading>
+    <Box>
+      <Heading
+        as="h2"
+        className={`form-header${onClick ? ' hover:underline' : ''}`}
+        fontSize="xl"
+        fontWeight="normal"
+        color={color}
+      >
+        {title}
+      </Heading>
+      {subtitle ? <Text fontSize="sm" color="gray.400" fontStyle="italic">{subtitle}</Text> : null}
+    </Box>
     {tooltip ? (
       <Tooltip label={tooltip}>
         <InfoOutlineIcon color={color} className="ml-2" />

--- a/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
@@ -1,5 +1,10 @@
 import React, { ReactElement } from 'react';
-import { Box, IconButton, Tooltip } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  IconButton,
+  Tooltip,
+} from '@chakra-ui/react';
 import { DeleteIcon } from '@chakra-ui/icons';
 import Select from 'react-select';
 import { Controller } from 'react-hook-form';
@@ -25,13 +30,13 @@ const DialectForm = ({
 
   return (
     <Box
-      className="my-3 bg-gray-200 rounded p-3"
+      className="mb-4 bg-gray-200 rounded p-3"
       key={`dialects.${dialect.id}.word`}
     >
       <Box className="flex flex-col justify-center items-center space-y-3 lg:space-y-0 space-x-3">
         <Box flex={3} className="w-full">
-          <Box className="flex flex-row justify-between items-center">
-            <h3 className="form-header">Word:</h3>
+          <Box className="flex flex-row justify-between items-center" mb={3}>
+            <Heading as="h3" m={0} fontSize="xl" fontWeight="normal">Word</Heading>
             <Tooltip label="Delete dialectal variation">
               <IconButton
                 colorScheme="red"
@@ -88,7 +93,7 @@ const DialectForm = ({
         </Box>
       </Box>
       <Box className="mt-4">
-        <h3 style={{ flex: 1 }} className="form-header">Dialects:</h3>
+        <Heading as="h3" style={{ flex: 1 }} fontSize="xl" fontWeight="normal" mb={3}>Dialects</Heading>
         <Box flex={1}>
           <Controller
             render={({ onChange }) => (

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -262,12 +262,6 @@ const WordEditForm = ({
               name="pronunciation"
               control={control}
             />
-            <Box className="flex flex-row justify-between items-center">
-              <FormHeader
-                title="Dialectal Variations"
-                tooltip="These are the dialectal (sound) variations with the current word."
-              />
-            </Box>
             <CurrentDialectsForms
               errors={errors}
               record={record}

--- a/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectsForms.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/CurrentDialectForms/CurrentDialectsForms.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Box, Button } from '@chakra-ui/react';
 import { AddIcon } from '@chakra-ui/icons';
+import FormHeader from '../../../FormHeader';
 import DialectForm from '../../DialectForm/DialectForm';
 import CurrentDialectFormsInterface from './CurrentDialectFormsInterface';
 
@@ -14,47 +15,57 @@ const CurrentDialectsForms = ({
   setDialects,
   dialects,
 }: CurrentDialectFormsInterface): ReactElement => (
-  <Box className="mb-4">
-    <Button
-      onClick={() => {
-        setDialects([
-          ...dialects,
-          {
-            word: 'New dialectal variation',
-            dialects: [],
-            variations: [],
-            pronunciation: '',
-          },
-        ]);
-      }}
-      colorScheme="green"
-      leftIcon={<AddIcon color="white" boxSize={5} />}
-    >
-      Add Dialectal Variation
-    </Button>
-    <Box
-      className={'grid grid-flow-row grid-cols-1 '
-      + `${dialects.length !== 1 ? 'xl:grid-cols-2' : 'xl:grid-cols-1'} gap-4`}
-    >
-      {dialects.map((dialect, index) => (
-        // eslint-disable-next-line
-        <Box key={`dialectal-variation-${dialect.word}-${dialect.id || ''}-${index}`}>
-          <DialectForm
-            errors={errors}
-            index={index}
-            record={record}
-            control={control}
-            getValues={getValues}
-            setValue={setValue}
-            setDialects={setDialects}
-            dialects={dialects}
-            originalRecord={originalRecord}
-          />
-        </Box>
-      ))}
-      {errors.dialects ? (
-        <p className="error">{errors.dialects.message}</p>
-      ) : null}
+  <Box>
+    <Box className="flex flex-row justify-between items-center">
+      <FormHeader
+        title="Dialectal Variations"
+        subtitle="Scroll to the bottom of this section to add a new dialectal variation 👇🏾"
+        tooltip="These are the dialectal (sound) variations with the current word."
+      />
+    </Box>
+    <Box className="my-4">
+      <Box
+        className={'grid grid-flow-row grid-cols-1 '
+        + `${dialects.length !== 1 ? 'xl:grid-cols-2' : 'xl:grid-cols-1'} gap-4`}
+      >
+        {dialects.map((dialect, index) => (
+          // eslint-disable-next-line
+          <Box key={`dialectal-variation-${dialect.word}-${dialect.id || ''}-${index}`}>
+            <DialectForm
+              errors={errors}
+              index={index}
+              record={record}
+              control={control}
+              getValues={getValues}
+              setValue={setValue}
+              setDialects={setDialects}
+              dialects={dialects}
+              originalRecord={originalRecord}
+            />
+          </Box>
+        ))}
+        {errors.dialects ? (
+          <p className="error">{errors.dialects.message}</p>
+        ) : null}
+      </Box>
+      <Button
+        onClick={() => {
+          setDialects([
+            ...dialects,
+            {
+              word: 'New dialectal variation',
+              dialects: [],
+              variations: [],
+              pronunciation: '',
+            },
+          ]);
+        }}
+        width="full"
+        colorScheme="green"
+        leftIcon={<AddIcon color="white" boxSize={5} />}
+      >
+        Add Dialectal Variation
+      </Button>
     </Box>
   </Box>
 );

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
@@ -44,7 +44,7 @@ const DefinitionsForm = ({
 
   return (
     <Box className="w-full">
-      <Box className="flex items-start my-12 w-full justify-between">
+      <Box className="flex items-start mt-12 w-full justify-between">
         <Box className="flex flex-col">
           <FormHeader
             title={`Definition Groups (${definitions.length})`}

--- a/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
@@ -77,7 +77,7 @@ const RelatedTerms = (
     </Box>
   ) : (
     <Box className="flex w-full justify-center">
-      <p className="text-gray-600 mb-4">No related terms</p>
+      <p className="text-gray-600 mb-4 italic">No related terms</p>
     </Box>
   );
 };

--- a/src/shared/components/views/components/WordEditForm/components/TensesForm/TensesForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/TensesForm/TensesForm.tsx
@@ -26,34 +26,36 @@ const TensesForm = ({
         window.open(TENSES_DOC, '_blank');
       }}
     />
-    {Object.entries(record.tenses || DEFAULT_TENSES).map(([key, value]) => (
-      <>
-        <Controller
-          render={({ onChange, ref }) => {
-            const label = capitalize(key.replace(/([A-Z])/g, ' $1'));
-            return (
-              <>
-                <h3 className="text-gray-700 mb-2">{`${label}:`}</h3>
-                <Input
-                  onChange={(e) => onChange(e.target.value)}
-                  defaultValue={record?.tenses?.[key]}
-                  placeholder={label}
-                  ref={ref}
-                  data-test={`tenses-${key}-input`}
-                  mb={4}
-                />
-              </>
-            );
-          }}
-          defaultValue={value}
-          name={`tenses.${key}`}
-          control={control}
-        />
-        {errors.tenses?.[key] ? (
-          <p className="error relative">Fill in associated tense</p>
-        ) : null}
-      </>
-    ))}
+    <Box className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {Object.entries(record.tenses || DEFAULT_TENSES).map(([key, value]) => (
+        <Box>
+          <Controller
+            render={({ onChange, ref }) => {
+              const label = capitalize(key.replace(/([A-Z])/g, ' $1'));
+              return (
+                <Box>
+                  <h3 className="text-gray-700 mb-2">{`${label}:`}</h3>
+                  <Input
+                    onChange={(e) => onChange(e.target.value)}
+                    defaultValue={record?.tenses?.[key]}
+                    placeholder={label}
+                    ref={ref}
+                    data-test={`tenses-${key}-input`}
+                    mb={4}
+                  />
+                </Box>
+              );
+            }}
+            defaultValue={value}
+            name={`tenses.${key}`}
+            control={control}
+          />
+          {errors.tenses?.[key] ? (
+            <p className="error relative">Fill in associated tense</p>
+          ) : null}
+        </Box>
+      ))}
+    </Box>
   </Box>
 );
 

--- a/src/shared/components/views/components/WordEditForm/components/VariationsForm/VariationsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/VariationsForm/VariationsForm.tsx
@@ -54,7 +54,7 @@ const VariationsForm = (
       </Box>
     )) : (
       <Box className="flex w-full justify-center">
-        <p className="text-gray-600 mb-4">No spelling variations</p>
+        <p className="text-gray-600 mb-4 italic">No spelling variations</p>
       </Box>
     )}
   </Box>

--- a/src/shared/components/views/shows/UserShow/UserShow.tsx
+++ b/src/shared/components/views/shows/UserShow/UserShow.tsx
@@ -16,7 +16,6 @@ const UserShow = (props: ShowProps): ReactElement => {
   const [totalCompletedExamples, setTotalCompletedExamples] = useState(null);
   const [totalDialectalVariations, setTotalDialectalVariations] = useState(null);
   const showProps = useShowController(props);
-  const { permissions } = props;
   let { record } = showProps;
 
   record = record || {};
@@ -65,10 +64,9 @@ const UserShow = (props: ShowProps): ReactElement => {
           </Box>
         </Box>
         <Heading size="lg" className="mt-3">Total User Stats</Heading>
-        {record.uid ? (
+        {record.uid && !isLoading ? (
           <UserStat
             uid={record.uid}
-            permissions={permissions}
             totalCompletedWords={totalCompletedWords}
             totalCompletedExamples={totalCompletedExamples}
             totalDialectalVariations={totalDialectalVariations}


### PR DESCRIPTION
## Background
* Improves a few aspects of the Word Edit Form
* Prevents from the double network requests for the `UserStats` fomponent

### Condensed tenses
<img width="1421" alt="Screen Shot 2022-12-03 at 6 07 19 PM" src="https://user-images.githubusercontent.com/16169291/205470575-b12f134b-eb4b-46fd-a49e-bf7ebe72b0eb.png">

### Updated dialectal variations designs
<img width="717" alt="Screen Shot 2022-12-03 at 6 07 32 PM" src="https://user-images.githubusercontent.com/16169291/205470580-3ccdf849-cb9f-472e-8277-85cf82a80d7b.png">
