### PR TITLE
Support Multiple Nsịbịdị

### DIFF
--- a/src/__tests__/wordSuggestions.test.ts
+++ b/src/__tests__/wordSuggestions.test.ts
@@ -176,6 +176,24 @@ describe('MongoDB Word Suggestions', () => {
       expect(result.body.authorId).toEqual(res.body.authorId);
     });
 
+    it('should update specific wordSuggestion with nested nsibidi', async () => {
+      const res = await suggestNewWord(wordSuggestionData);
+      expect(res.status).toEqual(200);
+      const result = await updateWordSuggestion({
+        id: res.body.id,
+        ...updatedWordSuggestionData,
+        definitions: [
+          {
+            definitions: ['first definition'],
+            wordClass: WordClass.NNC.value,
+            nsibidi: 'testing',
+          },
+          ...updatedWordSuggestionData.definitions,
+        ],
+      });
+      expect(result.body.nsibidi).toBeUndefined();
+      expect(result.body.definitions[0].nsibidi).toBe('testing');
+    });
     it('should update nested exampleSuggestion inside wordSuggestion', async () => {
       const updatedIgbo = 'updated example igbo text';
       const updatedEnglish = 'updated example english text';

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -49,7 +49,9 @@ export interface DefinitionSchema {
   wordClass: string | WordDialect,
   definitions: string[],
   igboDefinitions: string[],
-  _id: Types.ObjectId,
+  nsibidi: string,
+  _id?: Types.ObjectId,
+  id?: string,
 }
 
 export interface Word extends Document<any>, LeanDocument<any> {
@@ -73,7 +75,6 @@ export interface Word extends Document<any>, LeanDocument<any> {
     isBorrowedTerm: boolean,
     isStem: boolean,
   }
-  nsibidi: string,
   relatedTerms: string[],
   hypernyms: string[],
   hyponyms: string[],

--- a/src/backend/middleware/validateWordBody.ts
+++ b/src/backend/middleware/validateWordBody.ts
@@ -26,6 +26,7 @@ export const wordDataSchema = Joi.object().keys({
     wordClass: Joi.string().valid(...Object.keys(WordClass)).required(),
     definitions: Joi.array().min(1).items(Joi.string()).required(),
     igboDefinitions: Joi.array().min(0).items(Joi.string()).optional(),
+    nsibidi: Joi.string().allow('').optional(),
     label: Joi.string().allow('').optional(),
   })).required(),
   attributes: Joi.object().keys(Object.values(WordAttributes).reduce((finalSchema, { value }) => ({

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -17,6 +17,7 @@ const definitionSchema = new Schema({
   },
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
+  nsibidi: { type: String, default: '', index: true },
   igboDefinitions: { type: [{ type: String }], default: [] },
 }, { toObject: toObjectPlugin });
 
@@ -69,7 +70,6 @@ export const wordSchema = new Schema({
   relatedTerms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
-  nsibidi: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 toJSONPlugin(wordSchema);

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -20,6 +20,7 @@ const definitionSchema = new Schema({
   },
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
+  nsibidi: { type: String, default: '', index: true },
   igboDefinitions: { type: [{ type: String }], default: [] },
 }, { toObject: toObjectPlugin });
 
@@ -76,7 +77,6 @@ export const wordSuggestionSchema = new Schema(
     relatedTerms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
-    nsibidi: { type: String, default: '', index: true },
     approvals: { type: [{ type: String }], default: [] },
     denials: { type: [{ type: String }], default: [] },
     source: { type: String },

--- a/src/backend/shared/constants/Dialects.ts
+++ b/src/backend/shared/constants/Dialects.ts
@@ -4,6 +4,11 @@ export default {
     value: 'ABI',
     label: 'Abiriba',
   },
+  ACH: {
+    code: 'ibo-ach',
+    value: 'ACH',
+    label: 'Achalla',
+  },
   AFI: {
     code: 'ibo-afi',
     value: 'AFI',
@@ -13,6 +18,16 @@ export default {
     code: 'ibo-aja',
     value: 'AJA',
     label: 'Ajalli/Ajali',
+  },
+  AMA: {
+    code: 'ibo-ama',
+    value: 'AMA',
+    label: 'Amaifeke',
+  },
+  ANA: {
+    code: 'ibo-ana',
+    value: 'ANA',
+    lable: 'Anam',
   },
   ANI: {
     code: 'ibo-ani',
@@ -48,6 +63,11 @@ export default {
     code: 'ibo-eze',
     value: 'EZE',
     label: 'Ezeagu',
+  },
+  IHU: {
+    code: 'ibo-ihu',
+    value: 'IHU',
+    label: 'Ihuoma',
   },
   IQW: {
     code: 'ibo-iqw',

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -34,7 +34,6 @@ import StemsForm from './components/StemsForm';
 import RelatedTermsForm from './components/RelatedTermsForm';
 import HeadwordForm from './components/HeadwordForm';
 import TagsForm from './components/TagsForm';
-import NsibidiForm from './components/NsibidiForm';
 import TensesForm from './components/TensesForm';
 import AudioRecorder from '../AudioRecorder';
 import CurrentDialectsForms from './components/CurrentDialectForms/CurrentDialectsForms';
@@ -81,6 +80,7 @@ const WordEditForm = ({
     wordClass: '',
     definitions: [''],
     igboDefinitions: [],
+    nsibidi: '',
   }]);
   const [examples, setExamples] = useState(record.examples || []);
   const [variations, setVariations] = useState(record.variations || []);
@@ -241,11 +241,6 @@ const WordEditForm = ({
               record={record}
               getValues={getValues}
               watch={watch}
-            />
-            <NsibidiForm
-              control={control}
-              record={record}
-              getValues={getValues}
             />
             <TagsForm
               errors={errors}

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -19,6 +19,7 @@ const schema = yup.object().shape({
       value: yup.mixed().oneOf(Object.values(WordClass).map(({ value }) => value)),
       label: yup.mixed().oneOf(Object.values(WordClass).map(({ label }) => label)),
     }).required(),
+    nsibidi: yup.string().optional(),
     definitions: yup.mixed().test('definition-types', 'Definition is required', (value) => {
       if (Array.isArray(value)) {
         return value.length >= 1 && value[0].length >= 1;
@@ -45,7 +46,6 @@ const schema = yup.object().shape({
   relatedTerms: yup.array().min(0).of(yup.string()),
   pronunciation: yup.string().optional(),
   examples: yup.array().min(0).of(ExampleEditFormSchema),
-  nsibidi: yup.string(),
   twitterPollId: yup.string().optional(),
 });
 

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Tooltip } from '@chakra-ui/react';
 import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
 import FormHeader from '../../../FormHeader';
 import DefinitionsFormInterface from './DefinitionsFormInterface';
+import NsibidiForm from '../NsibidiForm';
 import PartOfSpeechForm from '../PartOfSpeechForm';
 import EnglishDefinitions from './EnglishDefinitions';
 import IgboDefinitions from './IgboDefinitions';
@@ -78,12 +79,12 @@ const DefinitionsForm = ({
         </Button>
       </Box>
       <Box className="w-full grid grid-flow-row grid-cols-1 gap-4 px-3">
-        {definitions.map(({ definitions: nestedDefinitions, igboDefinitions = [], _id }, index) => (
+        {definitions.map(({ definitions: nestedDefinitions, igboDefinitions = [], id }, index) => (
           <Box
             borderBottomWidth="1px"
             borderBottomColor="gray.300"
             mb={4}
-            key={_id}
+            key={id}
           >
             {definitions.length > 1 ? (
               <Tooltip label="Delete Definition Group">
@@ -104,15 +105,23 @@ const DefinitionsForm = ({
                 </Button>
               </Tooltip>
             ) : null}
-            <PartOfSpeechForm
-              errors={errors}
-              control={control}
-              getValues={getValues}
-              cacheForm={cacheForm}
-              options={options}
-              record={record}
-              index={index}
-            />
+            <Box className="flex flex-row space-x-3 items-start">
+              <PartOfSpeechForm
+                errors={errors}
+                control={control}
+                getValues={getValues}
+                cacheForm={cacheForm}
+                options={options}
+                record={record}
+                index={index}
+              />
+              <NsibidiForm
+                control={control}
+                record={record}
+                getValues={getValues}
+                name={`definitions[${index}].nsibidi`}
+              />
+            </Box>
             <Box className="flex flex-row items-center my-5 w-full justify-between">
               <FormHeader
                 title="Definitions"

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiForm.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { get } from 'lodash';
 import { Box } from '@chakra-ui/react';
 import { Controller } from 'react-hook-form';
 import FormHeader from '../../../FormHeader';
@@ -9,6 +10,7 @@ const NsibidiForm = ({
   control,
   record,
   getValues,
+  name,
 }: NsidibiFormInterface): ReactElement => (
   <Box className="flex flex-col w-full">
     <FormHeader
@@ -22,9 +24,9 @@ const NsibidiForm = ({
       render={(props) => (
         <NsibidiInput {...props} />
       )}
-      name="nsibidi"
+      name={name || 'nsibidi'}
       control={control}
-      defaultValue={record.nsibidi || getValues().nsibidi}
+      defaultValue={name ? get(record, name) : (record.nsibidi || getValues().nsibidi)}
     />
   </Box>
 );

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsidibiFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsidibiFormInterface.ts
@@ -5,6 +5,7 @@ interface NsidibiForm {
   control: Control,
   record: Record,
   getValues: (key: string) => any,
+  name?: string
 };
 
 export default NsidibiForm;

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -69,7 +69,6 @@ const WordShow = (props: ShowProps): ReactElement => {
     id,
     author,
     word,
-    nsibidi,
     approvals,
     denials,
     editorsNotes,
@@ -162,17 +161,6 @@ const WordShow = (props: ShowProps): ReactElement => {
                   fallbackValue={word}
                 />
               </Box>
-              <Box className="flex flex-col">
-                <Heading fontSize="lg" className="text-xl text-gray-600">Nsịbịdị</Heading>
-                <DiffField
-                  path="nsibidi"
-                  diffRecord={diffRecord}
-                  fallbackValue={nsibidi}
-                  renderNestedObject={(value) => (
-                    <span className={value ? 'akagu' : ''}>{value || 'N/A'}</span>
-                  )}
-                />
-              </Box>
             </Box>
             <Box className="flex flex-col mt-5">
               <Heading fontSize="lg" className="text-xl text-gray-600">Audio Pronunciation</Heading>
@@ -200,11 +188,11 @@ const WordShow = (props: ShowProps): ReactElement => {
               <Heading fontSize="lg" className="text-xl text-gray-600">Definition Groups</Heading>
               {record.definitions.map((definition, index) => (
                 <Box
-                  className="pl-4 pb-4"
+                  className="pl-4 pb-4 space-y-4 mt-4"
                   borderBottomColor="gray.200"
                   borderBottomWidth="1px"
                 >
-                  <Box className="flex flex-col mt-5">
+                  <Box className="flex flex-col">
                     <Heading fontSize="md" className="text-gray-600">Part of Speech</Heading>
                     <DiffField
                       path={`definitions.${index}.wordClass`}
@@ -215,7 +203,18 @@ const WordShow = (props: ShowProps): ReactElement => {
                       }
                     />
                   </Box>
-                  <Box className="flex flex-col mt-5">
+                  <Box className="flex flex-col">
+                    <Heading fontSize="lg" className="text-xl text-gray-600">Nsịbịdị</Heading>
+                    <DiffField
+                      path={`definitions.${index}.nsibidi`}
+                      diffRecord={diffRecord}
+                      fallbackValue={definition.nsibidi}
+                      renderNestedObject={(value) => (
+                        <span className={value ? 'akagu' : ''}>{value || 'N/A'}</span>
+                      )}
+                    />
+                  </Box>
+                  <Box className="flex flex-col">
                     <Heading fontSize="md" className="text-xl text-gray-600">Definitions</Heading>
                     {/* ts-expect-error */}
                     <ArrayDiffField


### PR DESCRIPTION
## Background
This PR enables Nsịbịdị to be associated with definition groups. Additionally, four new dialects are added to the platform: Amaifeke, Ihuoma, Achalla, and Anam