### PR TITLE
Open and close connections for each request

### DIFF
--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -331,9 +331,9 @@ export const onUpdateDashboardStats = async (): Promise<void> => {
       calculateTotalHeadwordsWithAudioPronunciations(Word, Stat),
       calculateWordStats(Word, Stat),
     ]);
-    await disconnectDatabase();
+    await disconnectDatabase(connection);
   } catch (err) {
-    await disconnectDatabase();
+    await disconnectDatabase(connection);
     console.log(err);
   };
 };

--- a/src/backend/middleware/afterRes.ts
+++ b/src/backend/middleware/afterRes.ts
@@ -8,7 +8,7 @@ export default () => async (req: Interfaces.EditorRequest, res: Response, next: 
   // Disconnect from database if not in a testing environment
   if (process.env.NODE_ENV !== 'test') {
     const afterResponse = async () => {
-      await disconnectDatabase();
+      await disconnectDatabase(mongooseConnection);
     };
     res.on('finish', afterResponse);
     res.on('close', afterResponse);

--- a/src/backend/middleware/errorHandler.ts
+++ b/src/backend/middleware/errorHandler.ts
@@ -9,6 +9,6 @@ export default async (err, req, res, next) => {
   }
   console.log(err?.message);
   console.log(err?.stack);
-  await disconnectDatabase();
+  await disconnectDatabase(req.mongooseConnection);
   return res.send({ error: err.message });
 };

--- a/src/backend/services/emailJobs.ts
+++ b/src/backend/services/emailJobs.ts
@@ -43,10 +43,10 @@ export const sendWeeklyStats = async (): Promise<void> => {
         endDate: new Date().toDateString(),
       };
       await sendMergedStats(emailData);
-      await disconnectDatabase();
+      await disconnectDatabase(mongooseConnection);
     }
   } catch (err) {
-    await disconnectDatabase();
+    await disconnectDatabase(mongooseConnection);
   }
 };
 
@@ -67,9 +67,9 @@ export const onSendEditorReminderEmail = async (): Promise<void> => {
         exampleSuggestionsCount: nonMergedExampleSuggestions.length,
       };
       await sendSuggestionsReminder(emailData);
-      await disconnectDatabase();
+      await disconnectDatabase(mongooseConnection);
     }
   } catch (err) {
-    await disconnectDatabase();
+    await disconnectDatabase(mongooseConnection);
   }
 };

--- a/src/backend/utils/database.ts
+++ b/src/backend/utils/database.ts
@@ -4,49 +4,42 @@ import { MONGO_URI } from 'src/backend/services/initializeAdmin';
 
 const config = functions.config();
 const DISCONNECTED = 0;
-const mongooseConnection = mongoose.connection;
 
 /* Opens a connection to MongoDB */
 export const connectDatabase = async (): Promise<mongoose.Connection> => new Promise((resolve) => {
   /* Connects to the MongoDB Database */
-  if (mongooseConnection?.readyState === DISCONNECTED) {
+  if (config?.runtime?.env === 'production') {
     console.time('Create MongoDB connection');
-    mongoose.connect(MONGO_URI, {
-      useNewUrlParser: true,
-      useFindAndModify: false,
-      useCreateIndex: true,
-      poolSize: 20,
-      bufferMaxEntries: 0,
-      useUnifiedTopology: true,
-    });
+  }
+  const mongooseConnection = mongoose.createConnection(MONGO_URI, {
+    useNewUrlParser: true,
+    useFindAndModify: false,
+    useCreateIndex: true,
+    poolSize: 20,
+    bufferMaxEntries: 0,
+    useUnifiedTopology: true,
+  });
 
-    mongooseConnection.on('error', console.error.bind(console, '❌ MongoDB connection error:'));
-    mongooseConnection.once('open', () => {
-      console.timeEnd('Create MongoDB connection');
-      if (config?.runtime?.env === 'production') {
-        console.log('🆕 Created a new mongooseConnection.');
-        console.log('🗄 Database is connected', process.env.CI, MONGO_URI);
-      }
-      resolve(mongooseConnection);
-    });
-  } else {
+  mongooseConnection.on('error', console.error.bind(console, '❌ MongoDB connection error:'));
+  mongooseConnection.once('open', () => {
     if (config?.runtime?.env === 'production') {
-      console.log('ℹ️  mongooseConnection has already been initialized and is being reused.');
+      console.timeEnd('Create MongoDB connection');
+      console.log('🆕 Created a new mongooseConnection.');
+      console.log('🗄 Database is connected', process.env.CI, MONGO_URI);
     }
     resolve(mongooseConnection);
-  }
+  });
 });
 
 /* Closes current connection to MongoDB */
-export const disconnectDatabase = (): Promise<void> => new Promise((resolve) => {
-  resolve();
-  // if (mongooseConnection.readyState !== DISCONNECTED) {
-  //   mongooseConnection.close();
-  //   mongooseConnection.once('close', () => {
-  //     if (config?.runtime?.env === 'production') {
-  //       console.log('🗃 Database is connection closed', process.env.CI, MONGO_URI);
-  //     }
-  //     resolve();
-  //   });
-  // }
+export const disconnectDatabase = (mongooseConnection: mongoose.Connection): Promise<void> => new Promise((resolve) => {
+  if (mongooseConnection.readyState !== DISCONNECTED) {
+    mongooseConnection.close();
+    mongooseConnection.once('close', () => {
+      if (config?.runtime?.env === 'production') {
+        console.log('🗃 Database is connection closed', process.env.CI, MONGO_URI);
+      }
+      resolve();
+    });
+  }
 });


### PR DESCRIPTION
## Background
Our MongoDB cluster was experiencing an extreme amount of "virtual data" getting created. That happens when there's an excessive amount of open connections. This PR opens and then closes a MongoDB connection on each request