### PR TITLE
Get word suggestions with dialect editors

### DIFF
--- a/src/Core/Dashboard/components/LacunaProgress/LacunaProgress.tsx
+++ b/src/Core/Dashboard/components/LacunaProgress/LacunaProgress.tsx
@@ -25,7 +25,6 @@ const LacunaProgress = ({
   totalCompletedWords: number,
   totalCompletedExamples: number,
   totalDialectalVariations: number,
-  wordSuggestionMergeStats?: { datasets: [{ data: number[] }] },
   exampleSuggestionMergeStat?: { datasets: [{ data: number[] }] },
   dialectalVariationMergeStats?: { datasets: [{ data: number[] }] },
 }): ReactElement => {
@@ -109,7 +108,6 @@ const LacunaProgress = ({
 };
 
 LacunaProgress.defaultProps = {
-  wordSuggestionMergeStats: { datasets: [{ data: [] }] },
   exampleSuggestionMergeStat: { datasets: [{ data: [] }] },
   dialectalVariationMergeStats: { datasets: [{ data: [] }] },
 };

--- a/src/Core/Dashboard/components/UserStat/UserStat.tsx
+++ b/src/Core/Dashboard/components/UserStat/UserStat.tsx
@@ -61,7 +61,6 @@ const createChartOptions = (title) => ({
   },
 });
 
-const wordSuggestionsChartOptions = createChartOptions('Merged Word Suggestions');
 const exampleSuggestionsChartOptions = createChartOptions('Merged Example Suggestions');
 const dialectalVariationsChartOptions = createChartOptions('Merged Dialectal Variations');
 const THREE_MONTH_WEEKS_COUNT = 12;
@@ -80,7 +79,6 @@ const UserStat = ({
   totalDialectalVariations: number,
 }): ReactElement => {
   const [userStats, setUserStats] = useState(null);
-  const [wordSuggestionMergeStats, setWordSuggestionMergeStats] = useState(null);
   const [exampleSuggestionMergeStats, setExampleSuggestionMergeStats] = useState(null);
   const [dialectalVariationMergeStats, setDialectalVariationMergeStats] = useState(null);
   const { permissions } = usePermissions();
@@ -93,26 +91,12 @@ const UserStat = ({
       if (uid) {
         const { json: merges } = await network(`/stats/users/${uid}/merge`);
         const {
-          wordSuggestionMerges,
           exampleSuggestionMerges,
           dialectalVariationMerges,
         } = merges;
         const labels = times(THREE_MONTH_WEEKS_COUNT, (index) => (
           `Week of ${moment().startOf('week').subtract(index, 'week').format('MMMM Do')}`
         )).reverse();
-        const wordSuggestionData = {
-          labels,
-          datasets: [
-            {
-              label: 'Word Suggestion Merges',
-              data: sortMerges(wordSuggestionMerges),
-              backgroundColor: '#48825D',
-              borderWidth: 2,
-              borderColor: '#18532D',
-              borderRadius: 10,
-            },
-          ],
-        };
         const exampleSuggestionData = {
           labels,
           datasets: [
@@ -139,7 +123,6 @@ const UserStat = ({
             },
           ],
         };
-        setWordSuggestionMergeStats(wordSuggestionData);
         setExampleSuggestionMergeStats(exampleSuggestionData);
         setDialectalVariationMergeStats(dialectalVariationData);
       }
@@ -152,7 +135,6 @@ const UserStat = ({
         totalCompletedWords={totalCompletedWords}
         totalCompletedExamples={totalCompletedExamples}
         totalDialectalVariations={totalDialectalVariations}
-        wordSuggestionMergeStats={wordSuggestionMergeStats}
         exampleSuggestionMergeStat={exampleSuggestionMergeStats}
         dialectalVariationMergeStats={dialectalVariationMergeStats}
       />
@@ -201,9 +183,6 @@ const UserStat = ({
                 </AccordionButton>
               </ChakraTooltip>
               <AccordionPanel>
-                {wordSuggestionMergeStats ? (
-                  <Bar options={wordSuggestionsChartOptions} data={wordSuggestionMergeStats} />
-                ) : null}
                 {exampleSuggestionMergeStats ? (
                   <Bar options={exampleSuggestionsChartOptions} data={exampleSuggestionMergeStats} />
                 ) : null}

--- a/src/__tests__/stats.test.ts
+++ b/src/__tests__/stats.test.ts
@@ -29,7 +29,6 @@ describe('MongoDB Stats', () => {
 
     it('should get all user merge stats', async () => {
       const res = await getUserMergeStats(AUTH_TOKEN.MERGER_AUTH_TOKEN);
-      expect(res.body.wordSuggestionMerges).not.toBeUndefined();
       expect(res.body.exampleSuggestionMerges).not.toBeUndefined();
       expect(res.body.dialectalVariationMerges).not.toBeUndefined();
     });

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -109,7 +109,7 @@ wordSuggestionSchema.index({
 
 wordSuggestionSchema.index({
   mergedBy: 1,
-  userInteractions: 1,
+  'dialects.editor': 1,
   updatedAt: -1,
 }, {
   name: 'Merged word suggestion index',


### PR DESCRIPTION
## Background
Use `dialects.editor` instead of `userInteractions` to grat all related word suggestions to count dialectal variations