### PR TITLE
Io/warn changing headword

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "react-draggable": "^4.4.3",
     "react-firebaseui": "^6.0.0",
     "react-hook-form": "^6.9.6",
-    "react-loadable": "^5.5.0",
     "react-player": "2.11.0",
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,18 +1,14 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
-import Loadable from 'react-loadable';
 import { pick } from 'lodash';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import IgboAPIAdmin from './IgboAPIAdmin';
 import authProvider from '../utils/authProvider';
 import PlatformLoader from './PlatformLoader';
 import ChakraTheme from './ChakraTheme';
 import '../styles.css';
 
 const auth = getAuth();
-const AsyncIgboAPIAdmin = Loadable({
-  loader: () => import('./IgboAPIAdmin'),
-  loading: PlatformLoader,
-});
 
 const App = (): React.ReactElement => {
   const [client, setClient] = useState(false);
@@ -59,7 +55,7 @@ const App = (): React.ReactElement => {
     }
   }, []);
 
-  return !client ? <PlatformLoader /> : <AsyncIgboAPIAdmin />;
+  return !client ? <PlatformLoader error={null} /> : <IgboAPIAdmin />;
 };
 
 export default (props: any): ReactElement => (

--- a/src/App/ChakraTheme.ts
+++ b/src/App/ChakraTheme.ts
@@ -197,6 +197,11 @@ export default extendTheme({
         variant: '',
       },
     },
+    Button: {
+      baseStyle: {
+        fontFamily: 'Silka',
+      },
+    },
     Textarea: {
       baseStyle: {
         backgroundColor: 'gray.200',

--- a/src/Core/Collections/IgboSoundbox/components/Home.tsx
+++ b/src/Core/Collections/IgboSoundbox/components/Home.tsx
@@ -27,7 +27,6 @@ const IgboSoundboxHome = ({
   }, []);
   return (
     <Box className="gradient-background">
-      {/* <PersonalStats /> */}
       <Box className="w-full h-full flex flex-col xl:flex-row justify-center items-center space-y-12 xl:space-y-0">
         <OptionCard
           title="Record your voice"

--- a/src/Core/Dashboard/__mocks__/network.tsx
+++ b/src/Core/Dashboard/__mocks__/network.tsx
@@ -1,0 +1,48 @@
+import StatTypes from 'src/backend/shared/constants/StatTypes';
+
+export default jest.fn(async (url = '') => {
+  if (url.startsWith('/stats/full')) {
+    return ({
+      body: JSON.stringify(Object.values(StatTypes).reduce((finalObject, value) => ({
+        ...finalObject,
+        [value]: { value: 0 },
+      }), [])),
+    });
+  }
+
+  if (url.startsWith('/stats/users/') && url.endsWith('/merge')) {
+    return ({
+      json: {
+        exampleSuggestionMerges: {},
+        dialectalVariationMerges: {},
+        currentMonthMerges: {},
+      },
+    });
+  }
+
+  if (url.startsWith('/stats/users/')) {
+    return ({
+      json: {
+        approvedWordSuggestionsCount: 0,
+        deniedWordSuggestionsCount: 0,
+        approvedExampleSuggestionsCount: 0,
+        deniedExampleSuggestionsCount: 0,
+        authoredWordSuggestionsCount: 0,
+        authoredExampleSuggestionsCount: 0,
+        mergedWordSuggestionsCount: 0,
+        mergedExampleSuggestionsCount: 0,
+        mergedByUserWordSuggestionsCount: 0,
+        mergedByUserExampleSuggestionsCount: 0,
+        currentEditingWordSuggestionsCount: 0,
+        currentEditingExampleSuggestionsCount: 0,
+      },
+    });
+  }
+  return {
+    json: {
+      exampleSuggestionMerges: {},
+      dialectalVariationMerges: {},
+      currentMonthMerges: {},
+    },
+  };
+});

--- a/src/Core/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/Core/Dashboard/__tests__/Dashboard.test.tsx
@@ -4,6 +4,7 @@ import Dashboard from 'src/Core/Dashboard';
 import TestContext from 'src/__tests__/components/TestContext';
 
 jest.mock('src/shared/DataCollectionAPI');
+jest.mock('src/Core/Dashboard/network');
 
 it('render the dashboard', async () => {
   const { findByText, findAllByText } = render(<TestContext><Dashboard /></TestContext>);

--- a/src/shared/__mocks__/API.ts
+++ b/src/shared/__mocks__/API.ts
@@ -18,6 +18,8 @@ export const getWords = jest.fn(async () => ([
   },
 ]));
 
+export const getWordSuggestions = jest.fn(async () => ([]));
+
 export const resolveWord = jest.fn(async () => ({
   word: 'resolved word',
   id: '567',

--- a/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Button,
   IconButton,
+  Text,
   Tooltip,
   useToast,
 } from '@chakra-ui/react';
@@ -24,6 +25,7 @@ const AudioRecorder = ({
   originalRecord: originalRecordProp,
   formTitle,
   formTooltip,
+  warningMessage,
 }: {
   path: string,
   getFormValues: (key: string) => any,
@@ -32,6 +34,7 @@ const AudioRecorder = ({
   originalRecord: Record,
   formTitle?: string,
   formTooltip?: string,
+  warningMessage?: string,
 }): ReactElement => {
   const originalRecord = record.originalWordId || record.originalExampleId
     ? originalRecordProp
@@ -213,6 +216,11 @@ const AudioRecorder = ({
             </Box>
           )}
         </Box>
+        {warningMessage ? (
+          <Box mt={2} p={2} backgroundColor="yellow.100" borderRadius="md">
+            <Text color="yellow.700">{warningMessage}</Text>
+          </Box>
+        ) : null}
       </Box>
     </Box>
   );

--- a/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Tooltip,
   useToast,
+  chakra,
 } from '@chakra-ui/react';
 import { RepeatIcon } from '@chakra-ui/icons';
 import { DEFAULT_EXAMPLE_RECORD, DEFAULT_WORD_RECORD } from 'src/shared/constants';
@@ -90,10 +91,10 @@ const AudioRecorder = ({
             controls
           />
           {shouldRenderNewPronunciationLabel() && (
-            <span className="text-green-500 mt-2">New pronunciation recorded</span>
+            <chakra.span className="text-green-500 mt-2" fontFamily="Silka">New pronunciation recorded</chakra.span>
           )}
         </Box>
-      ) : <span className="text-gray-700 italic">No audio pronunciation</span>}
+      ) : <chakra.span className="text-gray-700 italic" fontFamily="Silka">No audio pronunciation</chakra.span>}
     </Box>
   );
 

--- a/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
+++ b/src/shared/components/views/components/AudioRecorder/AudioRecorder.tsx
@@ -217,7 +217,13 @@ const AudioRecorder = ({
           )}
         </Box>
         {warningMessage ? (
-          <Box mt={2} p={2} backgroundColor="yellow.100" borderRadius="md">
+          <Box
+            mt={2}
+            p={2}
+            backgroundColor="yellow.100"
+            borderRadius="md"
+            data-test="audio-recording-warning-message"
+          >
             <Text color="yellow.700">{warningMessage}</Text>
           </Box>
         ) : null}

--- a/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/DialectForm/DialectForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { useState, ReactElement } from 'react';
 import {
   Box,
   Heading,
@@ -24,6 +24,7 @@ const DialectForm = ({
   dialects,
   originalRecord,
 }: DialectFormInterface) : ReactElement => {
+  const [warningMessage, setWarningMessage] = useState('');
   const dialect = dialects[index];
   const defaultDialectsValue = (dialect.dialects || []).map((value) => (
     { label: Dialects[value].label, value }
@@ -33,6 +34,12 @@ const DialectForm = ({
     || errors.dialects[index]?.message
     || errors.dialects.message
     : '').replace(`dialects[${index}].dialects`, 'Dialects');
+
+  const handleWarningMessage = (e) => {
+    setWarningMessage((record?.word || '') !== e.target.value
+      ? 'A change in this dialect has been detected. Please consider re-recording the audio to match.'
+      : '');
+  };
 
   return (
     <Box
@@ -59,7 +66,10 @@ const DialectForm = ({
           <Controller
             render={({ onChange }) => (
               <Input
-                onChange={onChange}
+                onChange={(e) => {
+                  handleWarningMessage(e);
+                  return onChange(e);
+                }}
                 placeholder="Dialectal variation"
                 data-test={`dialects-${index}-word-input`}
                 defaultValue={dialect.word || ''}
@@ -89,6 +99,7 @@ const DialectForm = ({
                 }}
                 record={record}
                 originalRecord={originalRecord}
+                warningMessage={warningMessage}
               />
             )}
             name={`dialects.${index}.pronunciation`}

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -95,6 +95,7 @@ const WordEditForm = ({
   const [relatedTerms, setRelatedTerms] = useState(record.relatedTerms || []);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [dialects, setDialects] = useState(record.dialects);
+  const [warningMessage, setWarningMessage] = useState('');
   const notify = useNotify();
   const redirect = useRedirect();
   const toast = useToast();
@@ -103,6 +104,12 @@ const WordEditForm = ({
   const isAnyDefinitionGroupAVerb = watchedWordClasses.some((watchedWordClass) => isVerb(watchedWordClass));
   const areAllWordClassesInvalidForRelatedTerms = watchedWordClasses.every((watchedWordClass) => (
     invalidRelatedTermsWordClasses.includes(watchedWordClass?.value)));
+
+  const handleWarningMessage = (e) => {
+    setWarningMessage((record?.word || '') !== e.target.value
+      ? 'A change in the headword has been detected. Please consider re-recording the audio to match.'
+      : '');
+  };
 
   /* Gets the original example id and associated words to prepare to send to the API */
   const sanitizeExamples = (examples = []) => {
@@ -254,6 +261,7 @@ const WordEditForm = ({
               record={record}
               getValues={getValues}
               watch={watch}
+              onChange={handleWarningMessage}
             />
             <TagsForm
               errors={errors}
@@ -270,6 +278,7 @@ const WordEditForm = ({
                   setPronunciation={setValue}
                   record={record}
                   originalRecord={originalRecord}
+                  warningMessage={warningMessage}
                 />
               )}
               defaultValue={record.pronunciation || ''}

--- a/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TestContext from 'src/__tests__/components/TestContext';
-
 import Collections from 'src/shared/constants/Collections';
 import Views from 'src/shared/constants/Views';
 import WordEditForm from '../WordEditForm';
+
+jest.mock('src/Core/Dashboard/network');
 
 describe('Word Edit', () => {
   beforeEach(() => {
@@ -114,5 +115,21 @@ describe('Word Edit', () => {
     userEvent.click(await findByText('retrieved word'));
     await findByText('ADJ');
     await findByText('resolved word definition');
+  });
+
+  it('show the updated headword warning message within audio recorder', async () => {
+    const { findByTestId } = render(
+      <TestContext>
+        <WordEditForm
+          view={Views.EDIT}
+          resource={Collections.WORD_SUGGESTIONS}
+          record={{ id: '123', definitions: [{ wordClass: 'NNC', definitions: [] }] }}
+          save={() => {}}
+          history={{}}
+        />
+      </TestContext>,
+    );
+    userEvent.type(await findByTestId('word-input'), 'new headword');
+    await findByTestId('audio-recording-warning-message');
   });
 });

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesForm.tsx
@@ -46,7 +46,7 @@ const ExamplesForm = ({
           <h2>
             <AccordionButton>
               <Box flex="1" textAlign="left">
-                {`Examples (${examples.length})`}
+                <Text fontFamily="Silka">{`Examples (${examples.length})`}</Text>
               </Box>
               <AccordionIcon />
             </AccordionButton>
@@ -64,7 +64,7 @@ const ExamplesForm = ({
               />
             )) : (
               <Box className="flex w-full justify-center mb-2">
-                <Text className="italic text-gray-700">No examples</Text>
+                <Text className="italic text-gray-700" fontFamily="Silka">No examples</Text>
               </Box>
             )}
           </AccordionPanel>

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordAttributes.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordAttributes.tsx
@@ -1,5 +1,10 @@
 import React, { ReactElement } from 'react';
-import { Box, Checkbox, Tooltip } from '@chakra-ui/react';
+import {
+  Box,
+  Checkbox,
+  Tooltip,
+  chakra,
+} from '@chakra-ui/react';
 import { Controller } from 'react-hook-form';
 import WordAttributes from 'src/backend/shared/constants/WordAttributes';
 import * as Interfaces from 'src/backend/controllers/utils/interfaces';
@@ -34,7 +39,7 @@ const HeadwordAttributes = ({
           data-test={`${WordAttributes.IS_STANDARD_IGBO.value}-checkbox`}
           size="lg"
         >
-          <span className="font-bold">{WordAttributes.IS_STANDARD_IGBO.label}</span>
+          <chakra.span className="font-bold" fontFamily="Silka">{WordAttributes.IS_STANDARD_IGBO.label}</chakra.span>
         </Checkbox>
       )}
       defaultValue={record.attributes?.[WordAttributes.IS_STANDARD_IGBO.value]
@@ -57,7 +62,7 @@ const HeadwordAttributes = ({
               data-test={`${WordAttributes.IS_ACCENTED.value}-checkbox`}
               size="lg"
             >
-              <span className="font-bold">{WordAttributes.IS_ACCENTED.label}</span>
+              <chakra.span className="font-bold" fontFamily="Silka">{WordAttributes.IS_ACCENTED.label}</chakra.span>
             </Checkbox>
           )}
           defaultValue={!!(isHeadwordAccented
@@ -83,7 +88,7 @@ const HeadwordAttributes = ({
               data-test={`${WordAttributes.IS_SLANG.label}-checkbox`}
               size="lg"
             >
-              <span className="font-bold">{WordAttributes.IS_SLANG.label}</span>
+              <chakra.span className="font-bold" fontFamily="Silka">{WordAttributes.IS_SLANG.label}</chakra.span>
             </Checkbox>
           )}
           defaultValue={record.attribute?.[WordAttributes.IS_SLANG.value]
@@ -113,7 +118,9 @@ const HeadwordAttributes = ({
               data-test={`${WordAttributes.IS_CONSTRUCTED_TERM.label}-checkbox`}
               size="lg"
             >
-              <span className="font-bold">{WordAttributes.IS_CONSTRUCTED_TERM.label}</span>
+              <chakra.span className="font-bold" fontFamily="Silka">
+                {WordAttributes.IS_CONSTRUCTED_TERM.label}
+              </chakra.span>
             </Checkbox>
           )}
           defaultValue={isConstructedPollTerm || record.attribute?.[WordAttributes.IS_CONSTRUCTED_TERM.value]
@@ -135,7 +142,9 @@ const HeadwordAttributes = ({
               data-test={`${WordAttributes.IS_BORROWED_TERM.label}-checkbox`}
               size="lg"
             >
-              <span className="font-bold">{WordAttributes.IS_BORROWED_TERM.label}</span>
+              <chakra.span className="font-bold" fontFamily="Silka">
+                {WordAttributes.IS_BORROWED_TERM.label}
+              </chakra.span>
             </Checkbox>
           )}
           defaultValue={record.attribute?.[WordAttributes.IS_BORROWED_TERM.value]
@@ -160,7 +169,7 @@ const HeadwordAttributes = ({
               data-test={`${WordAttributes.IS_STEM.label}-checkbox`}
               size="lg"
             >
-              <span className="font-bold">{WordAttributes.IS_STEM.label}</span>
+              <chakra.span className="font-bold" fontFamily="Silka">{WordAttributes.IS_STEM.label}</chakra.span>
             </Checkbox>
           )}
           defaultValue={record.attribute?.[WordAttributes.IS_STEM.value]
@@ -184,7 +193,7 @@ const HeadwordAttributes = ({
               data-test={`${WordAttributes.IS_COMMON.label}-checkbox`}
               size="lg"
             >
-              <span className="font-bold">{WordAttributes.IS_COMMON.label}</span>
+              <chakra.span className="font-bold" fontFamily="Silka">{WordAttributes.IS_COMMON.label}</chakra.span>
             </Checkbox>
           )}
           defaultValue={record.attribute?.[WordAttributes.IS_COMMON.value]

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -32,6 +32,7 @@ const HeadwordForm = ({
   record,
   getValues,
   watch,
+  onChange,
 }: HeadwordInterface): ReactElement => {
   const [flags, setFlags] = useState({});
   const isHeadwordAccented = (record.word || '').normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g);
@@ -69,6 +70,10 @@ const HeadwordForm = ({
         render={(props) => (
           <Input
             {...props}
+            onChange={(e) => {
+              onChange(e);
+              return props.onChange(e);
+            }}
             placeholder="i.e. ụgbo ala, biko, igwe, mmiri"
             data-test="word-input"
           />

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -20,7 +20,7 @@ const generateIPALabel = (word = '') => {
   });
   return (
     <Text>
-      <chakra.span fontWeight="bold">Generated IPA: </chakra.span>
+      <chakra.span fontWeight="bold" fontFamily="Silka">Generated IPA: </chakra.span>
       {IPA}
     </Text>
   );
@@ -84,10 +84,10 @@ const HeadwordForm = ({
       />
       <details className="mt-4 cursor-pointer">
         <summary>
-          <chakra.span fontWeight="bold">Advanced Headword Options</chakra.span>
+          <chakra.span fontWeight="bold" fontFamily="Silka">Advanced Headword Options</chakra.span>
         </summary>
         <Box className="space-y-3 mt-3">
-          <chakra.span fontWeight="bold">Headword pronunciation spelling: </chakra.span>
+          <chakra.span fontWeight="bold" fontFamily="Silka">Headword pronunciation spelling: </chakra.span>
           <Controller
             render={(props) => (
               <Input

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordFormInterface.ts
@@ -7,6 +7,7 @@ interface HeadwordForm {
   record: Interfaces.Word,
   watch: any,
   getValues: (key?: string) => any,
+  onChange: (value?: any) => void,
 };
 
 export default HeadwordForm;


### PR DESCRIPTION
## Background
We've run into word entries that have outdated audio recordings because the headword would change but the audio recording wouldn't. There will now be warning labels that appear whenever the headword or dialectal variation has been updated. 

### Headword audio recording warning
<img width="730" alt="Screen Shot 2023-03-04 at 11 53 54 PM" src="https://user-images.githubusercontent.com/16169291/222942653-a197def0-3120-44cc-87e7-98a282faf5b9.png">

### Dialectal variation audio recording warning
<img width="723" alt="Screen Shot 2023-03-04 at 11 54 05 PM" src="https://user-images.githubusercontent.com/16169291/222942651-4ce5f96e-9e19-4cfa-a284-661c14aab6fe.png">
