### PR TITLE
Make the  field immutable along with prevent waiting for `updateDocument`

### DIFF
--- a/src/backend/controllers/utils/MediaAPIs/CorpusMediaAPI.ts
+++ b/src/backend/controllers/utils/MediaAPIs/CorpusMediaAPI.ts
@@ -125,7 +125,7 @@ export const getUploadSignature = async ({ id, fileType } : { id: string, fileTy
   if (!id) {
     throw new Error('id must be provided');
   }
-  if (isCypress || !isAWSProductionProduction) {
+  if (isCypress || !isAWSProduction) {
     return {
       signedRequest: `mock-signed-request/${id}`,
       mediaUrl: `mock-url/${id}`,

--- a/src/backend/controllers/utils/index.ts
+++ b/src/backend/controllers/utils/index.ts
@@ -69,12 +69,12 @@ export const populateFirebaseUsers = async (
         })
     )));
   }));
-  const res = await findUser(docWithPopulateFirebaseUsers.authorId)
+  const authorRes = await findUser(docWithPopulateFirebaseUsers.authorId)
     .catch(() => {
       console.warn(`The user with the id ${docWithPopulateFirebaseUsers.authorId} doesn't exist in this database`);
       return fallbackUser;
     }) || {};
-  return assign(doc, { author: res });
+  return assign(doc, { author: authorRes });
 };
 
 /* Sorts all the docs based on the provided searchWord */

--- a/src/backend/controllers/wordSuggestions.ts
+++ b/src/backend/controllers/wordSuggestions.ts
@@ -5,7 +5,7 @@ import {
   Types,
 } from 'mongoose';
 import { Response, NextFunction } from 'express';
-import { assign, map } from 'lodash';
+import { assign, map, omit } from 'lodash';
 import { wordSuggestionSchema } from '../models/WordSuggestion';
 import { exampleSuggestionSchema } from '../models/ExampleSuggestion';
 import { packageResponse, handleQueries, populateFirebaseUsers } from './utils';
@@ -158,7 +158,7 @@ export const putWordSuggestion = (
           throw new Error('Unable to edit a merged word suggestion');
         }
 
-        delete data.authorId;
+        data = omit(data, ['authorId', 'author']);
         data = assignEditorsToDialects({
           clientData: data,
           compareData: wordSuggestion,

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -74,7 +74,12 @@ export const wordSuggestionSchema = new Schema(
     editorsNotes: { type: String, default: '' },
     userComments: { type: String, default: '' },
     authorEmail: { type: String, default: '' },
-    authorId: { type: String, default: '', index: true },
+    authorId: {
+      type: String,
+      default: '',
+      index: true,
+      immutable: true,
+    },
     stems: { type: [{ type: String }], default: [] },
     relatedTerms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },

--- a/src/backend/models/plugins/pronunciationHooks.ts
+++ b/src/backend/models/plugins/pronunciationHooks.ts
@@ -12,6 +12,9 @@ import removeAccents from 'src/backend/utils/removeAccents';
 /* If the client sent over blob data for pronunciations, it will be uploaded to AWS S3 */
 export const uploadWordPronunciation = (schema: mongoose.Schema<Interfaces.WordSuggestion>): void => {
   schema.pre('save', async function (next) {
+    if (this.isNew) {
+      console.log('Creating a brand new word suggestion document with the author Id of:', this.authorId);
+    }
     try {
       if (!this.skipPronunciationHook) {
         // @ts-ignore

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -45,8 +45,8 @@ export default {
     title: 'Approve Document',
     content: 'Are you sure you want to approve this document?',
     executeAction: async ({ record, resource } : { record: Record, resource: Collections }) : Promise<any> => {
-      await approveDocument({ resource, record: prepareRecord(record) });
-      return handleUpdateDocument({ type: ActionTypes.APPROVE, resource, record });
+      handleUpdateDocument({ type: ActionTypes.APPROVE, resource, record });
+      return approveDocument({ resource, record: prepareRecord(record) });
     },
     successMessage: 'Document has been approved 🙌🏾',
   },
@@ -55,8 +55,8 @@ export default {
     title: 'Deny Document',
     content: 'Are you sure you want to deny this document?',
     executeAction: async ({ record, resource }: { record: Record, resource: Collections }) : Promise<any> => {
-      await denyDocument({ resource, record: prepareRecord(record) });
-      return handleUpdateDocument({ type: ActionTypes.DENY, resource, record });
+      handleUpdateDocument({ type: ActionTypes.DENY, resource, record });
+      return denyDocument({ resource, record: prepareRecord(record) });
     },
     successMessage: 'Document has been denied 🙅🏾‍♀️',
   },
@@ -64,15 +64,15 @@ export default {
     type: 'Notify',
     title: 'Directly Notify Editors About Changes',
     content: 'Are you sure you want to notify editors?',
-    executeAction: ({ editorsNotes, record, resource }:
-    { editorsNotes: string, record: Record, resource: string }) : Promise<any> => (
+    executeAction: async ({ editorsNotes, record, resource }:
+    { editorsNotes: string, record: Record, resource: string }) : Promise<any> => {
       handleUpdateDocument({
         type: ActionTypes.NOTIFY,
         resource,
         record: prepareRecord({ ...record, editorsNotes }),
         includeEditors: true,
-      })
-    ),
+      });
+    },
     successMessage: 'Notification has been sent 📬',
   },
   [ActionTypes.MERGE]: {
@@ -84,11 +84,8 @@ export default {
       resource,
       collection,
     }: { record: Record | { id: string }, resource: Collections, collection: Collections }): Promise<any> => {
-      const [, res] = await Promise.all([
-        handleUpdateDocument({ type: ActionTypes.MERGE, resource, record }),
-        mergeDocument({ resource: collection, record }),
-      ]);
-      return res;
+      handleUpdateDocument({ type: ActionTypes.MERGE, resource, record });
+      return mergeDocument({ resource: collection, record });
     },
     successMessage: 'Document has been merged 🎉',
     hasLink: true,


### PR DESCRIPTION
## Background
This PR addresses the following bugs:
* The `authorId` is now marked as `immutable` within the Mongoose schema so it cannot be updated again once it's been set for the first time
* The `updateDocument` function is no longer `await`ed for performance improvements while approving or denying documents.