### PR TITLE
Run `sanitizeArray` on `associatedDefinitionsSchemas`

### DIFF
--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -109,9 +109,6 @@ export const updateExampleSuggestion = (
         // updatedExampleSuggestion = await applyAssociatedDefinitionSchemas(updatedExampleSuggestion);
       }
       return updatedExampleSuggestion.save();
-    })
-    .catch((err) => {
-      throw err;
     });
 };
 

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -78,6 +78,7 @@ const ExampleEditForm = ({
     const cleanedData = {
       ...record,
       ...data,
+      associatedDefinitionsSchemas: sanitizeArray(record.associatedDefinitionsSchemas || []),
       style: data.style.value,
       associatedWords: sanitizeArray(data.associatedWords),
     };

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
@@ -12,6 +12,7 @@ export const ExampleEditFormSchema = yup.object().shape({
     label: yup.mixed().oneOf(Object.values(ExampleStyle).map(({ label }) => label)),
   }).required(),
   associatedWords: yup.array().min(0).of(yup.string()),
+  associatedDefinitionsSchemas: yup.array().min(0).of(yup.string()),
   id: yup.string().optional(),
   originalExampleId: yup.string().nullable().optional(),
   pronunciation: yup.string().optional(),


### PR DESCRIPTION
## Background
A number of examples sentence suggestions are unable to be updated because there are documents that have a `[null]` value assigned to `associatedDefinitionsSchemas`