### PR TITLE
Make confirmation modal drawer on mobile and remove bottom whitespace

### DIFF
--- a/src/App/Theme.ts
+++ b/src/App/Theme.ts
@@ -65,6 +65,7 @@ const theme = createTheme({
       content: {
         backgroundColor: 'var(--chakra-colors-white) !important',
         marginLeft: 'var(--chakra-sizes-2)',
+        overflowY: 'hidden',
       },
       contentWithSidebar: {
         backgroundColor: 'var(--chakra-colors-white)',

--- a/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,14 +1,21 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import {
   AlertDialog,
   AlertDialogBody,
+  AlertDialogContent,
   AlertDialogFooter,
   AlertDialogHeader,
-  AlertDialogContent,
   AlertDialogOverlay,
   Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  useBreakpointValue,
 } from '@chakra-ui/react';
 import { isMobile } from 'react-device-detect';
 import ConfirmModalInterface from './ConfirmModalInterface';
@@ -24,44 +31,67 @@ const ConfirmModal = ({
   title,
   isDisabled,
   children,
-}: ConfirmModalInterface): ReactElement => (
-  <AlertDialog
-    closeOnEsc={false}
-    isOpen={isOpen}
-    onClose={onClose}
-  >
-    <AlertDialogOverlay />
-    <AlertDialogContent
-      position={isMobile ? 'fixed' : undefined}
-      right={isMobile ? '250px' : undefined}
-      opacity={isOpen ? '1 !important' : 0}
+}: ConfirmModalInterface): ReactElement => {
+  const ContainerComponent = useBreakpointValue({ base: Drawer, md: AlertDialog });
+  const ContainerOverlay = useBreakpointValue({ base: DrawerOverlay, md: AlertDialogOverlay });
+  const ContainerContent = useBreakpointValue({ base: DrawerContent, md: AlertDialogContent });
+  const ContainerHeader = useBreakpointValue({ base: DrawerHeader, md: AlertDialogHeader });
+  const ContainerBody = useBreakpointValue({ base: DrawerBody, md: AlertDialogBody });
+  const ContainerFooter = useBreakpointValue({ base: DrawerFooter, md: AlertDialogFooter });
+  const cancelRef = useRef();
+  return (
+    <ContainerComponent
+      closeOnEsc={false}
+      isOpen={isOpen}
+      onClose={onClose}
+      leastDestructiveRef={cancelRef}
+      placement="bottom"
     >
-      <AlertDialogHeader fontSize="lg" fontWeight="bold">
-        {title}
-      </AlertDialogHeader>
+      <ContainerOverlay
+        style={{
+          left: 'auto',
+          right: 0,
+          top: 'auto',
+          bottom: 0,
+        }}
+      />
+      <ContainerContent
+        position={isMobile ? 'fixed' : undefined}
+        right={isMobile ? '250px' : undefined}
+        opacity={isOpen ? '1 !important' : 0}
+        style={{ left: 'auto !important' }}
+      >
+        <ContainerHeader fontSize="lg" fontWeight="bold">
+          {title}
+        </ContainerHeader>
 
-      <AlertDialogBody>
-        {children}
-      </AlertDialogBody>
+        <ContainerBody>
+          {children}
+        </ContainerBody>
 
-      <AlertDialogFooter>
-        <Button onClick={onClose} data-test="confirmation-cancel-button">
-          {cancel}
-        </Button>
-        <Button
-          colorScheme={confirmColorScheme}
-          onClick={isDisabled ? noop : onConfirm}
-          isLoading={isConfirming}
-          disabled={isDisabled}
-          ml={3}
-          data-test="confirmation-confirm-button"
-        >
-          {confirm}
-        </Button>
-      </AlertDialogFooter>
-    </AlertDialogContent>
-  </AlertDialog>
-);
+        <ContainerFooter>
+          <Button
+            ref={cancelRef}
+            onClick={onClose}
+            data-test="confirmation-cancel-button"
+          >
+            {cancel}
+          </Button>
+          <Button
+            colorScheme={confirmColorScheme}
+            onClick={isDisabled ? noop : onConfirm}
+            isLoading={isConfirming}
+            disabled={isDisabled}
+            ml={3}
+            data-test="confirmation-confirm-button"
+          >
+            {confirm}
+          </Button>
+        </ContainerFooter>
+      </ContainerContent>
+    </ContainerComponent>
+  );
+};
 
 ConfirmModal.propTypes = {
   onClose: PropTypes.func.isRequired,


### PR DESCRIPTION
## Background
This PR removes the whitespace that's present beneath the entire platform on both desktop and mobile. Additionally, the Confirmation modal will become a Drawer when on mobile for improved readability when confirming any editor action.