### PR TITLE
Allow the first Igbo definition to be deleted

### DIFF
--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/IgboDefinitions.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/IgboDefinitions.tsx
@@ -40,15 +40,13 @@ const IgboDefinitions = ({
             defaultValue={igboDefinition}
             control={control}
           />
-          {igboDefinitionIndex ? (
-            <IconButton
-              colorScheme="red"
-              onClick={() => handleDeleteGroupIgboDefinition(index, igboDefinitionIndex)}
-              className="ml-3"
-              aria-label="Delete"
-              icon={<DeleteIcon />}
-            />
-          ) : null }
+          <IconButton
+            colorScheme="red"
+            onClick={() => handleDeleteGroupIgboDefinition(index, igboDefinitionIndex)}
+            className="ml-3"
+            aria-label="Delete"
+            icon={<DeleteIcon />}
+          />
         </Box>
       </Box>
     ))}


### PR DESCRIPTION
## Background
The Igbo definitions section didn't allow for the first definition to be deleted.