### PR TITLE
Show error messages for tags and dialectal variations in Word Edit Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "pretest": "yarn kill:project && node_modules/.bin/firebase functions:config:set runtime.env=\"cypress\" && yarn functions:env",
     "test": "yarn use:staging && node_modules/.bin/firebase emulators:exec 'npm-run-all -p -r start:docker:ci cypress:open' --only functions,firestore,hosting,pubsub",
     "test:firebase": "yarn use:staging && node_modules/.bin/firebase emulators:exec './node_modules/.bin/jest tests'",
+    "precypress:run": "node_modules/.bin/firebase functions:config:set runtime.env=\"cypress\"",
+    "precypress:open": "node_modules/.bin/firebase functions:config:set runtime.env=\"cypress\"",
     "test:ci": "npm-run-all -p -r dev cypress:run",
     "test:firebase:ci": "node_modules/.bin/firebase emulators:exec './node_modules/.bin/jest tests'",
     "jest:backend": "cross-env NODE_ENV=test jest --forceExit --runInBand --config=jest.backend.config.js" ,

--- a/src/backend/middleware/validateApprovals.ts
+++ b/src/backend/middleware/validateApprovals.ts
@@ -1,8 +1,9 @@
 import Requirements from 'src/backend/shared/constants/Requirements';
+import { isCypress } from '../config';
 
 export default (req, res, next) => {
   const { suggestionDoc } = req;
-  if (suggestionDoc.approvals.length < Requirements.MINIMUM_REQUIRED_APPROVALS) {
+  if (!isCypress && suggestionDoc.approvals.length < Requirements.MINIMUM_REQUIRED_APPROVALS) {
     throw new Error('Suggestion document doesn\'t have enough approvals to be merged.');
   }
   return next();

--- a/src/shared/components/Select/Select.tsx
+++ b/src/shared/components/Select/Select.tsx
@@ -60,7 +60,7 @@ const Select = ({
   const redirect = useRedirect();
   const toast = useToast();
   useFirebaseUid(setUid);
-  const hasEnoughApprovals = (
+  const hasEnoughApprovals = !!window.Cypress && (
     resource !== Collection.WORD_SUGGESTIONS
     || (record?.approvals?.length || 0) >= Requirements.MINIMUM_REQUIRED_APPROVALS
   );

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -133,6 +133,13 @@ const ExampleEditForm = ({
 
   useBeforeWindowUnload();
 
+  /* Scroll back to the top to let the editor know an error occurred */
+  useEffect(() => {
+    if (Object.keys(errors || {}).length) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [errors]);
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Box className="flex flex-col">

--- a/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
@@ -16,6 +16,7 @@ import AudioRecorder from '../../AudioRecorder';
 const DialectForm = ({
   index,
   record,
+  errors,
   control,
   getValues,
   setValue,
@@ -27,6 +28,11 @@ const DialectForm = ({
   const defaultDialectsValue = (dialect.dialects || []).map((value) => (
     { label: Dialects[value].label, value }
   ));
+  const errorMessage = (errors.dialects
+    ? errors.dialects[index]?.dialects?.message
+    || errors.dialects[index]?.message
+    || errors.dialects.message
+    : '').replace(`dialects[${index}].dialects`, 'Dialects');
 
   return (
     <Box
@@ -118,6 +124,9 @@ const DialectForm = ({
           />
         </Box>
       </Box>
+      {errors.dialects ? (
+        <p className="error relative">{errorMessage}</p>
+      ) : null}
     </Box>
   );
 };

--- a/src/shared/components/views/components/WordEditForm/DialectForm/DialectFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/DialectForm/DialectFormInterface.ts
@@ -4,6 +4,7 @@ import { WordDialect } from 'src/backend/controllers/utils/interfaces';
 
 interface DialectForm {
   index: number,
+  errors: { [key: string]: any },
   record: Record,
   control: Control,
   getValues: (key?: string) => any,

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -218,6 +218,13 @@ const WordEditForm = ({
     }
   }, []);
 
+  /* Scroll back to the top to let the editor know an error occurred */
+  useEffect(() => {
+    if (Object.keys(errors || {}).length) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [errors]);
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Box className="flex flex-col lg:flex-row lg:justify-between lg:items-start">
@@ -314,9 +321,9 @@ const WordEditForm = ({
         setValue={setValue}
         errors={errors}
       />
-      <Box className={`flex 
-        ${!areAllWordClassesInvalidForRelatedTerms ? 'lg:flex-row lg:space-x-3 lg:justify-between' : ''} 
-        flex-col`}
+      <Box className={'flex '
+        + `${!areAllWordClassesInvalidForRelatedTerms ? 'xl:flex-row xl:space-x-3 lg:justify-between' : ''} `
+        + 'flex-col'}
       >
         <VariationsForm
           variations={variations}

--- a/src/shared/components/views/components/WordEditForm/components/TagsForm/TagsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/TagsForm/TagsForm.tsx
@@ -7,10 +7,6 @@ import FormHeader from '../../../FormHeader';
 import TagsInterface from './TagsFormInterface';
 
 const TagsForm = ({ errors, control, record }: TagsInterface): ReactElement => {
-  const handleMultiSelectTags = (callback) => (selectedTags = []) => {
-    callback((selectedTags || []).map(({ value }) => value));
-  };
-
   const generateDefaultTags = () => {
     if (record?.tags) {
       return record.tags.map((tag) => WordTags[tag.toUpperCase()]);
@@ -32,7 +28,7 @@ const TagsForm = ({ errors, control, record }: TagsInterface): ReactElement => {
             render={({ onChange, ref }) => (
               <Select
                 ref={ref}
-                onChange={handleMultiSelectTags(onChange)}
+                onChange={onChange}
                 options={Object.values(WordTags)}
                 defaultValue={generateDefaultTags()}
                 isMulti
@@ -45,7 +41,7 @@ const TagsForm = ({ errors, control, record }: TagsInterface): ReactElement => {
         </Box>
       </Box>
       {errors.tags ? (
-        <p className="error relative">{errors.tags.message}</p>
+        <p className="error relative">{errors.tags[0]?.message || errors.tags.message}</p>
       ) : null}
     </Box>
   );


### PR DESCRIPTION
## Background
* Bypass two approval requirement for Cypress tests
* Render error message for tags input
* Render error messages for dialectal variations