### PR TITLE
Avoid headword from having audio overwritten

### DIFF
--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -311,7 +311,6 @@ const WordEditForm = ({
         examples={examples}
         setExamples={setExamples}
         getValues={getValues}
-        setValue={setValue}
         errors={errors}
       />
       <Box className={`flex 

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
@@ -17,7 +17,6 @@ const Example = ({
   examples,
   example,
   getValues,
-  setValue,
   index,
 }: ExamplesInterface): ReactElement => {
   const [originalRecord, setOriginalRecord] = useState(null);
@@ -59,7 +58,6 @@ const Example = ({
 
   const handleSetPronunciation = (path, value) => {
     // Setting the react-hook-form value
-    setValue(path, value);
     const updatedExamples = [...examples];
     updatedExamples[index].pronunciation = value;
     // Setting the local WordEditForm value
@@ -141,7 +139,6 @@ const Example = ({
             const updateExamples = [...examples];
             updateExamples.splice(index, 1);
             setExamples(updateExamples);
-            setValue('examples', []);
           }}
           className="ml-3"
           icon={isExistingExample ? (() => <>🗄</>)() : (() => <>🗑</>)()}

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/ExamplesInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/ExamplesInterface.ts
@@ -5,7 +5,6 @@ interface ExamplesFormInterface {
   example: Example,
   setExamples: (value: any) => void,
   getValues: (key?: string) => any,
-  setValue: (key: string, value: any) => void,
   index: number,
   definitionGroupId?: string,
 };

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesForm.tsx
@@ -17,7 +17,6 @@ const ExamplesForm = ({
   examples,
   setExamples,
   getValues,
-  setValue,
   definitionGroupId,
 }: ExamplesFormInterface): ReactElement => (
   // List of examples associated with the definition schema
@@ -60,7 +59,6 @@ const ExamplesForm = ({
                 examples={examples}
                 example={example}
                 getValues={getValues}
-                setValue={setValue}
                 index={index}
                 definitionGroupId={definitionGroupId}
               />

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesFormInterface.ts
@@ -4,7 +4,6 @@ interface ExamplesFormInterface {
   examples: ExampleSuggestion[],
   setExamples: (value: any) => void,
   getValues: () => any,
-  setValue: (key: string, value: any) => void,
   definitionGroupId: string,
 };
 


### PR DESCRIPTION
## Background
Handle the edge case where the last example sentence is overwritting the headword