### PR TITLE
Create Nsịbịdị Character Collection + Attach Nsịbịdi Characters to Words and Examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "google-gax": "^2.9.2",
     "husky": "^4.3.0",
     "jest": "^27.5.1",
-    "jest-fetch-mock": "^3.0.3",
     "kill-port": "^1.6.1",
     "lint-staged": "^10.4.2",
     "mocha": "^8.2.1",

--- a/src/__tests__/__mocks__/documentData.ts
+++ b/src/__tests__/__mocks__/documentData.ts
@@ -5,12 +5,15 @@ import WordClass from 'src/shared/constants/WordClass';
 const { ObjectId } = mongoose.Types;
 
 export const wordId = new ObjectId('5f864d7401203866b6546dd3');
+export const nsibidiCharacterId = new ObjectId('5f864d7401203866b6546dd4');
 export const wordSuggestionId = new ObjectId();
 export const wordSuggestionData = {
   word: 'word',
   definitions: [{
     wordClass: WordClass.NNC.value,
     definitions: ['first'],
+    nsibidi: 'nsibidi',
+    nsibidiCharacters: [nsibidiCharacterId],
     igboDefinitions: [{ igbo: 'igbo', nsibidi: 'nsibidi' }],
   }],
   dialects: [],

--- a/src/__tests__/shared/constants.ts
+++ b/src/__tests__/shared/constants.ts
@@ -23,6 +23,7 @@ export const EXAMPLE_SUGGESTION_KEYS = [
   'denials',
   'meaning',
   'nsibidi',
+  'nsibidiCharacters',
   'style',
   'source',
   'userInteractions',

--- a/src/__tests__/wordSuggestions.test.ts
+++ b/src/__tests__/wordSuggestions.test.ts
@@ -440,6 +440,13 @@ describe('MongoDB Word Suggestions', () => {
       expect(exampleSuggestionRes.body.mergedBy).toEqual(AUTH_TOKEN.ADMIN_AUTH_TOKEN);
       expect(exampleSuggestionRes.body.authorId).toEqual(AUTH_TOKEN.MERGER_AUTH_TOKEN);
     });
+
+    it('should update a word suggestion with an nsibidi character', async () => {
+      const wordSuggestionRes = await suggestNewWord(wordSuggestionData);
+      expect(wordSuggestionRes.status).toEqual(200);
+      expect(wordSuggestionRes.body.definitions[0].nsibidiCharacters[0])
+        .toEqual(wordSuggestionData.definitions[0].nsibidiCharacters[0].toString());
+    });
   });
 
   describe('/GET mongodb wordSuggestions', () => {

--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -444,7 +444,10 @@ export const getExampleSuggestion = async (
   }
 };
 
-export const removeExampleSuggestion = (id: string, mongooseConnection): Promise<Interfaces.ExampleSuggestion> => {
+export const removeExampleSuggestion = (
+  id: string,
+  mongooseConnection: Connection,
+): Promise<Interfaces.ExampleSuggestion> => {
   const ExampleSuggestion = mongooseConnection.model('ExampleSuggestion', exampleSuggestionSchema);
 
   return (

--- a/src/backend/controllers/nsibidiCharacters.ts
+++ b/src/backend/controllers/nsibidiCharacters.ts
@@ -1,0 +1,57 @@
+import { Response, NextFunction } from 'express';
+import { packageResponse, handleQueries } from './utils';
+import * as Interfaces from './utils/interfaces';
+import { nsibidiSchema } from '../models/Nsibidi';
+
+/* Returns all matching Nsibidi documents */
+export const getNsibidiCharacters = (
+  req: Interfaces.EditorRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<any> | void => {
+  try {
+    const {
+      regexKeyword,
+      searchWord,
+      skip,
+      limit,
+      mongooseConnection,
+      ...rest
+    } = handleQueries(req);
+
+    const query = { nsibidi: searchWord };
+    const Nsibidi = mongooseConnection.model('Nsibidi', nsibidiSchema);
+
+    return Nsibidi.find(query).then((nsibidiCharacters: [Interfaces.Nsibidi]) => (
+      packageResponse({
+        res,
+        docs: nsibidiCharacters,
+        model: Nsibidi,
+        query,
+        ...rest,
+      })
+    )).catch((err) => {
+      console.log(err);
+      throw new Error('An error has occurred while returning nsibidi characters, double check your provided data');
+    });
+  } catch (err) {
+    return next(err);
+  }
+};
+
+/* Returns a single Nsibidi character by using an id */
+export const getNsibidiCharacter = async (
+  req: Interfaces.EditorRequest,
+  res: Response,
+  next: NextFunction,
+) : Promise<any | void> => {
+  try {
+    const { mongooseConnection } = req;
+    const { id } = req.params;
+    const Nsibidi = mongooseConnection.model('Nsibidi', nsibidiSchema);
+    const nsibidiCharacter = await Nsibidi.findById(id);
+    return res.send(nsibidiCharacter.toJSON());
+  } catch (err) {
+    return next(err);
+  }
+};

--- a/src/backend/controllers/nsibidiCharacters.ts
+++ b/src/backend/controllers/nsibidiCharacters.ts
@@ -1,7 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { packageResponse, handleQueries } from './utils';
 import * as Interfaces from './utils/interfaces';
-import { nsibidiSchema } from '../models/Nsibidi';
+import { nsibidiCharacterSchema } from '../models/NsibidiCharacter';
 
 /* Returns all matching Nsibidi documents */
 export const getNsibidiCharacters = (
@@ -11,22 +11,21 @@ export const getNsibidiCharacters = (
 ): Promise<any> | void => {
   try {
     const {
-      regexKeyword,
       searchWord,
-      skip,
-      limit,
       mongooseConnection,
       ...rest
     } = handleQueries(req);
 
-    const query = { nsibidi: searchWord };
-    const Nsibidi = mongooseConnection.model('Nsibidi', nsibidiSchema);
+    // Loosely matches with an included Nsibidi character
+    const regex = new RegExp([...searchWord].join('|'));
+    const query = { nsibidi: { $regex: regex } };
+    const NsibidiCharacter = mongooseConnection.model('NsibidiCharacter', nsibidiCharacterSchema);
 
-    return Nsibidi.find(query).then((nsibidiCharacters: [Interfaces.Nsibidi]) => (
+    return NsibidiCharacter.find(query).then((nsibidiCharacters: Interfaces.NsibidiCharacter[]) => (
       packageResponse({
         res,
         docs: nsibidiCharacters,
-        model: Nsibidi,
+        model: NsibidiCharacter,
         query,
         ...rest,
       })
@@ -48,8 +47,8 @@ export const getNsibidiCharacter = async (
   try {
     const { mongooseConnection } = req;
     const { id } = req.params;
-    const Nsibidi = mongooseConnection.model('Nsibidi', nsibidiSchema);
-    const nsibidiCharacter = await Nsibidi.findById(id);
+    const NsibidiCharacter = mongooseConnection.model('NsibidiCharacter', nsibidiCharacterSchema);
+    const nsibidiCharacter = await NsibidiCharacter.findById(id);
     return res.send(nsibidiCharacter.toJSON());
   } catch (err) {
     return next(err);

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -180,6 +180,12 @@ export interface ExampleClientData {
   originalExampleId?: string,
 };
 
+export interface Nsibidi {
+  nsibidi: string,
+  definitions: { text: string }[],
+  pronunciations: { text: string }[],
+};
+
 export interface CachedDocument extends WordSuggestion, ExampleSuggestion {
   cachedAt: Date,
 }

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -180,7 +180,7 @@ export interface ExampleClientData {
   originalExampleId?: string,
 };
 
-export interface Nsibidi {
+export interface NsibidiCharacter {
   nsibidi: string,
   definitions: { text: string }[],
   pronunciations: { text: string }[],

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -70,6 +70,7 @@ export interface DefinitionSchema {
   definitions: string[],
   igboDefinitions: { igbo: string, nsibidi: string }[],
   nsibidi: string,
+  nsibidiCharacters: (Types.ObjectId | string)[],
   _id?: Types.ObjectId,
   id?: string,
 }
@@ -154,6 +155,7 @@ export interface Example extends Document<any>, LeanDocument<any> {
   english?: string,
   meaning?: string,
   nsibidi?: string,
+  nsibidiCharacters: string[],
   associatedWords: string[],
   associatedDefinitionsSchemas: string[],
   pronunciation: string,
@@ -181,6 +183,7 @@ export interface ExampleClientData {
 };
 
 export interface NsibidiCharacter {
+  id: Types.ObjectId,
   nsibidi: string,
   definitions: { text: string }[],
   pronunciations: { text: string }[],

--- a/src/backend/middleware/validateExampleBody.ts
+++ b/src/backend/middleware/validateExampleBody.ts
@@ -17,6 +17,7 @@ export const exampleDataSchema = Joi.object().keys({
   english: Joi.string().allow(''),
   meaning: Joi.string().allow('').optional(),
   nsibidi: Joi.string().allow('').optional(),
+  nsibidiCharacters: Joi.array().min(0).items(Joi.string()).optional(),
   style: Joi.string().valid(...Object.values(ExampleStyle).map(({ value }) => value)).optional(),
   associatedWords: Joi.array().external((associatedWords) => {
     if (!associatedWords) {

--- a/src/backend/middleware/validateWordBody.ts
+++ b/src/backend/middleware/validateWordBody.ts
@@ -22,14 +22,14 @@ export const wordDataSchema = Joi.object().keys({
   wordPronunciation: Joi.string().allow('', null).optional(),
   conceptualWord: Joi.string().allow('', null).optional(),
   nsibidi: Joi.string().allow(''),
-  nsibidiMeta: Joi.array().min(1).items(Joi.string()).optional(),
+  nsibidiCharacters: Joi.array().min(1).items(Joi.string()).optional(),
   definitions: Joi.array().min(1).items(Joi.object().keys({
     wordClass: Joi.string().valid(...Object.keys(WordClass)).required(),
     definitions: Joi.array().min(1).items(Joi.string()).required(),
     igboDefinitions: Joi.array().min(0).items(Joi.object().keys({
       igbo: Joi.string().allow('', null),
       nsibidi: Joi.string().allow('', null),
-      nsibidiMeta: Joi.array().min(1).items(Joi.string()).optional(),
+      nsibidiCharacters: Joi.array().min(1).items(Joi.string()).optional(),
       _id: Joi.string().optional(),
     })).optional(),
     nsibidi: Joi.string().allow('').optional(),

--- a/src/backend/middleware/validateWordBody.ts
+++ b/src/backend/middleware/validateWordBody.ts
@@ -21,18 +21,19 @@ export const wordDataSchema = Joi.object().keys({
   word: Joi.string().required(),
   wordPronunciation: Joi.string().allow('', null).optional(),
   conceptualWord: Joi.string().allow('', null).optional(),
+  // Deprecated: top-level nsibidi
   nsibidi: Joi.string().allow(''),
-  nsibidiCharacters: Joi.array().min(1).items(Joi.string()).optional(),
   definitions: Joi.array().min(1).items(Joi.object().keys({
     wordClass: Joi.string().valid(...Object.keys(WordClass)).required(),
     definitions: Joi.array().min(1).items(Joi.string()).required(),
     igboDefinitions: Joi.array().min(0).items(Joi.object().keys({
       igbo: Joi.string().allow('', null),
       nsibidi: Joi.string().allow('', null),
-      nsibidiCharacters: Joi.array().min(1).items(Joi.string()).optional(),
+      nsibidiCharacters: Joi.array().min(0).items(Joi.string()).optional(),
       _id: Joi.string().optional(),
     })).optional(),
     nsibidi: Joi.string().allow('').optional(),
+    nsibidiCharacters: Joi.array().min(0).items(Joi.string()).optional(),
     label: Joi.string().allow('').optional(),
   })).required(),
   attributes: Joi.object().keys(Object.values(WordAttributes).reduce((finalSchema, { value }) => ({

--- a/src/backend/middleware/validateWordBody.ts
+++ b/src/backend/middleware/validateWordBody.ts
@@ -22,12 +22,14 @@ export const wordDataSchema = Joi.object().keys({
   wordPronunciation: Joi.string().allow('', null).optional(),
   conceptualWord: Joi.string().allow('', null).optional(),
   nsibidi: Joi.string().allow(''),
+  nsibidiMeta: Joi.array().min(1).items(Joi.string()).optional(),
   definitions: Joi.array().min(1).items(Joi.object().keys({
     wordClass: Joi.string().valid(...Object.keys(WordClass)).required(),
     definitions: Joi.array().min(1).items(Joi.string()).required(),
     igboDefinitions: Joi.array().min(0).items(Joi.object().keys({
       igbo: Joi.string().allow('', null),
       nsibidi: Joi.string().allow('', null),
+      nsibidiMeta: Joi.array().min(1).items(Joi.string()).optional(),
       _id: Joi.string().optional(),
     })).optional(),
     nsibidi: Joi.string().allow('').optional(),

--- a/src/backend/models/Example.ts
+++ b/src/backend/models/Example.ts
@@ -9,6 +9,7 @@ export const exampleSchema = new Schema({
   english: { type: String, default: '', trim: true },
   meaning: { type: String, default: '', trim: true },
   nsibidi: { type: String, default: '' },
+  nsibidiCharacters: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
   type: {
     type: String,
     enum: Object.values(SentenceType),

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -24,6 +24,7 @@ export const exampleSuggestionSchema = new Schema({
   english: { type: String, default: '', trim: true },
   meaning: { type: String, default: '', trim: true },
   nsibidi: { type: String, default: '' },
+  nsibidiCharacters: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
   style: {
     type: String,
     enum: Object.values(ExampleStyle).map(({ value }) => value),

--- a/src/backend/models/Nsibidi.ts
+++ b/src/backend/models/Nsibidi.ts
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+import { toJSONPlugin } from './plugins';
+
+const { Schema } = mongoose;
+
+export const nsibidiSchema = new Schema({
+  nsibidi: { type: String, required: true, index: true },
+  definitions: { type: [{ text: String }], default: [] },
+  pronunciations: { type: [{ text: String }], default: [] },
+});
+
+toJSONPlugin(nsibidiSchema);
+
+mongoose.model('Nsibidi', nsibidiSchema);

--- a/src/backend/models/NsibidiCharacter.ts
+++ b/src/backend/models/NsibidiCharacter.ts
@@ -3,12 +3,12 @@ import { toJSONPlugin } from './plugins';
 
 const { Schema } = mongoose;
 
-export const nsibidiSchema = new Schema({
+export const nsibidiCharacterSchema = new Schema({
   nsibidi: { type: String, required: true, index: true },
   definitions: { type: [{ text: String }], default: [] },
   pronunciations: { type: [{ text: String }], default: [] },
 });
 
-toJSONPlugin(nsibidiSchema);
+toJSONPlugin(nsibidiCharacterSchema);
 
-mongoose.model('Nsibidi', nsibidiSchema);
+mongoose.model('NsibidiCharacter', nsibidiCharacterSchema);

--- a/src/backend/models/NsibidiCharacter.ts
+++ b/src/backend/models/NsibidiCharacter.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import WordClass from 'src/shared/constants/WordClass';
 import { toJSONPlugin } from './plugins';
 
 const { Schema } = mongoose;
@@ -6,7 +7,12 @@ const { Schema } = mongoose;
 export const nsibidiCharacterSchema = new Schema({
   nsibidi: { type: String, required: true, index: true },
   definitions: { type: [{ text: String }], default: [] },
-  pronunciations: { type: [{ text: String }], default: [] },
+  pronunciation: { type: String, default: '' },
+  wordClass: {
+    type: String,
+    default: WordClass.NNC.nsibidiValue,
+    enum: Object.values(WordClass).map(({ nsibidiValue }) => nsibidiValue),
+  },
 });
 
 toJSONPlugin(nsibidiCharacterSchema);

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -18,12 +18,12 @@ const definitionSchema = new Schema({
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '', index: true },
-  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
+  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
   igboDefinitions: {
     type: [{
       igbo: String,
       nsibidi: String,
-      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
+      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
     }],
     default: [],
   },

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -18,12 +18,12 @@ const definitionSchema = new Schema({
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '', index: true },
-  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
+  nsibidiCharacters: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
   igboDefinitions: {
     type: [{
       igbo: String,
       nsibidi: String,
-      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
+      nsibidiCharacters: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
     }],
     default: [],
   },

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -18,10 +18,12 @@ const definitionSchema = new Schema({
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '', index: true },
+  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
   igboDefinitions: {
     type: [{
       igbo: String,
       nsibidi: String,
+      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
     }],
     default: [],
   },

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -21,10 +21,12 @@ const definitionSchema = new Schema({
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '', index: true },
+  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
   igboDefinitions: {
     type: [{
       igbo: String,
       nsibidi: String,
+      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
     }],
     default: [],
   },

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -21,12 +21,12 @@ const definitionSchema = new Schema({
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '', index: true },
-  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
+  nsibidiCharacters: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
   igboDefinitions: {
     type: [{
       igbo: String,
       nsibidi: String,
-      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
+      nsibidiCharacters: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
     }],
     default: [],
   },

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -21,12 +21,12 @@ const definitionSchema = new Schema({
   label: { type: String, default: '', trim: true },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '', index: true },
-  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
+  nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
   igboDefinitions: {
     type: [{
       igbo: String,
       nsibidi: String,
-      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'Nsibidi' }], default: [] },
+      nsibidiMeta: { type: [{ type: Types.ObjectId, ref: 'NsibidiCharacter' }], default: [] },
     }],
     default: [],
   },

--- a/src/backend/routers/editorRouter.ts
+++ b/src/backend/routers/editorRouter.ts
@@ -127,8 +127,8 @@ editorRouter.delete(
   deleteExampleSuggestion,
 );
 
-editorRouter.get('/nsibidi', getNsibidiCharacters);
-editorRouter.get('/nsibidi/:id', validId, getNsibidiCharacter);
+editorRouter.get('/nsibidiCharacters', getNsibidiCharacters);
+editorRouter.get('/nsibidiCharacters/:id', validId, getNsibidiCharacter);
 
 editorRouter.delete(
   '/corpusSuggestions/:id',

--- a/src/backend/routers/editorRouter.ts
+++ b/src/backend/routers/editorRouter.ts
@@ -28,6 +28,7 @@ import {
   approveExampleSuggestion,
   denyExampleSuggestion,
 } from 'src/backend/controllers/exampleSuggestions';
+import { getNsibidiCharacters, getNsibidiCharacter } from 'src/backend/controllers/nsibidiCharacters';
 import {
   getStats,
   getUserStats,
@@ -125,6 +126,9 @@ editorRouter.delete(
   authorization([UserRoles.MERGER, UserRoles.ADMIN]),
   deleteExampleSuggestion,
 );
+
+editorRouter.get('/nsibidi', getNsibidiCharacters);
+editorRouter.get('/nsibidi/:id', validId, getNsibidiCharacter);
 
 editorRouter.delete(
   '/corpusSuggestions/:id',

--- a/src/backend/shared/constants/WordClass.ts
+++ b/src/backend/shared/constants/WordClass.ts
@@ -5,85 +5,106 @@ export default {
   ADJ: {
     value: 'ADJ',
     label: 'Adjective',
+    nsibidiValue: '依名器',
   },
   ADV: {
     value: 'ADV',
     label: 'Adverb',
+    nsibidiValue: 'ń器動',
   },
   AV: {
     value: 'AV',
     label: 'Active verb',
+    nsibidiValue: '動壊',
   },
   MV: {
     value: 'MV',
     label: 'Medial verb',
+    nsibidiValue: '論動',
   },
   PV: {
     value: 'PV',
     label: 'Passive verb',
+    nsibidiValue: 'ò轄動',
   },
   CJN: {
     value: 'CJN',
     label: 'Conjunction',
+    nsibidiValue: '依ǫ接接',
   },
   DEM: {
     value: 'DEM',
     label: 'Demonstrative',
+    nsibidiValue: 'ǫ探動',
   },
   NM: {
     value: 'NM',
     label: 'Name',
+    nsibidiValue: '名',
   },
   NNC: {
     value: 'NNC',
     label: 'Noun',
+    nsibidiValue: '依名',
   },
   ND: {
     value: 'ND',
     label: 'Nominal Modifier',
+    nsibidiValue: '名核伸',
   },
   NNP: {
     value: 'NNP',
     label: 'Proper noun',
+    nsibidiValue: '依名以',
   },
   CD: {
     value: 'CD',
     label: 'Number',
+    nsibidiValue: '口控',
   },
   PREP: {
     value: 'PREP',
     label: 'Preposition',
+    nsibidiValue: '簡残',
   },
   PRN: {
     value: 'PRN',
     label: 'Pronoun',
+    nsibidiValue: '依名衣',
   },
   FW: {
     value: 'FW',
     label: 'Foreign word',
+    nsibidiValue: '接穀',
   },
   QTF: {
     value: 'QTF',
     label: 'Quantifier',
+    nsibidiValue: '接感口',
   },
   WH: {
     value: 'WH',
     label: 'Interrogative',
+    nsibidiValue: 'ǹ絵',
   },
   INTJ: {
     value: 'INTJ',
     label: 'Interjection',
+    nsibidiValue: '撃岐営依',
   },
   ISUF: {
     value: 'ISUF',
     label: 'Inflectional suffix',
+    nsibidiValue: '壊興動',
   },
   ESUF: {
     value: 'ESUF',
     label: 'Extensional suffix',
+    nsibidiValue: '壊査動',
   },
   SYM: {
     value: 'SYM',
     label: 'Punctuations',
+    nsibidiValue: 'ò韻ǹ肝',
   },
 };

--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -20,7 +20,7 @@ export const getWord = async (id: string, { dialects } = { dialects: true }): Pr
   }
   const { data: result } = await request({
     method: 'GET',
-    url: `words/${id}?dialects=${dialects}`,
+    url: `${Collection.WORDS}/${id}?dialects=${dialects}`,
   })
     .then(async (res) => {
       await IndexedDBAPI.putDocument({ resource: Collection.WORDS, data: res.data });
@@ -31,12 +31,12 @@ export const getWord = async (id: string, { dialects } = { dialects: true }): Pr
 
 export const getWords = async (word: string): Promise<any> => (await request({
   method: 'GET',
-  url: `words?keyword=${word}`,
+  url: `${Collection.WORDS}?keyword=${word}`,
 })).data;
 
 export const getWordSuggestions = async (word: string): Promise<any> => (await request({
   method: 'GET',
-  url: `wordSuggestions?keyword=${word}`,
+  url: `${Collection.WORD_SUGGESTIONS}?keyword=${word}`,
 })).data;
 
 export const getExample = async (id: string): Promise<any> => {
@@ -46,7 +46,7 @@ export const getExample = async (id: string): Promise<any> => {
   }
   const { data: result } = await request({
     method: 'GET',
-    url: `examples/${id}`,
+    url: `${Collection.EXAMPLES}/${id}`,
   })
     .then(async (res) => {
       await IndexedDBAPI.putDocument({ resource: Collection.EXAMPLES, data: res.data });
@@ -57,12 +57,12 @@ export const getExample = async (id: string): Promise<any> => {
 
 export const getNsibidiCharacter = async (id: string): Promise<any> => (await request({
   method: 'GET',
-  url: `nsibidi/${id}`,
+  url: `${Collection.NSIBIDI_CHARACTERS}/${id}`,
 })).data;
 
 export const getNsibidiCharacters = async (nsibidi: string): Promise<any> => (await request({
   method: 'GET',
-  url: `nsibidi?keyword=${nsibidi}`,
+  url: `${Collection.NSIBIDI_CHARACTERS}?keyword=${nsibidi}`,
 })).data;
 
 export const getCorpus = async (id: string): Promise<any> => {
@@ -72,7 +72,7 @@ export const getCorpus = async (id: string): Promise<any> => {
   }
   const { data: result } = await request({
     method: 'GET',
-    url: `corpora/${id}`,
+    url: `${Collection.CORPORA}/${id}`,
   })
     .then(async (res) => {
       await IndexedDBAPI.putDocument({ resource: Collection.CORPORA, data: res.data });
@@ -101,19 +101,37 @@ export const resolveWord = async (wordId: string): Promise<any> => {
   return wordRes;
 };
 
+export const resolveNsibidiCharacter = async (nsibidiCharacterId: string): Promise<any> => {
+  const nsibidiCharacterRes = await getNsibidiCharacter(nsibidiCharacterId)
+    .catch(async () => {
+      /**
+       * If there is a regular Nsibidi character string (not a MongoDB Id) then the platform
+       * will search the Igbo API and find the matching Nsibidi character and insert
+       * that Nsibidi character's id
+       */
+
+      const { json: nsibidiCharactersResults } = (
+        await network(`/${Collection.NSIBIDI_CHARACTERS}?keyword=${nsibidiCharacterId}`)
+      );
+      const fallbackWord = nsibidiCharactersResults.find(({ nsibidi }) => nsibidi === nsibidiCharacterId);
+      return fallbackWord;
+    });
+  return nsibidiCharacterRes;
+};
+
 export const getAssociatedExampleSuggestions = async (id: string): Promise<any> => (await request({
   method: 'GET',
-  url: `examples/${id}/exampleSuggestions`,
+  url: `${Collection.EXAMPLES}/${id}/exampleSuggestions`,
 })).data;
 
 export const getAssociatedWordSuggestions = async (id: string): Promise<any> => (await request({
   method: 'GET',
-  url: `words/${id}/wordSuggestions`,
+  url: `${Collection.WORDS}/${id}/wordSuggestions`,
 })).data;
 
 export const getAssociatedWordSuggestionByTwitterId = async (id: string): Promise<any> => (await request({
   method: 'GET',
-  url: `words/${id}/twitterPolls`,
+  url: `${Collection.WORDS}/${id}/twitterPolls`,
 })).data;
 
 export const approveDocument = ({

--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -55,6 +55,16 @@ export const getExample = async (id: string): Promise<any> => {
   return result;
 };
 
+export const getNsibidiCharacter = async (id: string): Promise<any> => (await request({
+  method: 'GET',
+  url: `nsibidi/${id}`,
+})).data;
+
+export const getNsibidiCharacters = async (nsibidi: string): Promise<any> => (await request({
+  method: 'GET',
+  url: `nsibidi?keyword=${nsibidi}`,
+})).data;
+
 export const getCorpus = async (id: string): Promise<any> => {
   const cachedCorpus = await IndexedDBAPI.getDocument({ resource: Collection.CORPORA, id });
   if (cachedCorpus) {

--- a/src/shared/__mocks__/API.ts
+++ b/src/shared/__mocks__/API.ts
@@ -18,6 +18,18 @@ export const getWords = jest.fn(async () => ([
   },
 ]));
 
+export const getNsibidiCharacter = jest.fn(async () => ({
+  nsibidi: 'nsibidi',
+  definitions: [{ text: 'first definition' }],
+  pronunciations: [{ text: 'first pronunciation' }],
+}));
+
+export const getNsibidiCharacters = jest.fn(async () => ([{
+  nsibidi: 'nsibidi',
+  definitions: [{ text: 'first definition' }],
+  pronunciations: [{ text: 'first pronunciation' }],
+}]));
+
 export const getWordSuggestions = jest.fn(async () => ([]));
 
 export const resolveWord = jest.fn(async () => ({

--- a/src/shared/components/ResolvedNsibidiCharacter.tsx
+++ b/src/shared/components/ResolvedNsibidiCharacter.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState, ReactElement } from 'react';
+import {
+  Box,
+  Spinner,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react';
+import { WarningIcon } from '@chakra-ui/icons';
+import { getNsibidiCharacter } from '../API';
+import Collections from '../constants/Collections';
+
+const ResolvedNsibidiCharacter = ({ nsibidiCharacterId }: { nsibidiCharacterId: string }): ReactElement => {
+  const [resolvedNsibidiCharacter, setResolvedNsibidiCharacter] = useState(null);
+  const [isLinked, setIsLinked] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const nsibidiCharacter = await getNsibidiCharacter(nsibidiCharacterId)
+        .catch(() => {
+          setIsLinked(false);
+          return { nsibidiCharacter: nsibidiCharacterId };
+        });
+      setResolvedNsibidiCharacter(nsibidiCharacter);
+    })();
+  }, []);
+
+  return resolvedNsibidiCharacter ? (
+    isLinked ? (
+      <a className="text-blue-400 underline" href={`#/${Collections.NSIBIDI_CHARACTERS}/${nsibidiCharacterId}/show`}>
+        {resolvedNsibidiCharacter.nsibidi}
+      </a>
+    ) : (
+      <Tooltip
+        label={`This Nsibidi character metadata is not linked. To properly link this 
+        metadata to the Nsibidi character, edit this Nsibidi character and link this metadata.`}
+        backgroundColor="orange.300"
+        color="black"
+      >
+        <Box display="flex" alignItems="center" fontFamily="monospace" className="space-x-2">
+          <Text color="orange.600" fontWeight="bold" cursor="default">{resolvedNsibidiCharacter.nsibidi}</Text>
+          <WarningIcon color="orange.600" boxSize={3} className="ml-2" />
+        </Box>
+      </Tooltip>
+    )
+  ) : <Spinner />;
+};
+
+export default ResolvedNsibidiCharacter;

--- a/src/shared/components/ResolvedWord.tsx
+++ b/src/shared/components/ResolvedWord.tsx
@@ -7,6 +7,7 @@ import {
 } from '@chakra-ui/react';
 import { WarningIcon } from '@chakra-ui/icons';
 import { getWord } from '../API';
+import Collections from '../constants/Collections';
 
 const ResolvedWord = ({ wordId }: { wordId: string }): ReactElement => {
   const [resolvedWord, setResolvedWord] = useState(null);
@@ -25,7 +26,7 @@ const ResolvedWord = ({ wordId }: { wordId: string }): ReactElement => {
 
   return resolvedWord ? (
     isLinked ? (
-      <a className="text-blue-400 underline" href={`#/words/${wordId}/show`}>{resolvedWord.word}</a>
+      <a className="text-blue-400 underline" href={`#/${Collections.WORDS}/${wordId}/show`}>{resolvedWord.word}</a>
     ) : (
       <Tooltip
         label={`This word metadata is not linked. To properly link this 

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -19,7 +19,7 @@ import { Textarea, Input } from 'src/shared/primitives';
 import { handleUpdateDocument } from 'src/shared/constants/actionsMap';
 import ActionTypes from 'src/shared/constants/ActionTypes';
 import ExampleEditFormResolver from './ExampleEditFormResolver';
-import { onCancel, sanitizeArray } from '../utils';
+import { onCancel, sanitizeArray, sanitizeNsibidiCharacters } from '../utils';
 import FormHeader from '../FormHeader';
 import AssociatedWordsForm from './components/AssociatedWordsForm';
 import AudioRecorder from '../AudioRecorder';
@@ -45,6 +45,7 @@ const ExampleEditForm = ({
     defaultValues: {
       ...record,
       style,
+      nsibidiCharacters: (record?.nsibidiCharacters || []).map((nsibidiCharacterId) => ({ id: nsibidiCharacterId })),
     },
     ...ExampleEditFormResolver,
   });
@@ -83,6 +84,7 @@ const ExampleEditForm = ({
       associatedDefinitionsSchemas: sanitizeArray(record.associatedDefinitionsSchemas || []),
       style: data.style.value,
       associatedWords: sanitizeArray(data.associatedWords),
+      nsibidiCharacters: sanitizeNsibidiCharacters(data.nsibidiCharacters),
     };
     return cleanedData;
   };
@@ -97,7 +99,6 @@ const ExampleEditForm = ({
         {
           ...record,
           ...data,
-          style: data.style.value,
         },
         createCacheExampleData(data, record),
         {

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -23,7 +23,7 @@ import { onCancel, sanitizeArray } from '../utils';
 import FormHeader from '../FormHeader';
 import AssociatedWordsForm from './components/AssociatedWordsForm';
 import AudioRecorder from '../AudioRecorder';
-import NsibidiInput from '../WordEditForm/components/NsibidiForm/NsibidiInput';
+import NsibidiForm from '../WordEditForm/components/NsibidiForm';
 
 const ExampleEditForm = ({
   view,
@@ -260,23 +260,13 @@ const ExampleEditForm = ({
           <p className="error">{errors.meaning.message}</p>
         ) : null}
       </Box>
-      <Box className="flex flex-col">
-        <FormHeader
-          title="Nsịbịdị"
-          tooltip="This field is for the Nsịbịdị representation of the sentence"
-        />
-        <Controller
-          render={(props) => (
-            <NsibidiInput {...props} />
-          )}
-          name="nsibidi"
-          control={control}
-          defaultValue={record.nsibidi || getValues().nsibidi || ''}
-        />
-        {errors.nsibidi ? (
-          <p className="error">{errors.nsibidi.message}</p>
-        ) : null}
-      </Box>
+      <NsibidiForm
+        control={control}
+        record={record}
+        getValues={getValues}
+        setValue={setValue}
+        errors={errors}
+      />
       <Box className="mt-2">
         <AssociatedWordsForm
           errors={errors}

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
@@ -7,6 +7,9 @@ export const ExampleEditFormSchema = yup.object().shape({
   english: yup.string(),
   meaning: yup.string().optional(),
   nsibidi: yup.string().optional(),
+  nsibidiCharacters: yup.array().min(0).of(yup.object().shape({
+    id: yup.string(),
+  })).optional(),
   style: yup.object().shape({
     value: yup.mixed().oneOf(Object.values(ExampleStyle).map(({ value }) => value)),
     label: yup.mixed().oneOf(Object.values(ExampleStyle).map(({ label }) => label)),

--- a/src/shared/components/views/components/ExampleEditForm/components/AssociatedWordsForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/components/AssociatedWordsForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@chakra-ui/react';
 import { AddIcon } from '@chakra-ui/icons';
 import { Controller } from 'react-hook-form';
-import { Input, WordPill } from 'src/shared/primitives';
+import { Input, WordPills } from 'src/shared/primitives';
 import { resolveWord, getWord, getWords } from 'src/shared/API';
 import FormHeader from '../../FormHeader';
 import AssociatedWordsFormInterface from './AssociatedWordFormInterface';
@@ -37,6 +37,12 @@ const AssociatedWords = (
     }
   };
 
+  const handleDeleteAssociatedWords = (index: number) => {
+    const filteredAssociatedWords = [...associatedWordIds];
+    filteredAssociatedWords.splice(index, 1);
+    updateAssociatedWords(filteredAssociatedWords);
+  };
+
   useEffect(() => {
     resolveAssociatedWords((words) => {
       // Removes stale, invalid Word Ids
@@ -52,32 +58,10 @@ const AssociatedWords = (
     <Spinner />
   ) : resolvedAssociatedWords && resolvedAssociatedWords.length ? (
     <Box display="flex" flexDirection="column" className="space-y-3 py-4">
-      {resolvedAssociatedWords.map((associatedWord, index) => (
-        <Box
-          key={associatedWord.id}
-          display="flex"
-          flexDirection="row"
-          justifyContent="space-between"
-          alignItems="center"
-          borderColor="blue.400"
-          borderWidth="1px"
-          backgroundColor="blue.50"
-          borderRadius="full"
-          minWidth="36"
-          py={2}
-          px={6}
-        >
-          <WordPill
-            {...associatedWord}
-            index={index}
-            onDelete={() => {
-              const filteredAssociatedWords = [...associatedWordIds];
-              filteredAssociatedWords.splice(index, 1);
-              updateAssociatedWords(filteredAssociatedWords);
-            }}
-          />
-        </Box>
-      ))}
+      <WordPills
+        pills={resolvedAssociatedWords}
+        onDelete={handleDeleteAssociatedWords}
+      />
     </Box>
   ) : (
     <Box className="flex w-full justify-center">

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -28,7 +28,7 @@ import { invalidRelatedTermsWordClasses } from 'src/backend/controllers/utils/de
 import WordAttributes from 'src/backend/shared/constants/WordAttributes';
 import ActionTypes from 'src/shared/constants/ActionTypes';
 import WordEditFormResolver from './WordEditFormResolver';
-import { sanitizeArray, onCancel } from '../utils';
+import { sanitizeArray, sanitizeNsibidiCharacters, onCancel } from '../utils';
 import DefinitionsForm from './components/DefinitionsForm';
 import ExamplesForm from './components/ExamplesForm';
 import VariationsForm from './components/VariationsForm';
@@ -115,9 +115,6 @@ const WordEditForm = ({
       ? 'A change in the headword has been detected. Please consider re-recording the audio to match.'
       : '');
   };
-
-  /* Transforms nsibidiCharacters to be an array of just strings */
-  const sanitizeNsibidiCharacters = (nsibidiCharacters: { id: string }[]) => nsibidiCharacters.map(({ id }) => id);
 
   /* Gets the original example id and associated words to prepare to send to the API */
   const sanitizeExamples = (examples = []) => {

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -72,7 +72,10 @@ const WordEditForm = ({
         : [],
       relatedTerms: record.relatedTerms || [],
       stems: record.stems || [],
-      nsibidi: record.nsibidi,
+      definitions: (record.definitions || []).map((definition) => ({
+        ...definition,
+        nsibidiCharacters: (definition?.nsibidiCharacters || []).map((nsibidiCharacter) => ({ id: nsibidiCharacter })),
+      })),
       tenses: record.tenses || {},
       pronunciation: record.pronunciation || '',
       attributes: record.attributes || Object.values(WordAttributes).reduce((finalAttributes, attribute) => ({
@@ -112,6 +115,9 @@ const WordEditForm = ({
       ? 'A change in the headword has been detected. Please consider re-recording the audio to match.'
       : '');
   };
+
+  /* Transforms nsibidiCharacters to be an array of just strings */
+  const sanitizeNsibidiCharacters = (nsibidiCharacters: { id: string }[]) => nsibidiCharacters.map(({ id }) => id);
 
   /* Gets the original example id and associated words to prepare to send to the API */
   const sanitizeExamples = (examples = []) => {
@@ -160,6 +166,7 @@ const WordEditForm = ({
         ...definition,
         wordClass: definition.wordClass.value,
         definitions: sanitizeArray(definition.definitions),
+        nsibidiCharacters: sanitizeNsibidiCharacters(definition.nsibidiCharacters),
       })),
       variations: sanitizeArray(data.variations),
       relatedTerms: sanitizeArray(data.relatedTerms),
@@ -317,6 +324,7 @@ const WordEditForm = ({
       </Box>
       <DefinitionsForm
         getValues={getValues}
+        setValue={setValue}
         options={options}
         record={record}
         definitions={definitions}
@@ -335,6 +343,7 @@ const WordEditForm = ({
         examples={examples}
         setExamples={setExamples}
         getValues={getValues}
+        setValue={setValue}
         errors={errors}
       />
       <Box className={'flex '

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -22,6 +22,7 @@ const schema = yup.object().shape({
       label: yup.mixed().oneOf(Object.values(WordClass).map(({ label }) => label)),
     }).required(),
     nsibidi: yup.string().optional(),
+    nsibidiMeta: yup.array().min(0).of(yup.string()).optional(),
     definitions: yup.mixed().test('definition-types', 'Definition is required', (value) => {
       if (Array.isArray(value)) {
         return value.length >= 1 && value[0].length >= 1;
@@ -34,6 +35,7 @@ const schema = yup.object().shape({
     igboDefinitions: yup.array().min(0).of(yup.object().shape({
       igbo: yup.string().optional(),
       nsibidi: yup.string().optional(),
+      nsibidiMeta: yup.array().min(0).of(yup.string()).optional(),
     })).optional(),
   })),
   variations: yup.array().min(0).of(yup.string()),

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -22,7 +22,9 @@ const schema = yup.object().shape({
       label: yup.mixed().oneOf(Object.values(WordClass).map(({ label }) => label)),
     }).required(),
     nsibidi: yup.string().optional(),
-    nsibidiMeta: yup.array().min(0).of(yup.string()).optional(),
+    nsibidiCharacters: yup.array().min(0).of(yup.object().shape({
+      id: yup.string(),
+    })).optional(),
     definitions: yup.mixed().test('definition-types', 'Definition is required', (value) => {
       if (Array.isArray(value)) {
         return value.length >= 1 && value[0].length >= 1;
@@ -35,7 +37,9 @@ const schema = yup.object().shape({
     igboDefinitions: yup.array().min(0).of(yup.object().shape({
       igbo: yup.string().optional(),
       nsibidi: yup.string().optional(),
-      nsibidiMeta: yup.array().min(0).of(yup.string()).optional(),
+      nsibidiCharacters: yup.array().min(0).of(yup.object().shape({
+        id: yup.string(),
+      })).optional(),
     })).optional(),
   })),
   variations: yup.array().min(0).of(yup.string()),

--- a/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
@@ -132,4 +132,21 @@ describe('Word Edit', () => {
     userEvent.type(await findByTestId('word-input'), 'new headword');
     await findByTestId('audio-recording-warning-message');
   });
+
+  it('render nsibidi options', async () => {
+    const { findByTestId, findByText } = render(
+      <TestContext>
+        <WordEditForm
+          view={Views.EDIT}
+          resource={Collections.WORD_SUGGESTIONS}
+          record={{ id: '123', definitions: [{ wordClass: 'NNC', definitions: [] }] }}
+          save={() => {}}
+          history={{}}
+        />
+      </TestContext>,
+    );
+    userEvent.type(await findByTestId('nsibidi-input'), 'nsibidi');
+    await findByText('first definition');
+    await findByText('first pronunciation');
+  });
 });

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
@@ -10,6 +10,7 @@ import IgboDefinitions from './IgboDefinitions';
 
 const DefinitionsForm = ({
   getValues,
+  setValue,
   options,
   record,
   definitions,
@@ -117,7 +118,9 @@ const DefinitionsForm = ({
                 control={control}
                 record={record}
                 getValues={getValues}
+                setValue={setValue}
                 name={`definitions[${index}].nsibidi`}
+                errors={errors}
               />
             </Box>
             <Box className="flex flex-row items-center my-5 w-full justify-between">
@@ -141,6 +144,10 @@ const DefinitionsForm = ({
                 control={control}
                 handleDeleteGroupIgboDefinition={handleDeleteGroupIgboDefinition}
                 handleAddGroupIgboDefinition={handleAddGroupIgboDefinition}
+                errors={errors}
+                record={record}
+                getValues={getValues}
+                setValue={setValue}
               />
             </Box>
             {(errors.definitions || [])[index] ? (

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsFormInterface.ts
@@ -3,7 +3,8 @@ import { Control } from 'react-hook-form';
 import { DefinitionSchema } from 'src/backend/controllers/utils/interfaces';
 
 interface DefinitionsForm {
-  getValues: (value: any) => any,
+  getValues: (key?: any) => any,
+  setValue: (key: string, value: any) => void,
   options: any,
   record: Record,
   definitions: DefinitionSchema[],

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/IgboDefinitions.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/IgboDefinitions.tsx
@@ -1,24 +1,33 @@
 import React, { ReactElement } from 'react';
 import { Control, Controller } from 'react-hook-form';
+import { Record } from 'react-admin';
 import { Box, IconButton } from '@chakra-ui/react';
 import { DeleteIcon } from '@chakra-ui/icons';
 import { Textarea } from 'src/shared/primitives';
 import { DefinitionSchema } from 'src/backend/controllers/utils/interfaces';
-import NsibidiInput from '../NsibidiForm/NsibidiInput';
 import AddSection from './AddSection';
+import NsibidiForm from '../NsibidiForm';
 
 const IgboDefinitions = ({
   igboDefinitions,
   index,
   control,
+  errors,
   handleDeleteGroupIgboDefinition,
   handleAddGroupIgboDefinition,
+  record,
+  getValues,
+  setValue,
 } : {
   igboDefinitions: DefinitionSchema['igboDefinitions'],
   index: number,
   control: Control,
   handleDeleteGroupIgboDefinition: (value: number, secondValue: number) => void,
   handleAddGroupIgboDefinition: (value: number) => void,
+  errors: any,
+  record: Record,
+  getValues: (key?: string) => any,
+  setValue: (key: string, value) => void,
 }): ReactElement => (
   <Box className="w-full">
     {igboDefinitions.map((igboDefinition, igboDefinitionIndex) => (
@@ -42,17 +51,15 @@ const IgboDefinitions = ({
               defaultValue={igboDefinition?.igbo || ''}
               control={control}
             />
-            <Controller
-              render={(props) => (
-                <NsibidiInput
-                  {...props}
-                  placeholder="Definition in Nsịbịdị"
-                  data-test={`nested-definitions-nsibidi-${igboDefinitionIndex}-input`}
-                />
-              )}
-              name={`definitions[${index}].igboDefinitions[${igboDefinitionIndex}].nsibidi`}
-              defaultValue={igboDefinition?.nsibidi || ''}
+            <NsibidiForm
               control={control}
+              record={record}
+              getValues={getValues}
+              setValue={setValue}
+              name={`definitions[${index}].igboDefinitions[${igboDefinitionIndex}].nsibidi`}
+              placeholder="Definition in Nsịbịdị"
+              data-test={`nested-definitions-nsibidi-${igboDefinitionIndex}-input`}
+              errors={errors}
             />
           </Box>
           <IconButton

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
@@ -56,6 +56,16 @@ const Example = ({
     updatedExamples[index].nsibidi = e.target.value;
   };
 
+  const handleAppendNsibidiCharacter = (nsibidiCharacterId) => {
+    const updatedExamples = [...examples];
+    updatedExamples[index].nsibidiCharacters.push(nsibidiCharacterId);
+  };
+
+  const handleDeleteNsibidiCharacter = (index) => {
+    const updatedExamples = [...examples];
+    updatedExamples.splice(index, 1);
+  };
+
   const handleSetPronunciation = (path, value) => {
     // Setting the react-hook-form value
     const updatedExamples = [...examples];
@@ -113,6 +123,9 @@ const Example = ({
           placeholder="Example in Nsịbịdị"
           data-test={`examples-${index}-nsibidi-input`}
           defaultValue={nsibidi || (formData.examples && formData.examples[index]?.nsibidi) || ''}
+          append={handleAppendNsibidiCharacter}
+          remove={handleDeleteNsibidiCharacter}
+          nsibidiCharacterIds={examples[index].nsibidiCharacters}
         />
         <AudioRecorder
           path="pronunciation"

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/ExamplesInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/ExamplesInterface.ts
@@ -5,6 +5,7 @@ interface ExamplesFormInterface {
   example: Example,
   setExamples: (value: any) => void,
   getValues: (key?: string) => any,
+  setValue: (key: string, value: any) => void,
   index: number,
   definitionGroupId?: string,
 };

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiCharacters.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiCharacters.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import { Box, Spinner } from '@chakra-ui/react';
+import { compact } from 'lodash';
+import { WordPills } from 'src/shared/primitives';
+import { resolveNsibidiCharacter } from 'src/shared/API';
+
+const NsibidiCharacters = (
+  {
+    nsibidiCharacterIds,
+    remove,
+  }
+  : {
+    nsibidiCharacterIds: { id: string }[],
+    remove: (index: number) => void,
+  },
+): ReactElement => {
+  const [resolvedNsibidiCharacters, setResolvedNsibidiCharacters] = useState(null);
+  const [isLoadingNsibidiCharacters, setIsLoadingNsibidiCharacters] = useState(false);
+
+  const resolveNsibidiCharacters = async () => {
+    setIsLoadingNsibidiCharacters(true);
+    try {
+      /**
+       * We compact the resolved Nsibidi characters so that if an Nsibidi character cannot be found
+       * by its MongoDB Id or regular Nsibidi character search the compact array will omit null values.
+       */
+      const compactedResolvedNsibidiCharacters = compact(
+        await Promise.all(nsibidiCharacterIds.map(async ({ id: nsibidiCharacterId }) => {
+          const nsibidiCharacter = await resolveNsibidiCharacter(nsibidiCharacterId).catch(() => null);
+          return nsibidiCharacter;
+        })),
+      );
+      setResolvedNsibidiCharacters(compactedResolvedNsibidiCharacters);
+      return compactedResolvedNsibidiCharacters;
+    } finally {
+      setIsLoadingNsibidiCharacters(false);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      await resolveNsibidiCharacters();
+    })();
+  }, [nsibidiCharacterIds]);
+
+  return isLoadingNsibidiCharacters ? (
+    <Spinner />
+  ) : resolvedNsibidiCharacters && resolvedNsibidiCharacters.length ? (
+    <Box display="flex" flexDirection="column" className="space-y-3 py-4">
+      <WordPills
+        pills={resolvedNsibidiCharacters}
+        onDelete={remove}
+      />
+    </Box>
+  ) : (
+    <Box className="flex w-full justify-center">
+      <p className="text-gray-600 mb-4">No Nsibidi characters</p>
+    </Box>
+  );
+};
+
+export default NsibidiCharacters;

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiForm.tsx
@@ -11,7 +11,7 @@ const NsibidiForm = React.forwardRef(({
   record,
   getValues,
   setValue,
-  name,
+  name = 'nsibidi',
   errors,
   hideFormHeader,
   defaultValue,

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiForm.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { get } from 'lodash';
 import { Box } from '@chakra-ui/react';
-import { Controller } from 'react-hook-form';
+import { Controller, useFieldArray } from 'react-hook-form';
 import FormHeader from '../../../FormHeader';
 import NsidibiFormInterface from './NsidibiFormInterface';
 import NsibidiInput from './NsibidiInput';
@@ -10,25 +10,64 @@ const NsibidiForm = React.forwardRef(({
   control,
   record,
   getValues,
+  setValue,
   name,
-}: NsidibiFormInterface, ref): ReactElement => (
-  <Box ref={ref} className="flex flex-col w-full">
-    <FormHeader
-      title="Nsịbịdị"
-      tooltip={`Nsịbịdị is a West African native script that relies on buildable icons.
-      Since Nsịbịdị isn't officially supported by unicode values like Latin or Chinese script,
-      please reach out to the #translators Slack group to request the ability to edt this field.
-      `}
-    />
-    <Controller
-      render={(props) => (
-        <NsibidiInput {...props} />
-      )}
-      name={name || 'nsibidi'}
-      control={control}
-      defaultValue={(name ? get(record, name) : (record.nsibidi || getValues().nsibidi)) || ''}
-    />
-  </Box>
-));
+  errors,
+  hideFormHeader,
+  defaultValue,
+  ...rest
+}: NsidibiFormInterface, ref): ReactElement => {
+  const nsibidiCharactersName = `${name}Characters` || 'nsibidiCharacters';
+  const { fields: nsibidiCharacters, append, remove } = useFieldArray({
+    control,
+    name: nsibidiCharactersName,
+  });
+  return (
+    <Box ref={ref} className="flex flex-col w-full">
+      {!hideFormHeader ? (
+        <FormHeader
+          title="Nsịbịdị"
+          tooltip={`Nsịbịdị is a West African native script that relies on ideographic glyphs.
+          Since Nsịbịdị isn't officially supported by unicode values like Latin or Chinese script,
+          please reach out to the #translators Slack group to request the ability to edt this field.
+          `}
+        />
+      ) : null}
+      <Controller
+        render={(props) => (
+          <NsibidiInput
+            {...props}
+            {...rest}
+            append={append}
+            remove={remove}
+            nsibidiCharacterIds={nsibidiCharacters}
+          />
+        )}
+        name={name || 'nsibidi'}
+        control={control}
+        defaultValue={defaultValue || (name ? get(record, name) : (record.nsibidi || getValues().nsibidi)) || ''}
+      />
+      {nsibidiCharacters.map(({ id: nsibidiCharacterId }, index) => {
+        const currentNsibidiCharacterName = `${nsibidiCharactersName}.${index}.id`;
+        return (
+          <Controller
+            render={(props) => (
+              <input
+                {...props}
+                style={{ opacity: 0, position: 'absolute', pointerEvents: 'none' }}
+              />
+            )}
+            name={currentNsibidiCharacterName}
+            control={control}
+            defaultValue={nsibidiCharacterId}
+          />
+        );
+      })}
+      {get(errors, `${name || 'nsibidi'}`) ? (
+        <p className="error">{errors.nsibidi.message}</p>
+      ) : null}
+    </Box>
+  );
+});
 
 export default NsibidiForm;

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiInput.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiInput.tsx
@@ -1,6 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { useState, ReactElement, useEffect } from 'react';
 import { Text, Tooltip, chakra } from '@chakra-ui/react';
 import { Input } from 'src/shared/primitives';
+import { getNsibidiCharacters } from 'src/shared/API';
+import NsibidiDropdown from './components/NsibidiDropdown';
 
 const NsibidiInput = React.forwardRef((props : {
   value: string
@@ -9,11 +11,33 @@ const NsibidiInput = React.forwardRef((props : {
   'data-test'?: string,
   defaultValue?: string,
 }, ref): ReactElement => {
+  const [nsibidiOptions, setNsibidiOptions] = useState([]);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const [isNsibidiDropdownVisible, setIsNsibidiDropdownVisible] = useState(false);
   const {
     value,
     placeholder = 'i.e. 貝名, 貝è捧捧, 和硝',
     'data-test': dataTest = 'nsibidi-input',
   } = props;
+
+  const handleNsibidiChange = async (e: HTMLInputElement) => {
+    const input = e.target.value;
+    const nsibidiCharacters = await getNsibidiCharacters(input);
+    // TODO: filter out characters that are already attached
+    setNsibidiOptions(nsibidiCharacters);
+  };
+
+  const handleFocusInput = () => {
+    setIsInputFocused(true);
+  };
+
+  const handleBlurInput = () => {
+    setIsInputFocused(false);
+  };
+
+  useEffect(() => {
+    setIsNsibidiDropdownVisible(nsibidiOptions.length && isInputFocused);
+  }, [isInputFocused, nsibidiOptions]);
   return (
     <>
       <Input
@@ -21,6 +45,9 @@ const NsibidiInput = React.forwardRef((props : {
         ref={ref}
         placeholder={placeholder}
         data-test={dataTest}
+        onChange={handleNsibidiChange}
+        onFocus={handleFocusInput}
+        onBlur={handleBlurInput}
       />
       {value ? (
         <Tooltip
@@ -32,6 +59,9 @@ const NsibidiInput = React.forwardRef((props : {
             <chakra.span className="akagu">{value}</chakra.span>
           </Text>
         </Tooltip>
+      ) : null}
+      {isNsibidiDropdownVisible ? (
+        <NsibidiDropdown />
       ) : null}
     </>
   );

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsidibiFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsidibiFormInterface.ts
@@ -5,7 +5,12 @@ interface NsidibiForm {
   control: Control,
   record: Record,
   getValues: (key?: string) => any,
-  name?: string
+  setValue: (key: string, value: any) => void,
+  name?: string,
+  errors: any,
+  hideFormHeader?: boolean,
+  defaultValue?: any,
+  placeholder?: string,
 };
 
 export default NsidibiForm;

--- a/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@chakra-ui/react';
 import { AddIcon } from '@chakra-ui/icons';
 import { Controller } from 'react-hook-form';
-import { Input, WordPill } from 'src/shared/primitives';
+import { Input, WordPills } from 'src/shared/primitives';
 import { getWord, resolveWord } from 'src/shared/API';
 import RelatedTermsFormInterface from './RelatedTermsFormInterface';
 import FormHeader from '../../../FormHeader';
@@ -34,6 +34,13 @@ const RelatedTerms = (
       setIsLoadingRelatedTerms(false);
     }
   };
+
+  const handleDeleteRelatedTerms = (index: number) => {
+    const filteredRelatedTerms = [...relatedTermIds];
+    filteredRelatedTerms.splice(index, 1);
+    updateRelatedTerms(filteredRelatedTerms);
+  };
+
   useEffect(() => {
     resolveRelatedTerms((relatedTerms) => {
       // Remove stale, invalid Word Ids
@@ -48,32 +55,10 @@ const RelatedTerms = (
     <Spinner />
   ) : resolvedRelatedTerms && resolvedRelatedTerms.length ? (
     <Box display="flex" flexDirection="column" className="space-y-3 py-4">
-      {resolvedRelatedTerms.map((word, index) => (
-        <Box
-          key={word.id}
-          display="flex"
-          flexDirection="row"
-          justifyContent="space-between"
-          alignItems="center"
-          borderColor="blue.400"
-          borderWidth="1px"
-          backgroundColor="blue.50"
-          borderRadius="full"
-          minWidth="36"
-          py={2}
-          px={6}
-        >
-          <WordPill
-            {...word}
-            index={index}
-            onDelete={() => {
-              const filteredRelatedTerms = [...relatedTermIds];
-              filteredRelatedTerms.splice(index, 1);
-              updateRelatedTerms(filteredRelatedTerms);
-            }}
-          />
-        </Box>
-      ))}
+      <WordPills
+        pills={resolvedRelatedTerms}
+        onDelete={handleDeleteRelatedTerms}
+      />
     </Box>
   ) : (
     <Box className="flex w-full justify-center">

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
@@ -9,7 +9,7 @@ import {
 import { AddIcon } from '@chakra-ui/icons';
 import { compact } from 'lodash';
 import { Controller } from 'react-hook-form';
-import { Input, WordPill } from 'src/shared/primitives';
+import { Input, WordPills } from 'src/shared/primitives';
 import { getWord, resolveWord } from 'src/shared/API';
 import FormHeader from '../../../FormHeader';
 import StemsFormInterface from './StemsFormInterface';
@@ -43,6 +43,12 @@ const Stems = (
     }
   };
 
+  const handleDeleteStems = (index: number) => {
+    const filteredStems = [...stemIds];
+    filteredStems.splice(index, 1);
+    updateStems(filteredStems);
+  };
+
   useEffect(() => {
     resolveStems((stems) => {
       // Remove stale, invalid Word Ids
@@ -57,32 +63,10 @@ const Stems = (
     <Spinner />
   ) : resolvedStems && resolvedStems.length ? (
     <Box display="flex" flexDirection="column" className="space-y-3 py-4">
-      {resolvedStems.map((word, index) => (
-        <Box
-          key={word.id}
-          display="flex"
-          flexDirection="row"
-          justifyContent="space-between"
-          alignItems="center"
-          borderColor="blue.400"
-          borderWidth="1px"
-          backgroundColor="blue.50"
-          borderRadius="full"
-          minWidth="36"
-          py={2}
-          px={6}
-        >
-          <WordPill
-            {...word}
-            index={index}
-            onDelete={() => {
-              const filteredStems = [...stemIds];
-              filteredStems.splice(index, 1);
-              updateStems(filteredStems);
-            }}
-          />
-        </Box>
-      ))}
+      <WordPills
+        pills={resolvedStems}
+        onDelete={handleDeleteStems}
+      />
     </Box>
   ) : (
     <Box className="flex w-full justify-center">
@@ -133,6 +117,7 @@ const StemsForm = ({
       setInput('');
     }
   };
+
   return (
     <Box className="w-full bg-gray-200 rounded-lg p-2 mb-2 " height="fit-content">
       <Controller

--- a/src/shared/components/views/components/utils.ts
+++ b/src/shared/components/views/components/utils.ts
@@ -8,3 +8,8 @@ export const onCancel = ({ view, resource, history }: { view: string, resource: 
   localStorage.removeItem('igbo-api-admin-form');
   return view === View.CREATE ? history.push(`/${resource}`) : history.push(View.SHOW);
 };
+
+/* Transforms nsibidiCharacters to be an array of just strings */
+export const sanitizeNsibidiCharacters = (nsibidiCharacters: { id: string }[]): string[] => (
+  nsibidiCharacters.map(({ id }) => id)
+);

--- a/src/shared/components/views/shows/ExampleShow/ExampleShow.tsx
+++ b/src/shared/components/views/shows/ExampleShow/ExampleShow.tsx
@@ -15,7 +15,10 @@ import Collection from 'src/shared/constants/Collections';
 import { getExample } from 'src/shared/API';
 import SourceField from 'src/shared/components/SourceField';
 import ResolvedWord from 'src/shared/components/ResolvedWord';
+import ResolvedNsibidiCharacter from 'src/shared/components/ResolvedNsibidiCharacter';
 import DiffField from '../diffFields/DiffField';
+import ArrayDiffField from '../diffFields/ArrayDiffField';
+import ArrayDiff from '../diffFields/ArrayDiff';
 import {
   ShowDocumentStats,
   EditDocumentIds,
@@ -26,7 +29,7 @@ import { determineDate } from '../../utils';
 
 const ExampleShow = (props: ShowProps): ReactElement => {
   const [isLoading, setIsLoading] = useState(true);
-  const [, setOriginalExampleRecord] = useState({});
+  const [originalExampleRecord, setOriginalExampleRecord] = useState({});
   const [diffRecord, setDiffRecord] = useState(null);
   const { record, resource } = useShowController(props);
   const { permissions } = props;
@@ -174,6 +177,23 @@ const ExampleShow = (props: ShowProps): ReactElement => {
                 fallbackValue={nsibidi}
                 renderNestedObject={(value) => <chakra.span className="akagu">{String(value || false)}</chakra.span>}
               />
+              <Box className="flex flex-col">
+                <Heading fontSize="lg" className="text-xl text-gray-600">Nsịbịdị Characters</Heading>
+                <ArrayDiffField
+                  recordField="nsibidiCharacters"
+                  recordFieldSingular="nsibidiCharacter"
+                  record={record}
+                  originalRecord={originalExampleRecord}
+                >
+                  <ArrayDiff
+                    diffRecord={diffRecord}
+                    recordField="nsibidiCharacters"
+                    renderNestedObject={(nsibidiCharacterId) => (
+                      <ResolvedNsibidiCharacter nsibidiCharacterId={nsibidiCharacterId} />
+                    )}
+                  />
+                </ArrayDiffField>
+              </Box>
               <Box className="flex flex-col mt-5">
                 <Text fontWeight="bold" className="text-xl text-gray-600">Associated Words</Text>
                 {associatedWords?.length ? associatedWords?.map((associatedWord, index) => (

--- a/src/shared/components/views/shows/ExampleShow/__tests__/ExampleShow.test.tsx
+++ b/src/shared/components/views/shows/ExampleShow/__tests__/ExampleShow.test.tsx
@@ -39,6 +39,7 @@ describe('Example Show', () => {
     await findByText('first igbo example');
     await findByText('first english example');
     await findByText('English');
+    await findByText('Nsịbịdị');
     await findByText('Associated Words');
     expect(await queryByText('Editor\'s Note')).toBeNull();
     expect(await queryByText('User\'s comments')).toBeNull();

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -18,6 +18,7 @@ import WordClass from 'src/shared/constants/WordClass';
 import { getWord } from 'src/shared/API';
 import CompleteWordPreview from 'src/shared/components/CompleteWordPreview';
 import ResolvedWord from 'src/shared/components/ResolvedWord';
+import ResolvedNsibidiCharacter from 'src/shared/components/ResolvedNsibidiCharacter';
 import SourceField from 'src/shared/components/SourceField';
 import generateFlags from 'src/shared/utils/flagHeadword';
 import * as Interfaces from 'src/backend/controllers/utils/interfaces';
@@ -267,6 +268,23 @@ const WordShow = (props: ShowProps): ReactElement => {
                         <span className={value ? 'akagu' : ''}>{value || 'N/A'}</span>
                       )}
                     />
+                  </Box>
+                  <Box className="flex flex-col">
+                    <Heading fontSize="lg" className="text-xl text-gray-600">Nsịbịdị Characters</Heading>
+                    <ArrayDiffField
+                      recordField={`definitions.${index}.nsibidiCharacters`}
+                      recordFieldSingular="nsibidiCharacter"
+                      record={record}
+                      originalWordRecord={originalWordRecord}
+                    >
+                      <ArrayDiff
+                        diffRecord={diffRecord}
+                        recordField={`definitions.${index}.definitions`}
+                        renderNestedObject={(nsibidiCharacterId) => (
+                          <ResolvedNsibidiCharacter nsibidiCharacterId={nsibidiCharacterId} />
+                        )}
+                      />
+                    </ArrayDiffField>
                   </Box>
                   <Box className="flex flex-col">
                     <Heading fontSize="md" className="text-xl text-gray-600">English Definitions</Heading>

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -275,11 +275,11 @@ const WordShow = (props: ShowProps): ReactElement => {
                       recordField={`definitions.${index}.nsibidiCharacters`}
                       recordFieldSingular="nsibidiCharacter"
                       record={record}
-                      originalWordRecord={originalWordRecord}
+                      originalRecord={originalWordRecord}
                     >
                       <ArrayDiff
                         diffRecord={diffRecord}
-                        recordField={`definitions.${index}.definitions`}
+                        recordField={`definitions.${index}.nsibidiCharacters`}
                         renderNestedObject={(nsibidiCharacterId) => (
                           <ResolvedNsibidiCharacter nsibidiCharacterId={nsibidiCharacterId} />
                         )}
@@ -292,7 +292,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                       recordField={`definitions.${index}.definitions`}
                       recordFieldSingular="definition"
                       record={record}
-                      originalWordRecord={originalWordRecord}
+                      originalRecord={originalWordRecord}
                     >
                       <ArrayDiff diffRecord={diffRecord} recordField={`definitions.${index}.definitions`} />
                     </ArrayDiffField>
@@ -303,7 +303,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                       recordField={`definitions.${index}.igboDefinitions`}
                       recordFieldSingular="igboDefinition"
                       record={record}
-                      originalWordRecord={originalWordRecord}
+                      originalRecord={originalWordRecord}
                     >
                       <ArrayDiff
                         diffRecord={diffRecord}
@@ -326,7 +326,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                 recordField="variations"
                 recordFieldSingular="variation"
                 record={record}
-                originalWordRecord={originalWordRecord}
+                originalRecord={originalWordRecord}
               >
                 <ArrayDiff diffRecord={diffRecord} recordField="variations" />
               </ArrayDiffField>
@@ -337,7 +337,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                 recordField="stems"
                 recordFieldSingular="stem"
                 record={record}
-                originalWordRecord={originalWordRecord}
+                originalRecord={originalWordRecord}
               >
                 <ArrayDiff
                   diffRecord={diffRecord}
@@ -352,7 +352,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                 recordField="relatedTerms"
                 recordFieldSingular="relatedTerm"
                 record={record}
-                originalWordRecord={originalWordRecord}
+                originalRecord={originalWordRecord}
               >
                 <ArrayDiff
                   diffRecord={diffRecord}
@@ -368,7 +368,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                   recordField="examples"
                   recordFieldSingular="example"
                   record={{ examples } as Interfaces.Word}
-                  originalWordRecord={originalWordRecord}
+                  originalRecord={originalWordRecord}
                 >
                   <ExampleDiff
                     diffRecord={diffRecord}
@@ -401,7 +401,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                     recordField="tags"
                     recordFieldSingular="tag"
                     record={record}
-                    originalWordRecord={originalWordRecord}
+                    originalRecord={originalWordRecord}
                   >
                     <ArrayDiff diffRecord={diffRecord} recordField="tags" />
                   </ArrayDiffField>

--- a/src/shared/components/views/shows/WordShow/__tests__/WordShow.test.tsx
+++ b/src/shared/components/views/shows/WordShow/__tests__/WordShow.test.tsx
@@ -87,6 +87,7 @@ describe('Word Show', () => {
     await findByText('Is Slang');
     await findByText('Is Constructed Term');
     await findByText('Nsịbịdị');
+    await findByText('Nsịbịdị Characters');
     await findByText('Definition Groups');
     await findByText('Part of Speech');
     await findByText('English Definitions');

--- a/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
+++ b/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
@@ -1,21 +1,21 @@
 import React, { ReactElement } from 'react';
 import { capitalize, get, has } from 'lodash';
 import { Box, Text } from '@chakra-ui/react';
-import * as Interfaces from 'src/backend/controllers/utils/interfaces';
+import { Word, Example } from 'src/backend/controllers/utils/interfaces';
 
 const ArrayDiffField = (
   {
     recordField,
     recordFieldSingular,
     record,
-    originalWordRecord,
+    originalRecord,
     children = [],
   }
   : {
     recordField: string,
     recordFieldSingular: string,
-    record: Interfaces.Word,
-    originalWordRecord: Interfaces.Word,
+    record: Word | Example,
+    originalRecord: Word | Example,
     children: ReactElement[] | ReactElement,
   },
 ): ReactElement => {
@@ -23,10 +23,10 @@ const ArrayDiffField = (
   // getting the longest one
   const longestRecordField = (recordField === 'examples'
     ? get(record, recordField)
-    : !originalWordRecord || !has(originalWordRecord, recordField)
+    : !originalRecord || !has(originalRecord, recordField)
       ? get(record, recordField)
-      : get(originalWordRecord, recordField)?.length > get(record, recordField)?.length
-        ? get(originalWordRecord, recordField)
+      : get(originalRecord, recordField)?.length > get(record, recordField)?.length
+        ? get(originalRecord, recordField)
         : get(record, recordField)) || [];
 
   return longestRecordField?.length ? longestRecordField?.map((value, index) => (

--- a/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
+++ b/src/shared/components/views/shows/diffFields/ArrayDiffField.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { get, has } from 'lodash';
+import { capitalize, get, has } from 'lodash';
 import { Box, Text } from '@chakra-ui/react';
 import * as Interfaces from 'src/backend/controllers/utils/interfaces';
 
@@ -21,13 +21,13 @@ const ArrayDiffField = (
 ): ReactElement => {
   // If we have examples, we want to use the current record examples array instead of
   // getting the longest one
-  const longestRecordField = recordField === 'examples'
+  const longestRecordField = (recordField === 'examples'
     ? get(record, recordField)
     : !originalWordRecord || !has(originalWordRecord, recordField)
       ? get(record, recordField)
       : get(originalWordRecord, recordField)?.length > get(record, recordField)?.length
         ? get(originalWordRecord, recordField)
-        : get(record, recordField);
+        : get(record, recordField)) || [];
 
   return longestRecordField?.length ? longestRecordField?.map((value, index) => (
     <Box
@@ -41,7 +41,7 @@ const ArrayDiffField = (
         React.cloneElement(child, { value, index })
       ))}
     </Box>
-  )) : <Text className="text-gray-500 italic">{`No ${recordField}`}</Text>;
+  )) : <Text className="text-gray-500 italic">{`No ${capitalize(recordField)}`}</Text>;
 };
 
 export default ArrayDiffField;

--- a/src/shared/constants/Collections.ts
+++ b/src/shared/constants/Collections.ts
@@ -9,6 +9,7 @@ enum Collections {
   USERS = 'users',
   POLLS = 'polls',
   NOTIFICATIONS = 'notifications',
+  NSIBIDI_CHARACTERS = 'nsibidiCharacters',
   DATA_DUMP = 'dataDump',
 };
 

--- a/src/shared/constants/WordClass.ts
+++ b/src/shared/constants/WordClass.ts
@@ -5,85 +5,106 @@ export default {
   ADJ: {
     value: 'ADJ',
     label: 'Adjective',
+    nsibidiValue: '依名器',
   },
   ADV: {
     value: 'ADV',
     label: 'Adverb',
+    nsibidiValue: 'ń器動',
   },
   AV: {
     value: 'AV',
     label: 'Active verb',
+    nsibidiValue: '動壊',
   },
   MV: {
     value: 'MV',
     label: 'Medial verb',
+    nsibidiValue: '論動',
   },
   PV: {
     value: 'PV',
     label: 'Passive verb',
+    nsibidiValue: 'ò轄動',
   },
   CJN: {
     value: 'CJN',
     label: 'Conjunction',
+    nsibidiValue: '依ǫ接接',
   },
   DEM: {
     value: 'DEM',
     label: 'Demonstrative',
+    nsibidiValue: 'ǫ探動',
   },
   NM: {
     value: 'NM',
     label: 'Name',
+    nsibidiValue: '名',
   },
   NNC: {
     value: 'NNC',
     label: 'Noun',
+    nsibidiValue: '依名',
   },
   ND: {
     value: 'ND',
     label: 'Nominal Modifier',
+    nsibidiValue: '名核伸',
   },
   NNP: {
     value: 'NNP',
     label: 'Proper noun',
+    nsibidiValue: '依名以',
   },
   CD: {
     value: 'CD',
     label: 'Number',
+    nsibidiValue: '口控',
   },
   PREP: {
     value: 'PREP',
     label: 'Preposition',
+    nsibidiValue: '簡残',
   },
   PRN: {
     value: 'PRN',
     label: 'Pronoun',
+    nsibidiValue: '依名衣',
   },
   FW: {
     value: 'FW',
     label: 'Foreign word',
+    nsibidiValue: '接穀',
   },
   QTF: {
     value: 'QTF',
     label: 'Quantifier',
+    nsibidiValue: '接感口',
   },
   WH: {
     value: 'WH',
     label: 'Interrogative',
+    nsibidiValue: 'ǹ絵',
   },
   INTJ: {
     value: 'INTJ',
     label: 'Interjection',
+    nsibidiValue: '撃岐営依',
   },
   ISUF: {
     value: 'ISUF',
     label: 'Inflectional suffix',
+    nsibidiValue: '壊興動',
   },
   ESUF: {
     value: 'ESUF',
     label: 'Extensional suffix',
+    nsibidiValue: '壊査動',
   },
   SYM: {
     value: 'SYM',
     label: 'Punctuations',
+    nsibidiValue: 'ò韻ǹ肝',
   },
 };

--- a/src/shared/primitives/WordPills/WordPill.tsx
+++ b/src/shared/primitives/WordPills/WordPill.tsx
@@ -12,7 +12,7 @@ import { CloseIcon } from '@chakra-ui/icons';
 const WordPill = ({
   nsibidi,
   definitions,
-  pronunciations,
+  pronunciation,
   word,
   onDelete,
   index,
@@ -21,7 +21,7 @@ const WordPill = ({
   nsibidi?: string,
   wordClass?: string,
   definitions: ({ text: string } | string)[],
-  pronunciations?: { text: string }[],
+  pronunciation?: string,
   onDelete: () => void;
   index: number,
 }): ReactElement => (
@@ -47,7 +47,7 @@ const WordPill = ({
           {word || nsibidi}
         </Text>
         <Text fontSize="xs" fontStyle="italic" color="blue.400">
-          {get(pronunciations, '[0].text') || get(definitions, '[0].wordClass')}
+          {pronunciation || get(definitions, '[0].wordClass')}
         </Text>
       </Box>
       <Text fontSize="xs" color="blue.400">

--- a/src/shared/primitives/WordPills/WordPill.tsx
+++ b/src/shared/primitives/WordPills/WordPill.tsx
@@ -10,24 +10,33 @@ import {
 import { CloseIcon } from '@chakra-ui/icons';
 
 const WordPill = ({
-  word,
+  nsibidi,
   definitions,
+  pronunciations,
+  word,
   onDelete,
   index,
 }: {
-  word: string,
-  wordClass: string,
-  definitions: [string],
+  word?: string,
+  nsibidi?: string,
+  wordClass?: string,
+  definitions: ({ text: string } | string)[],
+  pronunciations?: { text: string }[],
   onDelete: () => void;
   index: number,
 }): ReactElement => (
   <Box
     data-test={`word-pill-${index}`}
-    width="full"
+    width="fit-content"
     display="flex"
     flexDirection="row"
     justifyContent="space-between"
     alignItems="center"
+    borderColor="blue.400"
+    borderWidth="1px"
+    backgroundColor="blue.50"
+    borderRadius="md"
+    p={2}
   >
     <Box display="flex" flexDirection="column" className="space-y-1">
       <Box display="flex" flexDirection="row" alignItems="center" className="space-x-2">
@@ -35,12 +44,14 @@ const WordPill = ({
           <chakra.span fontWeight="normal">
             {`${index + 1}. `}
           </chakra.span>
-          {word}
+          {word || nsibidi}
         </Text>
-        <Text fontSize="sm" fontStyle="italic" color="blue.400">{get(definitions, '[0].wordClass')}</Text>
+        <Text fontSize="xs" fontStyle="italic" color="blue.400">
+          {get(pronunciations, '[0].text') || get(definitions, '[0].wordClass')}
+        </Text>
       </Box>
-      <Text fontSize="sm" color="blue.400">
-        {truncate(get(definitions, '[0].definitions[0]'))}
+      <Text fontSize="xs" color="blue.400" m={0}>
+        {truncate(get(definitions, '[0].text') || get(definitions, '[0].definitions[0]'))}
       </Text>
     </Box>
     <Tooltip label="Remove item">
@@ -55,7 +66,7 @@ const WordPill = ({
         _active={{
           backgroundColor: 'transparent',
         }}
-        icon={<CloseIcon boxSize={4} />}
+        icon={<CloseIcon boxSize={3} />}
       />
     </Tooltip>
   </Box>

--- a/src/shared/primitives/WordPills/WordPill.tsx
+++ b/src/shared/primitives/WordPills/WordPill.tsx
@@ -38,8 +38,8 @@ const WordPill = ({
     borderRadius="md"
     p={2}
   >
-    <Box display="flex" flexDirection="column" className="space-y-1">
-      <Box display="flex" flexDirection="row" alignItems="center" className="space-x-2">
+    <Box display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="row" alignItems="start" className="space-x-2">
         <Text fontSize="sm" color="blue.500" fontWeight="bold">
           <chakra.span fontWeight="normal">
             {`${index + 1}. `}
@@ -50,7 +50,7 @@ const WordPill = ({
           {get(pronunciations, '[0].text') || get(definitions, '[0].wordClass')}
         </Text>
       </Box>
-      <Text fontSize="xs" color="blue.400" m={0}>
+      <Text fontSize="xs" color="blue.400">
         {truncate(get(definitions, '[0].text') || get(definitions, '[0].definitions[0]'))}
       </Text>
     </Box>
@@ -59,6 +59,9 @@ const WordPill = ({
         variant="ghost"
         color="red.400"
         aria-label="Remove"
+        minWidth={6}
+        alignItems="start"
+        justifyContent="end"
         onClick={onDelete}
         _hover={{
           backgroundColor: 'transparent',

--- a/src/shared/primitives/WordPills/WordPills.tsx
+++ b/src/shared/primitives/WordPills/WordPills.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+import { Box } from '@chakra-ui/react';
+import { NsibidiCharacter, Word } from 'src/backend/controllers/utils/interfaces';
+import WordPill from './WordPill';
+
+const WordPills = ({
+  pills,
+  onDelete,
+} : {
+  pills: (Word | NsibidiCharacter)[],
+  onDelete: (index: number) => void,
+}): ReactElement => (
+  <Box className="w-full space-x-2 flex flex-row flex-wrap items-center justify-start">
+    {pills.map((pill, index) => (
+      <WordPill
+        {...pill}
+        key={pill.id.toString()}
+        index={index}
+        onDelete={() => onDelete(index)}
+      />
+    ))}
+  </Box>
+);
+
+export default WordPills;

--- a/src/shared/primitives/WordPills/index.tsx
+++ b/src/shared/primitives/WordPills/index.tsx
@@ -1,0 +1,3 @@
+import WordPills from './WordPills';
+
+export default WordPills;

--- a/src/shared/primitives/index.ts
+++ b/src/shared/primitives/index.ts
@@ -1,11 +1,11 @@
 import CreateButton from './CreateButton';
 import Input from './Input';
 import Textarea from './Textarea';
-import WordPill from './WordPill';
+import WordPills from './WordPills';
 
 export {
   CreateButton,
   Input,
   Textarea,
-  WordPill,
+  WordPills,
 };


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | N/A |

## Requested Feature
The Nsịbịdị lexicographers requested to be able to attach more metadata information associated with Nsịbịdị in the database. While a lexicographer is typing in the Chinese Unicode for Nsịbịdị, a dropdown should appear that shows all relevant Nsịbịdị characters to be added to the word entry.

## Solution
* Implemented a dropdown that will act similar to the dropdown for related terms and word stems
* Show all attached Nsịbịdị documents in the Word and Example show views

## Before & After Screenshots

**BEFORE**:
Essentially, there was no dropdown that would appear within the Nsịbịdị Input components. There was also no Nsịbịdị Characters section within the Word Show component.

**AFTER**:
<img width="614" alt="Xnapper-2023-05-08-00 09 33" src="https://user-images.githubusercontent.com/16169291/236734241-38c9edd1-acd0-46c2-9497-7e2b7e647dba.png">
_Dropdown of nsibidi options to appear_

<img width="450" alt="Xnapper-2023-05-08-00 09 25" src="https://user-images.githubusercontent.com/16169291/236734244-13e6eaa5-ada4-41fa-87e5-baf62cd75818.png">
_Word pill to appear for selected nsibidi characters_

<img width="427" alt="Xnapper-2023-05-08-00 08 45" src="https://user-images.githubusercontent.com/16169291/236734246-237ac257-b8f4-44c2-b0eb-61f16c95c24e.png">
_Resolved nsibidi character document in the word show component_

  
## QA
_How did you test your solution?_
  
- [x] Wrote two new Jest tests
- [x] Manually QA'd the solution


## Other changes (e.g. bug fixes, UI tweaks, small refactors)
* Remove `jest-fetch-mock` from `package.json`
* Created `WordPills` to handle rendering multiple `WordPill` components in a group
