### PR TITLE
Remove `@ts-ignore` in WordShow

### DIFF
--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -269,15 +269,12 @@ const WordShow = (props: ShowProps): ReactElement => {
                   </Box>
                   <Box className="flex flex-col">
                     <Heading fontSize="md" className="text-xl text-gray-600">Definitions</Heading>
-                    {/* ts-expect-error */}
                     <ArrayDiffField
                       recordField={`definitions.${index}.definitions`}
                       recordFieldSingular="definition"
                       record={record}
-                      // ts-expect-error
                       originalWordRecord={originalWordRecord}
                     >
-                      {/* ts-expect-error */}
                       <ArrayDiff diffRecord={diffRecord} recordField={`definitions.${index}.definitions`} />
                     </ArrayDiffField>
                   </Box>
@@ -286,29 +283,23 @@ const WordShow = (props: ShowProps): ReactElement => {
             </Box>
             <Box className="flex flex-col mt-5">
               <Heading fontSize="lg" className="text-xl text-gray-600">Variations</Heading>
-              {/* @ts-ignore */}
               <ArrayDiffField
                 recordField="variations"
                 recordFieldSingular="variation"
                 record={record}
-                // @ts-ignore
                 originalWordRecord={originalWordRecord}
               >
-                {/* @ts-ignore */}
                 <ArrayDiff diffRecord={diffRecord} recordField="variations" />
               </ArrayDiffField>
             </Box>
             <Box className="flex flex-col mt-5">
               <Heading fontSize="lg" className="text-xl text-gray-600">Word Stems</Heading>
-              {/* @ts-ignore */}
               <ArrayDiffField
                 recordField="stems"
                 recordFieldSingular="stem"
                 record={record}
-                // @ts-ignore
                 originalWordRecord={originalWordRecord}
               >
-                {/* @ts-ignore */}
                 <ArrayDiff
                   diffRecord={diffRecord}
                   recordField="stems"
@@ -318,15 +309,12 @@ const WordShow = (props: ShowProps): ReactElement => {
             </Box>
             <Box className="flex flex-col mt-5">
               <Heading fontSize="lg" className="text-xl text-gray-600">Related Terms</Heading>
-              {/* @ts-ignore */}
               <ArrayDiffField
                 recordField="relatedTerms"
                 recordFieldSingular="relatedTerm"
                 record={record}
-                // @ts-ignore
                 originalWordRecord={originalWordRecord}
               >
-                {/* @ts-ignore */}
                 <ArrayDiff
                   diffRecord={diffRecord}
                   recordField="relatedTerms"
@@ -336,18 +324,14 @@ const WordShow = (props: ShowProps): ReactElement => {
             </Box>
             <Box className="flex flex-col mt-5">
               <Heading fontSize="lg" className="text-xl text-gray-600">Examples</Heading>
-              {/* @ts-ignore */}
               <ArrayDiffField
                 recordField="examples"
                 recordFieldSingular="example"
-                record={{ examples }}
-                // @ts-ignore
+                record={{ examples } as Interfaces.Word}
                 originalWordRecord={originalWordRecord}
               >
-                {/* @ts-ignore */}
                 <ExampleDiff
                   diffRecord={diffRecord}
-                  // @ts-ignore
                   resource={resource}
                 />
               </ArrayDiffField>
@@ -410,15 +394,12 @@ const WordShow = (props: ShowProps): ReactElement => {
               <Box className="flex flex-col space-y-6 mt-5">
                 <Box className="flex flex-col mt-5">
                   <Heading fontSize="lg" className="text-xl text-gray-600">Tags</Heading>
-                  {/* @ts-ignore */}
                   <ArrayDiffField
                     recordField="tags"
                     recordFieldSingular="tag"
                     record={record}
-                    // @ts-ignore
                     originalWordRecord={originalWordRecord}
                   >
-                    {/* @ts-ignore */}
                     <ArrayDiff diffRecord={diffRecord} recordField="tags" />
                   </ArrayDiffField>
                 </Box>

--- a/src/shared/components/views/shows/diffFields/ArrayDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/ArrayDiff.tsx
@@ -9,9 +9,9 @@ const ArrayDiff = (
     diffRecord,
     renderNestedObject,
   } : {
-    recordField: string,
-    value: any,
-    index: number,
+    recordField?: string,
+    value?: any,
+    index?: number,
     diffRecord: any,
     renderNestedObject?: ((value: any, hasChanged: boolean) => ReactElement | ReactElement[]),
   },

--- a/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
+++ b/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
@@ -16,7 +16,7 @@ const ArrayDiffField = (
     recordFieldSingular: string,
     record: Interfaces.Word,
     originalWordRecord: Interfaces.Word,
-    children: ReactElement[],
+    children: ReactElement[] | ReactElement,
   },
 ): ReactElement => {
   // If we have examples, we want to use the current record examples array instead of

--- a/src/shared/components/views/shows/diffFields/ExampleDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/ExampleDiff.tsx
@@ -11,8 +11,8 @@ const ExampleDiff = ({
   diffRecord,
   resource,
 } : {
-  value: ExampleClientData,
-  index: number,
+  value?: ExampleClientData,
+  index?: number,
   diffRecord: Record,
   resource: string,
 }): ReactElement => (


### PR DESCRIPTION
## Background
Fixes the underlying TS errors that were getting ignored by `@ts-ignore`