### PR TITLE
Fix `isAWSProduction` typo

### DIFF
--- a/src/Core/Collections/CorpusSuggestions/CorpusSuggestionList.tsx
+++ b/src/Core/Collections/CorpusSuggestions/CorpusSuggestionList.tsx
@@ -49,13 +49,13 @@ const ExampleSuggestionList = (props: ListProps): React.ReactElement => {
             <FunctionField
               label="Approvals"
               render={(record) => (
-                <span data-test="approval">{record.approvals.length}</span>
+                <span data-test="approval">{record.approvals?.length}</span>
               )}
             />
             <FunctionField
               label="Denials"
               render={(record) => (
-                <span data-test="denial">{record.denials.length}</span>
+                <span data-test="denial">{record.denials?.length}</span>
               )}
             />
             <IdField label="Id" source="id" />

--- a/src/backend/controllers/utils/MediaAPIs/CorpusMediaAPI.ts
+++ b/src/backend/controllers/utils/MediaAPIs/CorpusMediaAPI.ts
@@ -125,7 +125,7 @@ export const getUploadSignature = async ({ id, fileType } : { id: string, fileTy
   if (!id) {
     throw new Error('id must be provided');
   }
-  if (isCypress || !isisAWSProductionProduction) {
+  if (isCypress || !isAWSProductionProduction) {
     return {
       signedRequest: `mock-signed-request/${id}`,
       mediaUrl: `mock-url/${id}`,


### PR DESCRIPTION
## Background
Fix the `isAWSProduction` typo so audio and video files can be uploaded for corpus suggestions again