### PR TITLE
Avoid seek error

### DIFF
--- a/src/shared/primitives/FilePicker.tsx
+++ b/src/shared/primitives/FilePicker.tsx
@@ -80,7 +80,7 @@ const FilePicker = ({
   }, []);
 
   useEffect(() => {
-    if (mediaRef.current) {
+    if (mediaRef.current && typeof seekTime === 'number') {
       mediaRef.current.seekTo(seekTime);
     }
   }, [seekTime]);


### PR DESCRIPTION
## Background
Whenever a transcriber types in a timestamp, the audio player will automatically jump to that timestamp for easier listening