### PR TITLE
Dump JSON Files for Data Collection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
   "cSpell.words": [
     "firebaseapp",
     "firestore",
-    "personalizations"
+    "personalizations",
+    "Silka"
   ],
   "cSpell.ignoreWords": [
     "appspot"

--- a/src/Core/Collections/DataDump/DataDump.tsx
+++ b/src/Core/Collections/DataDump/DataDump.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
 } from 'react';
 import compact from 'lodash/compact';
+import trim from 'lodash/trim';
 import {
   Accordion,
   AccordionItem,
@@ -19,12 +20,17 @@ import {
   Progress,
   Link,
   useToast,
+  chakra,
 } from '@chakra-ui/react';
+import { InfoIcon, WarningIcon } from '@chakra-ui/icons';
+import pluralize from 'pluralize';
 import { Textarea } from 'src/shared/primitives';
 import { Confirmation } from 'src/shared/components';
 import Collections from 'src/shared/constants/Collections';
 import Views from 'src/shared/constants/Views';
 import actionsMap from 'src/shared/constants/actionsMap';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
+import SentenceType from 'src/backend/shared/constants/SentenceType';
 import UploadStatus from './UploadStats';
 import type StatusType from './StatusType';
 
@@ -35,8 +41,10 @@ const DataDump = (): ReactElement => {
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
   const [successes, setSuccesses] = useState<StatusType[][]>([]);
   const [failures, setFailures] = useState([]);
+  const [fileData, setFileData] = useState([]);
   const [totalSentences, setTotalSentences] = useState(-1);
   const toast = useToast();
+  const isDataPresent = textareaValue.length || fileData?.length;
   const action = {
     ...actionsMap.BulkUploadExamples,
     content: `Are you sure you want to upload ${totalSentences} example suggestions at once? `
@@ -58,13 +66,14 @@ const DataDump = (): ReactElement => {
   };
 
   const onProgressFailure = (message) => {
-    console.log('Failure message:', message);
+    const { response } = message;
+    console.log('Failure message:', response.data);
     const updatedFailures = [...failures];
     updatedFailures.push(message);
     setFailures(updatedFailures);
     toast({
       title: 'An error occurred',
-      description: 'Unable to bulk upload example sentences.',
+      description: 'Bulk upload for a batch has failed.',
       status: 'error',
       duration: 4000,
       isClosable: true,
@@ -75,13 +84,45 @@ const DataDump = (): ReactElement => {
     const trimmedTextareaValue = textareaValue.trim();
     const separatedSentences = compact(trimmedTextareaValue.split(/\n/));
     const payload = separatedSentences.map((text) => ({ igbo: text.trim() }));
-    setTotalSentences(payload.length);
+    setTotalSentences(payload.length + fileData?.length);
   };
 
   const handleCloseConfirmation = () => {
     setIsConfirmationOpen(false);
     setSuccesses([]);
     setFailures([]);
+  };
+
+  const omitNonCleanExamples = (event) => {
+    const { result } = event.target;
+    if (typeof result === 'string') {
+      const jsonData = JSON.parse(result) || [];
+      if (Array.isArray(jsonData)) {
+        const omittedData = [];
+        const cleanedData = jsonData.reduce((finalData, data) => {
+          const isDataClean = trim(data.igbo) && trim(data.style) === ExampleStyle.BIBLICAL.value;
+          if (isDataClean) {
+            finalData.push({
+              ...data,
+              type: SentenceType.BIBLICAL,
+            });
+          } else {
+            omittedData.push(data);
+          }
+          return finalData;
+        }, []);
+        setFileData(cleanedData);
+      }
+    }
+  };
+
+  const handleFileUpload = (e) => {
+    const dataDumpFile = e.target.files[0];
+    if (dataDumpFile) {
+      const reader = new FileReader();
+      reader.readAsText(dataDumpFile, 'utf-8');
+      reader.onload = omitNonCleanExamples;
+    }
   };
 
   const handleFormSubmit = async (e: FormEvent) => {
@@ -91,7 +132,7 @@ const DataDump = (): ReactElement => {
     } catch (err) {
       toast({
         title: 'An error occurred',
-        description: 'Unable to bulk upload example sentences.',
+        description: 'Unable to submit bulk upload example sentences request.',
         status: 'error',
         duration: 4000,
         isClosable: true,
@@ -101,7 +142,7 @@ const DataDump = (): ReactElement => {
 
   useEffect(() => {
     handleCalculateSentenceCount();
-  }, [textareaValue]);
+  }, [textareaValue, fileData]);
 
   return (
     <>
@@ -113,7 +154,7 @@ const DataDump = (): ReactElement => {
         isOpen={isConfirmationOpen}
         view={Views.SHOW}
         actionHelpers={{
-          data: textareaValue,
+          data: { file: fileData, text: textareaValue },
           onProgressFailure,
           onProgressSuccess,
         }}
@@ -131,41 +172,87 @@ const DataDump = (): ReactElement => {
           </Link>
           .
         </Text>
-        <form onSubmit={handleFormSubmit}>
+        <form onSubmit={handleFormSubmit} className="space-y-4">
           <Textarea
             data-test="data-dump-textarea"
             value={textareaValue}
             onChange={handleChangeTextarea}
             placeholder="Sentences separated either by periods or new lines"
           />
-          <Box className="w-full flex flex-row justify-between items-center mt-5">
-            <Tooltip
-              label={!textareaValue.length
-                ? 'Each Igbo sentence will be uploaded to the Igbo API data set as an example sentence'
-                : 'Disabled because there are not example sentences to upload'}
-            >
-              <Box className="w-full lg:w-4/12">
-                <Button type="submit" disabled={!textareaValue.length}>
-                  Bulk upload sentences
-                </Button>
+          <Box className="w-full flex flex-col lg:flex-row justify-between items-start space-y-4 lg:space-y-0">
+            <Box className="w-full lg:w-8/12">
+              {textareaValue && fileData?.length ? (
+                <Text className="space-x-2 mb-2">
+                  <WarningIcon boxSize={3} color="orange.600" />
+                  <chakra.span color="orange.600" fontSize="xs">
+                    {`Both an uploaded file and text within the text area have been provided. 
+                    Both sources of data will be uploaded.`}
+                  </chakra.span>
+                </Text>
+              ) : null}
+              <Box className="w-full flex flex-col space-y-4">
+                <Tooltip
+                  label={!textareaValue.length
+                    ? 'Each Igbo sentence will be uploaded to the Igbo API data set as an example sentence'
+                    : 'Disabled because there are not example sentences to upload'}
+                >
+                  <Box className="w-full lg:w-4/12">
+                    <Button
+                      colorScheme="green"
+                      type="submit"
+                      disabled={!isDataPresent}
+                    >
+                      Bulk upload sentences
+                    </Button>
+                  </Box>
+                </Tooltip>
+                {totalSentences > -1 ? (
+                  <Box className="w-full lg:w-6/12">
+                    <Text fontWeight="bold">Uploaded examples</Text>
+                    <Box className="w-full flex flex-row space-x-6 items-center">
+                      <Progress
+                        value={!totalSentences ? 0 : Math.floor((successes.flat().length / totalSentences) * 100)}
+                        colorScheme="blue"
+                        size="lg"
+                        width="full"
+                        height="8px"
+                        borderRadius="full"
+                      />
+                      <Text fontFamily="Silka" className="w-4/12">
+                        {`${successes.flat().length} / ${totalSentences}`}
+                      </Text>
+                    </Box>
+                  </Box>
+                ) : null}
               </Box>
-            </Tooltip>
-            {totalSentences > -1 ? (
-              <Box className="w-full lg:w-6/12">
-                <Text fontWeight="bold">Uploaded examples</Text>
-                <Box className="w-full flex flex-row space-x-6 items-center">
-                  <Progress
-                    value={!totalSentences ? 0 : Math.floor((successes.flat().length / totalSentences) * 100)}
-                    colorScheme="blue"
-                    size="lg"
-                    width="full"
-                    height="8px"
-                    borderRadius="full"
-                  />
-                  <Text fontFamily="Silka" className="w-4/12">{`${successes.flat().length} / ${totalSentences}`}</Text>
-                </Box>
-              </Box>
-            ) : null}
+            </Box>
+            <Box className="w-full lg:w-4/12 flex flex-row justify-end items-center">
+              <Tooltip label="Click here to see data uploading alternatives">
+                <details className="cursor-pointer">
+                  <summary className="lg:text-right mb-2">
+                    <chakra.span m="2" fontWeight="bold">More data upload options</chakra.span>
+                  </summary>
+                  <Box className="space-y-2 p-4 rounded-md" backgroundColor="gray.200">
+                    <Text fontWeight="bold">Select a JSON file to bulk upload example sentences.</Text>
+                    <input
+                      type="file"
+                      name="data-dump"
+                      accept=".json"
+                      onChange={handleFileUpload}
+                    />
+                    {fileData.length ? (
+                      <Text color="green.600" className="space-x-2">
+                        <InfoIcon boxSize={3} />
+                        <chakra.span fontStyle="italic">
+                          {`${pluralize('example sentence', fileData.length, true)} 
+                          from this JSON file will be uploaded`}
+                        </chakra.span>
+                      </Text>
+                    ) : null}
+                  </Box>
+                </details>
+              </Tooltip>
+            </Box>
           </Box>
         </form>
         {totalSentences > -1 ? (

--- a/src/Core/Collections/DataDump/DataDump.tsx
+++ b/src/Core/Collections/DataDump/DataDump.tsx
@@ -19,6 +19,7 @@ import {
   Tooltip,
   Progress,
   Link,
+  Switch,
   useToast,
   chakra,
 } from '@chakra-ui/react';
@@ -42,6 +43,7 @@ const DataDump = (): ReactElement => {
   const [successes, setSuccesses] = useState<StatusType[][]>([]);
   const [failures, setFailures] = useState([]);
   const [fileData, setFileData] = useState([]);
+  const [isExample, setIsExample] = useState(false);
   const [totalSentences, setTotalSentences] = useState(-1);
   const toast = useToast();
   const isDataPresent = textareaValue.length || fileData?.length;
@@ -49,6 +51,10 @@ const DataDump = (): ReactElement => {
     ...actionsMap.BulkUploadExamples,
     content: `Are you sure you want to upload ${totalSentences} example suggestions at once? `
     + 'This will take a few minutes to complete.',
+  };
+
+  const handleExampleDocumentType = (event) => {
+    setIsExample(event.target.checked);
   };
 
   const handleChangeTextarea = (e) => {
@@ -154,7 +160,7 @@ const DataDump = (): ReactElement => {
         isOpen={isConfirmationOpen}
         view={Views.SHOW}
         actionHelpers={{
-          data: { file: fileData, text: textareaValue },
+          data: { file: fileData, text: textareaValue, isExample },
           onProgressFailure,
           onProgressSuccess,
         }}
@@ -227,11 +233,13 @@ const DataDump = (): ReactElement => {
               </Box>
             </Box>
             <Box className="w-full lg:w-4/12 flex flex-row justify-end items-center">
-              <Tooltip label="Click here to see data uploading alternatives">
-                <details className="cursor-pointer">
+              <details className="cursor-pointer">
+                <Tooltip label="Click here to see data uploading alternatives">
                   <summary className="lg:text-right mb-2">
                     <chakra.span m="2" fontWeight="bold">More data upload options</chakra.span>
                   </summary>
+                </Tooltip>
+                <Box className="space-y-2">
                   <Box className="space-y-2 p-4 rounded-md" backgroundColor="gray.200">
                     <Text fontWeight="bold">Select a JSON file to bulk upload example sentences.</Text>
                     <input
@@ -250,8 +258,20 @@ const DataDump = (): ReactElement => {
                       </Text>
                     ) : null}
                   </Box>
-                </details>
-              </Tooltip>
+                  <Tooltip label="Either upload these sentences as either Examples or Example Suggestions">
+                    <Box className="flex flex-row justify-start items-center space-x-2">
+                      <Text fontWeight="bold" color={!isExample ? '' : 'gray.300'}>Example Suggestion</Text>
+                      <Switch onChange={handleExampleDocumentType} />
+                      <Text fontWeight="bold" color={isExample ? '' : 'gray.300'}>Example</Text>
+                    </Box>
+                  </Tooltip>
+                  {isExample ? (
+                    <Text className="italic" fontSize="sm">These sentences will become examples</Text>
+                  ) : (
+                    <Text className="italic" fontSize="sm">These sentences will become example suggestions.</Text>
+                  )}
+                </Box>
+              </details>
             </Box>
           </Box>
         </form>

--- a/src/Core/Collections/DataDump/StatusType.ts
+++ b/src/Core/Collections/DataDump/StatusType.ts
@@ -1,3 +1,12 @@
-type StatusType = { success: boolean, message?: string, meta: { igbo: string, id?: string } };
+import { ExampleClientData } from 'src/backend/controllers/utils/interfaces';
+
+type StatusType = {
+  success: boolean,
+  message?: string,
+  meta: {
+    id: string,
+    sentenceData: ExampleClientData,
+  }
+};
 
 export default StatusType;

--- a/src/Core/Collections/DataDump/UploadStats.tsx
+++ b/src/Core/Collections/DataDump/UploadStats.tsx
@@ -11,6 +11,7 @@ import {
   chakra,
 } from '@chakra-ui/react';
 import { CheckIcon, CloseIcon } from '@chakra-ui/icons';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 import type StatusType from './StatusType';
 
 const UploadStatus = ({
@@ -45,15 +46,31 @@ const UploadStatus = ({
                 </Text>
                 {message ? (
                   <Text fontWeight="bold" fontSize="sm">
-                    {'Error message: '}
+                    {'Response message: '}
                     <chakra.span fontWeight="normal">
                       {message}
                     </chakra.span>
                   </Text>
                 ) : null}
                 <Text fontWeight="bold" fontSize="sm">
-                  {'Sentence: '}
-                  <chakra.span fontWeight="normal">{meta.igbo}</chakra.span>
+                  {'Igbo Sentence: '}
+                  <chakra.span fontWeight="normal">{meta.sentenceData.igbo}</chakra.span>
+                </Text>
+                <Text fontWeight="bold" fontSize="sm">
+                  {'English Sentence: '}
+                  <chakra.span fontWeight="normal" className={!meta.sentenceData.english ? 'text-gray-500 italic' : ''}>
+                    {meta.sentenceData.english || 'N/A'}
+                  </chakra.span>
+                </Text>
+                <Text fontWeight="bold" fontSize="sm">
+                  {'Sentence Type: '}
+                  <chakra.span fontWeight="normal">{meta.sentenceData.type}</chakra.span>
+                </Text>
+                <Text fontWeight="bold" fontSize="sm">
+                  {'Sentence Style: '}
+                  <chakra.span fontWeight="normal">
+                    {ExampleStyle[(meta.sentenceData.style || 'NO_STYLE').toUpperCase()].label}
+                  </chakra.span>
                 </Text>
                 {meta.id ? (
                   <Text fontWeight="bold" fontSize="sm">

--- a/src/__tests__/__mocks__/documentData.ts
+++ b/src/__tests__/__mocks__/documentData.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import SentenceType from 'src/backend/shared/constants/SentenceType';
 import WordClass from 'src/shared/constants/WordClass';
 
 const { ObjectId } = mongoose.Types;
@@ -75,6 +76,11 @@ export const exampleSuggestionApprovedData = {
 
 export const malformedExampleSuggestionData = {
   associatedWords: ['wrong'],
+};
+
+export const bulkUploadExampleSuggestionData = {
+  english: '',
+  type: SentenceType.DATA_COLLECTION,
 };
 
 export const exampleId = new ObjectId('5f864d7401203866b6546dd3');

--- a/src/__tests__/exampleSuggestions.test.ts
+++ b/src/__tests__/exampleSuggestions.test.ts
@@ -160,6 +160,12 @@ describe('MongoDB Example Suggestions', () => {
       const res = await postBulkUploadExampleSuggestions(payload);
       expect(res.body[0].success).toBe(false);
     });
+
+    it('should throw an error bulk uploading example suggestions with insufficient permissions', async () => {
+      const payload = [{ ...bulkUploadExampleSuggestionData, igbo: uuid() }];
+      const res = await postBulkUploadExampleSuggestions(payload, { token: AUTH_TOKEN.EDITOR_AUTH_TOKEN });
+      expect(res.status).toEqual(403);
+    });
   });
 
   describe('/PUT mongodb exampleSuggestions', () => {

--- a/src/__tests__/shared/commands.ts
+++ b/src/__tests__/shared/commands.ts
@@ -79,6 +79,13 @@ export const postBulkUploadExampleSuggestions = (data: { igbo: string }[], optio
     .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
 );
 
+export const postBulkUploadExamples = (data: { igbo: string }[], options = { token: '' }): Request => (
+  chaiServer
+    .post('/examples/upload')
+    .send(data)
+    .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
+);
+
 export const putRandomExampleSuggestions = (
   data: { id: string, pronunciation?: string, review?: ReviewActions }[],
   options = { token: '' },

--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -254,21 +254,24 @@ export const postBulkUploadExampleSuggestions = async (
 
     const ExampleSuggestion = mongooseConnection.model('ExampleSuggestion', exampleSuggestionSchema);
 
-    const result = await Promise.all(data.map(async ({ igbo }) => {
-      const existingExampleSuggestion = await ExampleSuggestion.findOne({ igbo });
+    const result = await Promise.all(data.map(async (sentenceData: Interfaces.ExampleClientData) => {
+      const existingExampleSuggestion = await ExampleSuggestion.findOne({ igbo: sentenceData.igbo });
       if (existingExampleSuggestion) {
         return {
           success: false,
           message: 'There is an example suggestion with identical Igbo text',
-          meta: { igbo },
+          meta: sentenceData,
         };
       }
-      const exampleSuggestion = new ExampleSuggestion({ igbo, type: SentenceType.DATA_COLLECTION });
+      const exampleSuggestion = new ExampleSuggestion({
+        ...sentenceData,
+        type: sentenceData?.type || SentenceType.DATA_COLLECTION,
+      });
       const savedExampleSuggestion = await exampleSuggestion.save();
       return {
         success: true,
         message: 'Success',
-        meta: { igbo, id: savedExampleSuggestion._id },
+        meta: { sentenceData, id: savedExampleSuggestion._id },
       };
     }));
 

--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -244,6 +244,7 @@ export const getRandomExampleSuggestions = async (
   }
 };
 
+/* Bulk uploads examples suggestions for data dump */
 export const postBulkUploadExampleSuggestions = async (
   req: Interfaces.EditorRequest,
   res: Response,

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -7,6 +7,7 @@ import {
 import { Request } from 'express';
 import UserRoles from 'src/backend/shared/constants/UserRoles';
 import Collections from 'src/shared/constants/Collections';
+import SentenceType from 'src/backend/shared/constants/SentenceType';
 
 export interface HandleQueries {
   searchWord: string,
@@ -169,6 +170,8 @@ export interface ExampleClientData {
   english?: string,
   meaning?: string,
   nsibidi?: string,
+  type?: SentenceType,
+  style?: string,
   pronunciation?: string,
   associatedWords: string[],
   associatedDefinitionsSchemas: string[],

--- a/src/backend/middleware/validateBulkUploadExampleSuggestionBody.ts
+++ b/src/backend/middleware/validateBulkUploadExampleSuggestionBody.ts
@@ -1,11 +1,9 @@
 import { Response, NextFunction } from 'express';
-import Joi from 'joi';
 import * as Interfaces from 'src/backend/controllers/utils/interfaces';
 import { BULK_UPLOAD_LIMIT } from 'src/Core/constants';
+import { bulkSentencesSchema } from 'src/shared/schemas/buildSentencesSchema';
 
-export const randomExampleSuggestionSchema = Joi.array().max(BULK_UPLOAD_LIMIT).items(Joi.object().keys({
-  igbo: Joi.string(),
-}));
+export const randomExampleSuggestionSchema = bulkSentencesSchema.max(BULK_UPLOAD_LIMIT);
 
 export default async (req: Interfaces.EditorRequest, res: Response, next: NextFunction): Promise<Response | void> => {
   const { body: finalData } = req;

--- a/src/backend/routers/transcriberRouter.ts
+++ b/src/backend/routers/transcriberRouter.ts
@@ -8,6 +8,7 @@ import {
   getTotalRecordedExampleSuggestions,
   putRandomExampleSuggestions,
 } from 'src/backend/controllers/exampleSuggestions';
+import { postBulkUploadExamples } from 'src/backend/controllers/examples';
 import {
   getCorpusSuggestion,
   getCorpusSuggestions,
@@ -29,6 +30,13 @@ import resourcePermission from 'src/backend/middleware/resourcePermission';
 const transcriberRouter = express.Router();
 const allRoles = [UserRoles.EDITOR, UserRoles.MERGER, UserRoles.ADMIN, UserRoles.TRANSCRIBER];
 transcriberRouter.use(authentication, authorization(allRoles));
+
+transcriberRouter.post(
+  '/examples/upload',
+  authorization([UserRoles.ADMIN]),
+  validateBulkUploadExampleSuggestionBody,
+  postBulkUploadExamples,
+);
 
 transcriberRouter.get('/exampleSuggestions/random', getRandomExampleSuggestions);
 transcriberRouter.put(

--- a/src/backend/shared/constants/SentenceType.ts
+++ b/src/backend/shared/constants/SentenceType.ts
@@ -1,5 +1,6 @@
 enum SentenceType {
   DATA_COLLECTION = 'data_collection',
+  BIBLICAL = 'biblical',
   DEFAULT = 'default',
 };
 

--- a/src/shared/DataCollectionAPI.ts
+++ b/src/shared/DataCollectionAPI.ts
@@ -40,17 +40,18 @@ export const putRandomExampleSuggestions = (rawData: {
 };
 
 export const bulkUploadExampleSuggestions = async (
-  data: { igbo: string }[],
+  payload: { sentences: { igbo: string }[], isExample: boolean },
   onProgressSuccess: (value: any) => void,
   onProgressFailure: (err: Error) => void,
 ): Promise<any> => {
+  const { sentences, isExample } = payload;
   let chunkIndex = 0;
   const groupSize = BULK_UPLOAD_LIMIT;
   const dataChunks = [];
-  while (chunkIndex < data.length) {
+  while (chunkIndex < sentences.length) {
     const chunkStart = chunkIndex;
-    const chunkEnd = chunkIndex + groupSize >= data.length ? data.length : chunkIndex + groupSize;
-    const dataChunk = data.slice(chunkStart, chunkEnd);
+    const chunkEnd = chunkIndex + groupSize >= sentences.length ? sentences.length : chunkIndex + groupSize;
+    const dataChunk = sentences.slice(chunkStart, chunkEnd);
     dataChunks.push(dataChunk);
     chunkIndex += groupSize;
   }
@@ -60,7 +61,7 @@ export const bulkUploadExampleSuggestions = async (
       .then(() => (
         request({
           method: 'POST',
-          url: 'exampleSuggestions/upload',
+          url: isExample ? 'examples/upload' : 'exampleSuggestions/upload',
           data: dataChunk,
         })
       ))

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -11,6 +11,10 @@ import {
   deleteDocument,
   combineDocument,
 } from 'src/shared/API';
+import { ExampleClientData } from 'src/backend/controllers/utils/interfaces';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
+import SentenceType from 'src/backend/shared/constants/SentenceType';
+import { bulkSentencesSchema } from 'src/shared/schemas/buildSentencesSchema';
 import ActionTypes from './ActionTypes';
 import Collections from './Collections';
 
@@ -182,18 +186,35 @@ export default {
     content: 'Are you sure you want to upload multiple example suggestions at once? '
     + 'This will take a few minutes to complete.',
     executeAction: async ({
-      data: textareaValue,
+      data,
       onProgressSuccess,
       onProgressFailure,
     } : {
-      data: string,
+      data: { file: ExampleClientData[], text: string }
       onProgressSuccess: (value: any) => any,
       onProgressFailure: (value: any) => any,
     }): Promise<any> => {
-      const trimmedTextareaValue = textareaValue.trim();
+      let payload = [];
+      const { file, text } = data;
+      const trimmedTextareaValue = text.trim();
       const separatedSentences = compact(trimmedTextareaValue.split(/\n/));
-      const payload = separatedSentences.map((text) => ({ igbo: text.trim() }));
-      await bulkUploadExampleSuggestions(payload, onProgressSuccess, onProgressFailure);
+
+      // Combines the data from both the uploaded file and text area input
+      payload = payload.concat(separatedSentences.map((sentenceText) => ({
+        igbo: sentenceText.trim(),
+        english: '',
+        style: ExampleStyle.NO_STYLE.value,
+        type: SentenceType.DATA_COLLECTION,
+      })), file);
+
+      try {
+        // Validating the body of the bulk sentences
+        bulkSentencesSchema.validate(payload);
+        await bulkUploadExampleSuggestions(payload, onProgressSuccess, onProgressFailure);
+      } catch (err) {
+        console.log('Data validation for bulk sentence upload failed.');
+        throw err;
+      }
     },
   },
 };

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -190,12 +190,12 @@ export default {
       onProgressSuccess,
       onProgressFailure,
     } : {
-      data: { file: ExampleClientData[], text: string }
+      data: { file: ExampleClientData[], text: string, isExample: boolean }
       onProgressSuccess: (value: any) => any,
       onProgressFailure: (value: any) => any,
     }): Promise<any> => {
       let payload = [];
-      const { file, text } = data;
+      const { file, text, isExample } = data;
       const trimmedTextareaValue = text.trim();
       const separatedSentences = compact(trimmedTextareaValue.split(/\n/));
 
@@ -210,7 +210,7 @@ export default {
       try {
         // Validating the body of the bulk sentences
         bulkSentencesSchema.validate(payload);
-        await bulkUploadExampleSuggestions(payload, onProgressSuccess, onProgressFailure);
+        await bulkUploadExampleSuggestions({ sentences: payload, isExample }, onProgressSuccess, onProgressFailure);
       } catch (err) {
         console.log('Data validation for bulk sentence upload failed.');
         throw err;

--- a/src/shared/schemas/buildSentencesSchema.ts
+++ b/src/shared/schemas/buildSentencesSchema.ts
@@ -1,0 +1,13 @@
+import Joi from 'joi';
+import SentenceType from 'src/backend/shared/constants/SentenceType';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
+
+export const bulkSentencesSchema = Joi.array().items(
+  Joi.object({
+    igbo: Joi.string().required(),
+    // https://stackoverflow.com/questions/42370881/allow-string-to-be-null-or-empty-in-joi-and-express-validation
+    english: Joi.string().empty(''),
+    style: Joi.string().valid(...Object.values(ExampleStyle).map(({ value }) => value)),
+    type: Joi.string().valid(...Object.values(SentenceType)).required(),
+  }),
+);


### PR DESCRIPTION
## Background
Adds support for bulk uploading example sentences to the Igbo API Editor Platform. The only expected data type will be JSON and it must be an array of objects with the following valid keys:
* `igbo` - required
* `english`
* `style`
* `type`

<img width="1649" alt="Xnapper-2023-04-27-15 25 29" src="https://user-images.githubusercontent.com/16169291/235004182-37cacd0b-b3d9-4bb5-8c35-7d57b5a769e6.png">
