### PR TITLE
Add `type` to Example model

### DIFF
--- a/src/Core/Collections/DataDump/DataDump.tsx
+++ b/src/Core/Collections/DataDump/DataDump.tsx
@@ -166,13 +166,13 @@ const DataDump = (): ReactElement => {
         }}
       />
       <Box className="space-y-3">
-        <Heading>Bulk Upload Example Suggestions</Heading>
+        <Heading>Bulk Upload Sentences</Heading>
         <Text fontFamily="Silka">
           {`This page expects a list of newline-separated sentences that
           will be bulk uploaded to the Igbo API dataset.`}
         </Text>
         <Text fontSize="sm" fontWeight="bold" fontFamily="Silka">
-          {'Want to see all data dumped example suggestions? Use the '}
+          {'Want to see all data dumped examples or example suggestions? Use the '}
           <Link href={isDataCollectionLink} color="green">
             {'\'Is Data Collection\' Filter'}
           </Link>

--- a/src/Core/Collections/DataDump/UploadStats.tsx
+++ b/src/Core/Collections/DataDump/UploadStats.tsx
@@ -54,22 +54,25 @@ const UploadStatus = ({
                 ) : null}
                 <Text fontWeight="bold" fontSize="sm">
                   {'Igbo Sentence: '}
-                  <chakra.span fontWeight="normal">{meta.sentenceData.igbo}</chakra.span>
+                  <chakra.span fontWeight="normal">{meta.sentenceData?.igbo}</chakra.span>
                 </Text>
                 <Text fontWeight="bold" fontSize="sm">
                   {'English Sentence: '}
-                  <chakra.span fontWeight="normal" className={!meta.sentenceData.english ? 'text-gray-500 italic' : ''}>
-                    {meta.sentenceData.english || 'N/A'}
+                  <chakra.span
+                    fontWeight="normal"
+                    className={!meta.sentenceData?.english ? 'text-gray-500 italic' : ''}
+                  >
+                    {meta.sentenceData?.english || 'N/A'}
                   </chakra.span>
                 </Text>
                 <Text fontWeight="bold" fontSize="sm">
                   {'Sentence Type: '}
-                  <chakra.span fontWeight="normal">{meta.sentenceData.type}</chakra.span>
+                  <chakra.span fontWeight="normal">{meta.sentenceData?.type}</chakra.span>
                 </Text>
                 <Text fontWeight="bold" fontSize="sm">
                   {'Sentence Style: '}
                   <chakra.span fontWeight="normal">
-                    {ExampleStyle[(meta.sentenceData.style || 'NO_STYLE').toUpperCase()].label}
+                    {ExampleStyle[(meta.sentenceData?.style || 'NO_STYLE').toUpperCase()].label}
                   </chakra.span>
                 </Text>
                 {meta.id ? (

--- a/src/backend/models/Example.ts
+++ b/src/backend/models/Example.ts
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
+import SentenceType from 'src/backend/shared/constants/SentenceType';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
@@ -8,6 +9,11 @@ export const exampleSchema = new Schema({
   english: { type: String, default: '', trim: true },
   meaning: { type: String, default: '', trim: true },
   nsibidi: { type: String, default: '' },
+  type: {
+    type: String,
+    enum: Object.values(SentenceType),
+    default: SentenceType.DEFAULT,
+  },
   style: {
     type: String,
     enum: Object.values(ExampleStyle).map(({ value }) => value),

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -182,8 +182,8 @@ export default {
   },
   [ActionTypes.BULK_UPLOAD_EXAMPLES]: {
     type: 'BulkUploadExamples',
-    title: 'Bulk Upload Example Suggestions',
-    content: 'Are you sure you want to upload multiple example suggestions at once? '
+    title: 'Bulk Upload Sentences',
+    content: 'Are you sure you want to upload multiple sentences at once? '
     + 'This will take a few minutes to complete.',
     executeAction: async ({
       data,


### PR DESCRIPTION
## Background
The `type` field wasn't getting saved on Example documents because the Example model didn't include the `type` field.