### PR TITLE
Handle case where dialects doesn't exist

### DIFF
--- a/src/Core/Dashboard/components/UserStat/UserStat.tsx
+++ b/src/Core/Dashboard/components/UserStat/UserStat.tsx
@@ -97,7 +97,7 @@ const UserStat = ({
         const threeMonthsAgoWeek = moment().subtract(3, 'months').isoWeek();
         const labels = [];
         for (let i = threeMonthsAgoWeek; i <= threeMonthsAgoWeek + THREE_MONTH_WEEKS_COUNT; i += 1) {
-          labels.push(`Week of ${moment().isoWeek(i).format('MMMM Do')}`);
+          labels.push(`Week of ${moment().isoWeek(i).startOf('week').format('MMMM Do')}`);
         }
         const wordSuggestionData = {
           labels,

--- a/src/shared/components/views/shows/diffFields/DialectDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/DialectDiff.tsx
@@ -66,7 +66,7 @@ const DialectDiff = (
         >
           {(record.dialects as Interfaces.WordDialect[]).map(({
             variations = [],
-            dialects,
+            dialects = [],
             pronunciation,
             word: dialectalWord,
           }) => (


### PR DESCRIPTION
## Background
An error page would appear in the show view when there's no `dialects` field on the original record. The odd part was the default fallback value for a non-existent `dialects` array was an empty object