### PR TITLE
Io/fix nsibidi bugs

### DIFF
--- a/src/backend/controllers/utils/queries.ts
+++ b/src/backend/controllers/utils/queries.ts
@@ -53,9 +53,13 @@ const generateSearchFilters = (filters: { [key: string]: string }, uid: string):
         break;
       case 'nsibidi':
         if (value) {
-          allFilters.$and = [{ nsibidi: { $ne: null } }, { nsibidi: { $ne: '' } }];
+          allFilters.$and = [{ 'definitions.nsibidi': { $ne: null } }, { 'definitions.nsibidi': { $ne: '' } }];
         } else {
-          allFilters.$or = [...allFilters.$or, { nsibidi: { $eq: null } }, { nsibidi: { $eq: '' } }];
+          allFilters.$or = [
+            ...allFilters.$or,
+            { 'definitions.nsibidi': { $eq: null } },
+            { 'definitions.nsibidi': { $eq: '' } },
+          ];
         }
         break;
       case WordAttributes.IS_CONSTRUCTED_TERM.value:

--- a/src/shared/components/ArrayPreview.tsx
+++ b/src/shared/components/ArrayPreview.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { get, truncate } from 'lodash';
-import { Text } from '@chakra-ui/react';
+import { Text, Tooltip, chakra } from '@chakra-ui/react';
 import WordClass from '../constants/WordClass';
 import { ArrayPreviewProps } from '../interfaces';
 import ResolvedWord from './ResolvedWord';
@@ -20,6 +20,11 @@ const populateList = (items = [], source) => {
         <>
           <Text className="italic text-gray-700">
             {get(WordClass[item.wordClass], 'label') || '[UPDATE PART OF SPEECH]'}
+            {get(item, 'nsibidi') ? (
+              <Tooltip label={get(item, 'nsibidi')}>
+                <chakra.span className="akagu not-italic cursor-default" ml={3}>{get(item, 'nsibidi')}</chakra.span>
+              </Tooltip>
+            ) : null}
           </Text>
           {(item.definitions || []).map((definition) => (
             <Text>{truncate(definition, { length: 120 }) || 'no definition'}</Text>

--- a/src/shared/components/WordPanel.tsx
+++ b/src/shared/components/WordPanel.tsx
@@ -52,25 +52,34 @@ const WordPanel = ({ record }: { record?: Record }): ReactElement => (
         <Text fontSize="xl" className="font-bold">Word</Text>
         <Text>{get(record, 'word')}</Text>
       </Box>
-      <Box>
-        <Text fontSize="xl" className="font-bold">Nsịbịdị</Text>
-        <Text
-          className={record.nsibidi ? 'akagu' : 'italic text-gray-600'}
-        >
-          {get(record, 'nsibidi') || 'No Nsịbịdị'}
-        </Text>
-      </Box>
     </Box>
     <Box className="flex flex-row items-start space-x-8">
       <Box className="space-y-2">
         <Box>
           <Text fontSize="xl" className="font-bold">Definition Groups</Text>
           <Box>
-            {(get(record, 'definitions') || []).map(({ wordClass, definitions, id }) => (
+            {(get(record, 'definitions') || []).map(({
+              wordClass,
+              definitions,
+              nsibidi,
+              id,
+            }) => (
               <Box key={id}>
-                <Box>
-                  <Text fontSize="lg" className="font-bold">Part of Speech</Text>
-                  <Text>{get(WordClass[wordClass], 'label')}</Text>
+                <Box className="flex flex-row space-x-3 items-start">
+                  <Box>
+                    <Text fontSize="lg" className="font-bold">Part of Speech</Text>
+                    <Text>{get(WordClass[wordClass], 'label')}</Text>
+                  </Box>
+                  <Box>
+                    <Text fontSize="lg" className="font-bold">Nsịbịdị</Text>
+                    <Tooltip label={nsibidi}>
+                      <Text
+                        className={`${nsibidi ? 'akagu' : 'italic text-gray-600'} cursor-default`}
+                      >
+                        {nsibidi || 'No Nsịbịdị'}
+                      </Text>
+                    </Tooltip>
+                  </Box>
                 </Box>
                 <Text fontSize="lg" className="font-bold">Definitions</Text>
                 {definitions?.length ? definitions.map((definition, index) => (
@@ -136,7 +145,7 @@ const WordPanel = ({ record }: { record?: Record }): ReactElement => (
       <Text fontSize="lg" className="font-bold">Examples</Text>
       <Box className="space-y-2">
         {get(record, 'examples.length') ? record.examples.map((example, index) => {
-          const { igbo, english } = example;
+          const { igbo, english, nsibidi } = example;
           return (
             <>
               <Box className="flex flex-row items-center space-x-2">
@@ -144,6 +153,7 @@ const WordPanel = ({ record }: { record?: Record }): ReactElement => (
                 <Box>
                   <Text>{igbo}</Text>
                   <Text className="italic text-gray-600">{english}</Text>
+                  <Text className={nsibidi ? 'akagu' : 'italic text-gray-600'}>{nsibidi || 'No Nsịbịdị'}</Text>
                 </Box>
               </Box>
               <AudioRecordingPreview record={example} />

--- a/src/shared/components/actions/ListActions.tsx
+++ b/src/shared/components/actions/ListActions.tsx
@@ -120,7 +120,10 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
   useEffect(() => {
     const updatedFilters: { wordClass?: string[] } = currentFilters.reduce(
       (allFilters, filter) => {
-        if (filter !== 'word' && filter !== 'example') {
+        if (filter === 'noNsibidi') {
+          // @ts-expect-error nsibidi
+          allFilters.nsibidi = false;
+        } else if (filter !== 'word' && filter !== 'example') {
           allFilters[filter] = true;
         }
         return allFilters;
@@ -240,6 +243,9 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
                         </MenuItemOption>,
                         <MenuItemOption value="nsibidi" key="nsibidi">
                           Has Nsịbịdị
+                        </MenuItemOption>,
+                        <MenuItemOption value="noNsibidi" key="noNsibidi">
+                          Has No Nsịbịdị
                         </MenuItemOption>,
                         <MenuItemOption
                           value={WordAttributes.IS_CONSTRUCTED_TERM.value}


### PR DESCRIPTION
## Background
This PR focuses on address bugs that surround Nsịbịdị on the editor platform. Specifically, making filtering easier and showing Nsịbịdị in the list and quick show view.

### Quick Word View shows Nsịbịdị
<img width="899" alt="Screen Shot 2023-02-17 at 11 19 04 AM" src="https://user-images.githubusercontent.com/16169291/219708279-dd4a6533-7b7a-458b-a3b4-a32341553b35.png">

### List View includes Nsịbịdị
<img width="364" alt="Screen Shot 2023-02-17 at 11 18 47 AM" src="https://user-images.githubusercontent.com/16169291/219708281-e3679128-b23f-44ab-a0e0-ef325656a217.png">

### New Has No Nsịbịdị filtering option
<img width="363" alt="Screen Shot 2023-02-17 at 11 18 31 AM" src="https://user-images.githubusercontent.com/16169291/219708282-97a10c68-5dc1-437f-831f-ce949186d1d6.png">
