### PR TITLE
Include `sentenceData` field in error response + Filtering Biblical sentences

### DIFF
--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -191,6 +191,7 @@ describe('MongoDB Examples', () => {
       ];
       const res = await postBulkUploadExamples(payload);
       expect(res.body[0].success).toBe(false);
+      expect(res.body[0].meta.sentenceData).toBeDefined();
     });
 
     it('should throw an error with insufficient permissions', async () => {

--- a/src/__tests__/exampleSuggestions.test.ts
+++ b/src/__tests__/exampleSuggestions.test.ts
@@ -159,6 +159,7 @@ describe('MongoDB Example Suggestions', () => {
       ];
       const res = await postBulkUploadExampleSuggestions(payload);
       expect(res.body[0].success).toBe(false);
+      expect(res.body[0].meta.sentenceData).toBeDefined();
     });
 
     it('should throw an error bulk uploading example suggestions with insufficient permissions', async () => {

--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -261,7 +261,7 @@ export const postBulkUploadExampleSuggestions = async (
         return {
           success: false,
           message: 'There is an example suggestion with identical Igbo text',
-          meta: sentenceData,
+          meta: { sentenceData },
         };
       }
       const exampleSuggestion = new ExampleSuggestion({

--- a/src/backend/controllers/examples.ts
+++ b/src/backend/controllers/examples.ts
@@ -328,7 +328,7 @@ export const postBulkUploadExamples = async (
         return {
           success: false,
           message: 'There is an example with identical Igbo text',
-          meta: sentenceData,
+          meta: { sentenceData },
         };
       }
       const example = new Example({

--- a/src/backend/controllers/utils/queries.ts
+++ b/src/backend/controllers/utils/queries.ts
@@ -92,6 +92,9 @@ const generateSearchFilters = (filters: { [key: string]: string }, uid: string):
       case 'isDataCollection':
         allFilters.type = { $eq: SentenceType.DATA_COLLECTION };
         break;
+      case 'isBiblical':
+        allFilters.type = { $eq: SentenceType.BIBLICAL };
+        break;
       case 'wordClass':
         allFilters['definitions.wordClass'] = { $in: value };
         break;
@@ -186,9 +189,9 @@ export const searchRandomExampleSuggestionsRegexQuery = (uid: string) : {
   userInteractions: { $nin: [uid] },
 });
 export const searchRandomExampleSuggestionsToReviewRegexQuery = () : {
-  [key: string]: { $exists: boolean },
+  [key: string]: { $exists: boolean } | { $and: { $ne: string | null }[] },
 } => ({
-  'pronunciation': { $and: [{ $ne: '' }, { $ne: null }] },
+  pronunciation: { $and: [{ $ne: '' }, { $ne: null }] },
   'approvals.1': { $exists: false },
   'denials.1': { $exists: false },
 });

--- a/src/shared/components/actions/ListActions.tsx
+++ b/src/shared/components/actions/ListActions.tsx
@@ -231,6 +231,9 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
                         <MenuItemOption value="isDataCollection" key="isDataCollection">
                           Is Data Collection
                         </MenuItemOption>,
+                        <MenuItemOption value="isBiblical" key="isBiblical">
+                          Is Biblical
+                        </MenuItemOption>,
                       ]
                       : null}
                     {isWordResource


### PR DESCRIPTION
## Background
* An error gets thrown when a sentence fails to upload because the response shape doesn't match the expected shape that includes the `sentenceData` field
* Adds filtering support for Biblical sentences in the Examples and Example Suggesitons list view