### PR TITLE
Wait for permissions to load

### DIFF
--- a/src/App/IgboAPIAdmin.tsx
+++ b/src/App/IgboAPIAdmin.tsx
@@ -42,7 +42,7 @@ const Resources = memo(() => {
   ));
 
   useEffect(() => {
-    if (permissions) {
+    if (permissions?.loaded) {
       const hasPermission = hasAccessToPlatformPermissions(permissions, true);
       if (!hasPermission) {
         authProvider.logout();

--- a/src/utils/authProvider.ts
+++ b/src/utils/authProvider.ts
@@ -3,6 +3,13 @@ import { omit } from 'lodash';
 import useFirebaseConfig from 'src/hooks/useFirebaseConfig';
 import LocalStorageKeys from 'src/shared/constants/LocalStorageKeys';
 
+const clearLocalStorage = () => {
+  window.localStorage.removeItem(LocalStorageKeys.UID);
+  window.localStorage.removeItem(LocalStorageKeys.ACCESS_TOKEN);
+  window.localStorage.removeItem(LocalStorageKeys.PERMISSIONS);
+  window.localStorage.removeItem(LocalStorageKeys.FORM);
+};
+
 const LOGIN_HASH = '#/login';
 const firebaseConfig = useFirebaseConfig();
 const firebaseAuthProvider = FirebaseAuthProvider(firebaseConfig, { lazyLoading: { enabled: true }, logging: false });
@@ -16,10 +23,7 @@ export default {
       localStorage.removeItem(LocalStorageKeys[key]);
     });
     window.location.hash = '#/login';
-    window.localStorage.removeItem(LocalStorageKeys.UID);
-    window.localStorage.removeItem(LocalStorageKeys.ACCESS_TOKEN);
-    window.localStorage.removeItem(LocalStorageKeys.PERMISSIONS);
-    window.localStorage.removeItem(LocalStorageKeys.FORM);
+    clearLocalStorage();
     return firebaseAuthProvider.logout(args);
   },
 };


### PR DESCRIPTION
## Background
Use the `loaded` field on the `permissions` object to know when to determine if the user has permission to the platform. This fixes the bug where upon a refresh, the user is logged out of the platform.