### PR TITLE
Make it more clear when a user doesn't have access to the platform

### DIFF
--- a/src/App/IgboAPIAdmin.tsx
+++ b/src/App/IgboAPIAdmin.tsx
@@ -1,5 +1,10 @@
-import React, { memo, ReactElement, useState } from 'react';
-import { Box } from '@chakra-ui/react';
+import React, {
+  memo,
+  ReactElement,
+  useEffect,
+  useState,
+} from 'react';
+import { Box, useToast } from '@chakra-ui/react';
 import {
   AdminContext,
   AdminUI,
@@ -16,11 +21,13 @@ import {
 import Login from 'src/Login';
 import dataProvider from 'src/utils/dataProvider';
 import authProvider from 'src/utils/authProvider';
+import { hasAccessToPlatformPermissions } from 'src/shared/utils/permissions';
 import { getResourceObjects } from './Resources';
 import Theme from './Theme';
 
 const Resources = memo(() => {
   const [permissions, setPermissions] = useState(usePermissions());
+  const toast = useToast();
   const resources = getResourceObjects(permissions).map((resource) => (
     <Resource
       name={resource.name}
@@ -33,6 +40,24 @@ const Resources = memo(() => {
       icon={resource.icon}
     />
   ));
+
+  useEffect(() => {
+    if (permissions) {
+      const hasPermission = hasAccessToPlatformPermissions(permissions, true);
+      if (!hasPermission) {
+        authProvider.logout();
+        if (permissions?.role) {
+          toast({
+            title: 'Insufficient permissions',
+            description: 'You\'re account doesn\'t have the necessary permissions to access the platform.',
+            status: 'warning',
+            duration: 4000,
+            isClosable: true,
+          });
+        }
+      }
+    }
+  }, [permissions]);
 
   return (
     <AdminUI

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/SuggestedWords.tsx
@@ -45,7 +45,7 @@ const SuggestedWords = ({ word, id: wordId } : { word: string, id: string | Reco
       {filteredWords.length || filteredWordSuggestions.length ? (
         <Text color="orange.500" fontSize="sm" className="italic mt-4">
           {'⚠️ If you are seeing similar existing below, '}
-          <chakra.span fontWeight="bold">please consider delete this document if necessary</chakra.span>
+          <chakra.span fontWeight="bold">please consider deleting this document if necessary</chakra.span>
           {' and edit those existing documents to avoid duplicates.'}
         </Text>
       ) : null}

--- a/src/shared/utils/permissions.ts
+++ b/src/shared/utils/permissions.ts
@@ -2,7 +2,7 @@ import UserRoles from 'src/backend/shared/constants/UserRoles';
 import { betaEmailList } from 'src/shared/constants/emailList';
 
 export const hasNoEditorPermissions = (
-  permissions: { role?: string } = { role: '' },
+  permissions: { role?: UserRoles } = { role: UserRoles.USER },
   returnWithPermission: any,
 ): any | void => {
   if (
@@ -16,7 +16,7 @@ export const hasNoEditorPermissions = (
 };
 
 export const hasEditorPermissions = (
-  permissions: { role?: string } = { role: '' },
+  permissions: { role?: UserRoles } = { role: UserRoles.USER },
   returnWithPermission: any,
 ): any | void => {
   if (
@@ -30,7 +30,7 @@ export const hasEditorPermissions = (
 };
 
 export const hasAdminOrMergerPermissions = (
-  permissions: { role?: string } = { role: '' },
+  permissions: { role?: UserRoles } = { role: UserRoles.USER },
   returnWithPermission: any,
 ): any | void => {
   if (permissions?.role === UserRoles.ADMIN || permissions?.role === UserRoles.MERGER) {
@@ -40,7 +40,7 @@ export const hasAdminOrMergerPermissions = (
 };
 
 export const hasAdminPermissions = (
-  permissions: { role?: string } = { role: '' },
+  permissions: { role?: UserRoles } = { role: UserRoles.USER },
   returnWithPermission: any,
 ): any | null => {
   if (permissions?.role === UserRoles.ADMIN) {
@@ -50,7 +50,7 @@ export const hasAdminPermissions = (
 };
 
 export const hasBetaPermissions = (
-  permissions: { role?: string, email?: string } = { role: '', email: '' },
+  permissions: { role?: UserRoles, email?: string } = { role: UserRoles.USER, email: '' },
   returnWithPermission: any,
 ): any | null => {
   if (permissions?.role === UserRoles.ADMIN || betaEmailList.includes(permissions?.email)) {
@@ -60,12 +60,25 @@ export const hasBetaPermissions = (
 };
 
 export const hasTranscriberPermissions = (
-  permissions: { role?: string } = { role: '' },
+  permissions: { role?: UserRoles } = { role: UserRoles.USER },
   returnWithPermission: any,
 ): any | null => {
   if (
     permissions?.role === UserRoles.TRANSCRIBER
     || hasBetaPermissions(permissions, true)
+  ) {
+    return returnWithPermission;
+  }
+  return null;
+};
+
+export const hasAccessToPlatformPermissions = (
+  permissions: { role?: UserRoles } = { role: UserRoles.USER },
+  returnWithPermission: any,
+): any | null => {
+  if (
+    Object.values(UserRoles).includes(permissions?.role)
+    && permissions?.role !== UserRoles.USER
   ) {
     return returnWithPermission;
   }

--- a/src/utils/authProvider.ts
+++ b/src/utils/authProvider.ts
@@ -16,6 +16,10 @@ export default {
       localStorage.removeItem(LocalStorageKeys[key]);
     });
     window.location.hash = '#/login';
+    window.localStorage.removeItem(LocalStorageKeys.UID);
+    window.localStorage.removeItem(LocalStorageKeys.ACCESS_TOKEN);
+    window.localStorage.removeItem(LocalStorageKeys.PERMISSIONS);
+    window.localStorage.removeItem(LocalStorageKeys.FORM);
     return firebaseAuthProvider.logout(args);
   },
 };


### PR DESCRIPTION
## Background
New users would have an infinite loading screen after logging in with a newly created account. This experience is confusing and misleading since the user believes they will eventually see the platform when they don't have the correct permissions to view it.

This PR:
* Update the login flow logic
* A new toast warning message will appear when a user with insufficient permissions attempts to access the platform
* Ensure the new user message appears when an account is created.

## Screenshot of toast
![image](https://user-images.githubusercontent.com/16169291/232326167-b58ac3b5-fb13-452d-8ab7-b9a2645466ac.png)