### PR TITLE
Update models to support ObjectIds for stems

### DIFF
--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -66,7 +66,7 @@ export const wordSchema = new Schema({
     }), {}),
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },
-  stems: { type: [{ type: String }], default: [] },
+  stems: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   relatedTerms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -80,7 +80,7 @@ export const wordSuggestionSchema = new Schema(
       index: true,
       immutable: true,
     },
-    stems: { type: [{ type: String }], default: [] },
+    stems: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     relatedTerms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },


### PR DESCRIPTION
## Background
Handle `stems` and ObjectIds and handle the edge case where `stems` or `relatedTerms` are not valid ObjectIds.