### PR TITLE
Stop using isAccented and english length for determine complete words and examples

### DIFF
--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -115,10 +115,7 @@ const calculateWordStats = async (Word, Stat):
 Promise<{ sufficientWordsCount: number, completeWordsCount: number, dialectalVariationsCount: number } | void> => {
   const INCLUDE_ALL_WORDS_LIMIT = 100000;
   const words = await findWordsWithMatch({
-    match: {
-      word: { $regex: /./ },
-      'attributes.isStandardIgbo': { $eq: true },
-    },
+    match: { 'attributes.isStandardIgbo': { $eq: true } },
     examples: true,
     limit: INCLUDE_ALL_WORDS_LIMIT,
     Word,
@@ -133,7 +130,7 @@ Promise<{ sufficientWordsCount: number, completeWordsCount: number, dialectalVar
 
 const countCompletedExamples = async (examples) => {
   const sufficientExamplesCount = compact(await Promise.all(examples.map(async (example) => (
-    !(await determineExampleCompleteness(example)).completeExampleRequirements.length)))).length;
+    !(await determineExampleCompleteness(example, true)).completeExampleRequirements.length)))).length;
   return sufficientExamplesCount;
 };
 
@@ -144,7 +141,6 @@ Promise<{ sufficientExamplesCount: number, completedExamplesCount: number } | vo
     .find({
       $and: [
         { $expr: { $gt: [{ $strLenCP: '$igbo' }, 3] } },
-        { $expr: { $gte: ['$english', '$igbo'] } },
         { 'associatedWords.0': { $exists: true } },
       ],
     });

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -28,15 +28,18 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
     tenses = {},
   } = record;
 
-  const isAudioAvailable = !skipAudioCheck && await new Promise((resolve) => {
-    axios.get(pronunciation)
-      .then(() => resolve(true))
-      .catch(() => {
-        if (pronunciation?.startsWith?.('https://igbo-api-test-local/')) {
-          return resolve(true);
-        }
-        return resolve(false);
-      });
+  const isAudioAvailable = await new Promise((resolve) => {
+    if (!skipAudioCheck) {
+      axios.get(pronunciation)
+        .then(() => resolve(true))
+        .catch(() => {
+          if (pronunciation?.startsWith?.('https://igbo-api-test-local/')) {
+            return resolve(true);
+          }
+          return resolve(false);
+        });
+    }
+    return resolve(pronunciation?.startsWith('https://'));
   });
 
   const sufficientWordRequirements = compact([

--- a/src/backend/controllers/utils/determineExampleCompleteness.ts
+++ b/src/backend/controllers/utils/determineExampleCompleteness.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { compact } from 'lodash';
 import { Record } from 'react-admin';
-import { Word } from 'src/backend/controllers/utils/interfaces';
+import { Example } from 'src/backend/controllers/utils/interfaces';
 import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 
-export default async (record: Word | Record) : Promise<{
+export default async (record: Example | Record, skipAudioCheck = false) : Promise<{
   sufficientExampleRequirements: string[],
   completeExampleRequirements: string[],
 }> => {
@@ -18,14 +18,17 @@ export default async (record: Word | Record) : Promise<{
   } = record;
 
   const isAudioAvailable = await new Promise((resolve) => {
-    axios.get(pronunciation)
-      .then(() => resolve(true))
-      .catch(() => {
-        if (pronunciation?.startsWith?.('https://igbo-api-test-local/')) {
-          return resolve(true);
-        }
-        return resolve(false);
-      });
+    if (!skipAudioCheck) {
+      axios.get(pronunciation)
+        .then(() => resolve(true))
+        .catch(() => {
+          if (pronunciation?.startsWith?.('https://igbo-api-test-local/')) {
+            return resolve(true);
+          }
+          return resolve(false);
+        });
+    }
+    return resolve(pronunciation?.startsWith('https://'));
   });
 
   const sufficientExampleRequirements = compact([


### PR DESCRIPTION
## Background
This PR finally loosens up the db query used to determine the total number of complete dialectal variations and examples on the platform.