### PR TITLE
Igbo Definitions Flow

### DIFF
--- a/src/App/Resources.tsx
+++ b/src/App/Resources.tsx
@@ -24,6 +24,7 @@ import PollCreate from 'src/Core/Collections/Polls/PollCreate';
 import UserList from 'src/Core/Collections/Users/UserList';
 import UserShow from 'src/Core/Collections/Users/UserShow';
 import IgboSoundbox from 'src/Core/Collections/IgboSoundbox';
+import IgboDefinitions from 'src/Core/Collections/IgboDefinitions';
 import DataDump from 'src/Core/Collections/DataDump';
 import withLastRoute from './withLastRoute';
 
@@ -129,9 +130,16 @@ const transcriberRoutes = (permissions) => hasTranscriberPermissions(permissions
     list: IgboSoundbox,
     icon: () => <>🔊</>,
   },
+  {
+    name: 'igboDefinitions',
+    key: 'igboDefinitions',
+    options: { label: 'Igbo Definitions' },
+    list: IgboDefinitions,
+    icon: () => <>✍🏾</>,
+  },
 ]) || [];
 
-export const getResourceObjects = (permissions: any) => [
+export const getResourceObjects = (permissions: any): any => [
   ...editorRoutes(permissions),
   ...adminRoutes(permissions),
   ...transcriberRoutes(permissions),

--- a/src/Core/Collections/IgboDefinitions/IgboDefinitions.tsx
+++ b/src/Core/Collections/IgboDefinitions/IgboDefinitions.tsx
@@ -1,0 +1,174 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  ReactElement,
+} from 'react';
+import { compact, noop } from 'lodash';
+import {
+  Box,
+  Heading,
+  Input,
+  Spinner,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
+import { ActivityButton, Card, PrimaryButton } from 'src/shared/primitives';
+import WordClass from 'src/shared/constants/WordClass';
+import useBeforeWindowUnload from 'src/hooks/useBeforeWindowUnload';
+import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
+import { getWordSuggestionsWithoutIgboDefinitions, setWordSuggestionsWithoutIgboDefinitions } from 'src/shared/API';
+import NavbarWrapper from '../components/NavbarWrapper';
+import Completed from '../components/Completed';
+
+const IgboDefinitions = (): ReactElement => {
+  const [currentCardIndex, setCurrentCardIndex] = useState(0);
+  const [igboDefinitions, setIgboDefinitions] = useState<string[]>([]);
+  const [wordSuggestions, setWordSuggestions] = useState([]);
+  const [isComplete, setIsComplete] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [, setIsDirty] = useState(false);
+  const igboDefinitionInputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
+  const currentCard = wordSuggestions[currentCardIndex];
+  const showSubmitButton = (
+    currentCardIndex === wordSuggestions.length - 1
+    && igboDefinitions.some((igboDefinition) => !!igboDefinition)
+  );
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    try {
+      const payload = compact(igboDefinitions.map((igboDefinition, index) => igboDefinition && ({
+        id: wordSuggestions[index]._id,
+        igboDefinition,
+      })));
+      await setWordSuggestionsWithoutIgboDefinitions(payload);
+      setIsComplete(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleNext = () => {
+    setCurrentCardIndex(currentCardIndex + 1);
+    igboDefinitionInputRef.current.focus();
+  };
+
+  const handlePrevious = () => {
+    setCurrentCardIndex(currentCardIndex - 1);
+    igboDefinitionInputRef.current.focus();
+  };
+
+  const handleInputChange = (e) => {
+    const updatedIgboDefinitions = [...igboDefinitions];
+    updatedIgboDefinitions[currentCardIndex] = e.target.value;
+    setIgboDefinitions(updatedIgboDefinitions);
+  };
+
+  const fetchWordSuggestions = async () => {
+    try {
+      setIsLoading(true);
+      const fetchedWordSuggestions = await getWordSuggestionsWithoutIgboDefinitions();
+      setWordSuggestions(fetchedWordSuggestions);
+      setIgboDefinitions(fetchedWordSuggestions.map(() => ''));
+    } catch (err) {
+      toast({
+        title: 'Error loading Igbo definitions',
+        description: 'Unable to load Igbo definitions. Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /* Resets the page */
+  useEffect(() => {
+    if (!isComplete) {
+      setCurrentCardIndex(0);
+      setWordSuggestions([]);
+      setIgboDefinitions([]);
+      fetchWordSuggestions();
+      if (igboDefinitionInputRef.current) {
+        igboDefinitionInputRef.current.focus();
+      }
+    }
+  }, [isComplete]);
+  useBeforeWindowUnload();
+
+  return !isComplete ? (
+    <Box className="flex flex-col justify-center items-center">
+      <Box className="w-11/12 lg:w-full flex flex-col justify-center items-center">
+        <NavbarWrapper>
+          <Heading fontFamily="Silka" textAlign="center" width="full">Igbo Definitions</Heading>
+        </NavbarWrapper>
+        {currentCard ? (
+          <Card>
+            <Box className="flex flex-row justify-start items-center space-x-4">
+              <Text fontWeight="bold">{currentCard.word}</Text>
+              <Text fontStyle="italic">{WordClass[currentCard.definitions[0].wordClass].label}</Text>
+            </Box>
+            <Text>{currentCard.definitions[0].definitions[0]}</Text>
+          </Card>
+        ) : isLoading ? (
+          <Box minHeight="md" className="flex flex-row justify-center items-center">
+            <Spinner color="green" />
+          </Box>
+        ) : null}
+        <Box className="w-full flex flex-col justify-center items-center space-y-4" mb={12}>
+          {currentCard ? <Text>{`${currentCardIndex + 1} / ${wordSuggestions.length}`}</Text> : null}
+          {showSubmitButton ? (
+            <PrimaryButton
+              onClick={isLoading ? noop : handleSubmit}
+              rightIcon={(() => <>💾</>)()}
+              aria-label="Complete Igbo definitions"
+              disabled={isLoading}
+            >
+              Submit
+            </PrimaryButton>
+          ) : null}
+        </Box>
+        <Box className="flex flex-row relative w-full">
+          <Input
+            placeholder="Type Igbo definition here"
+            ref={igboDefinitionInputRef}
+            px={12}
+            value={igboDefinitions[currentCardIndex]}
+            onChange={handleInputChange}
+          />
+          <ActivityButton
+            tooltipLabel="Previous Igbo definition"
+            onClick={currentCardIndex === 0 ? noop : handlePrevious}
+            icon={<ArrowBackIcon />}
+            aria-label="Previous Igbo definition"
+            position="absolute"
+            disabled={currentCardIndex === 0}
+            left={0}
+          />
+          <ActivityButton
+            tooltipLabel="Next Igbo definition"
+            onClick={currentCardIndex === wordSuggestions.length - 1 ? noop : handleNext}
+            icon={<ArrowForwardIcon />}
+            aria-label="Next Igbo definition"
+            position="absolute"
+            disabled={currentCardIndex === wordSuggestions.length - 1}
+            right={0}
+          />
+        </Box>
+      </Box>
+    </Box>
+  ) : (
+    <Completed
+      type={CrowdsourcingType.INPUT_IGBO_DEFINITION}
+      setIsComplete={setIsComplete}
+      setIsDirty={setIsDirty}
+      goHome={() => noop}
+    />
+  );
+};
+
+export default IgboDefinitions;

--- a/src/Core/Collections/IgboDefinitions/index.tsx
+++ b/src/Core/Collections/IgboDefinitions/index.tsx
@@ -1,0 +1,3 @@
+import IgboDefinitions from './IgboDefinitions';
+
+export default IgboDefinitions;

--- a/src/Core/Collections/IgboSoundbox/RecordSentenceAudio.tsx
+++ b/src/Core/Collections/IgboSoundbox/RecordSentenceAudio.tsx
@@ -2,9 +2,7 @@ import React, { useEffect, useState, ReactElement } from 'react';
 import { noop } from 'lodash';
 import {
   Box,
-  Button,
   Heading,
-  IconButton,
   Spinner,
   Text,
   Tooltip,
@@ -13,8 +11,10 @@ import {
 import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 import { ExampleSuggestion } from 'src/backend/controllers/utils/interfaces';
 import { getRandomExampleSuggestions, putRandomExampleSuggestions } from 'src/shared/DataCollectionAPI';
+import { ActivityButton, Card, PrimaryButton } from 'src/shared/primitives';
+import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 import SandboxAudioRecorder from './SandboxAudioRecorder';
-import Completed from './Completed';
+import Completed from '../components/Completed';
 import EmptyExamples from './EmptyExamples';
 
 const RecordSentenceAudio = ({
@@ -125,47 +125,21 @@ const RecordSentenceAudio = ({
     >
       <Heading as="h1" fontSize="2xl" color="gray.600">Record sentence audio</Heading>
       <Text fontFamily="Silka">Record audio for each sentence</Text>
-      <Box
-        backgroundColor="gray.100"
-        borderRadius="md"
-        borderColor="gray.300"
-        borderWidth="1px"
-        minHeight={32}
-        width={['full', 'lg']}
-        m="12"
-        display="flex"
-        flexDirection="column"
-        justifyContent="center"
-        alignItems="center"
-        p="6"
-        className="space-y-6"
-      >
+      <Card>
         <Text fontSize="xl" textAlign="center" fontFamily="Silka" color="gray.700">
           {examples[exampleIndex].igbo}
         </Text>
-      </Box>
+      </Card>
       <Box className="mb-12 w-full flex flex-row justify-center items-center space-x-4">
-        <Tooltip label="You will not lose your current progress by going back.">
-          <IconButton
-            variant="ghost"
-            onClick={exampleIndex !== 0 ? handleBack : noop}
-            icon={<ArrowBackIcon />}
-            aria-label="Previous sentence"
-            disabled={exampleIndex === 0}
-            _hover={{
-              backgroundColor: 'white',
-            }}
-            _active={{
-              backgroundColor: 'white',
-            }}
-            _focus={{
-              backgroundColor: 'white',
-            }}
-          />
-        </Tooltip>
+        <ActivityButton
+          tooltipLabel="You will not lose your current progress by going back."
+          onClick={exampleIndex !== 0 ? handleBack : noop}
+          icon={<ArrowBackIcon />}
+          aria-label="Previous sentence"
+          disabled={exampleIndex === 0}
+        />
         <Text fontFamily="Silka" fontWeight="bold">{`${exampleIndex + 1} / ${examples.length}`}</Text>
-        <IconButton
-          variant="ghost"
+        <ActivityButton
           onClick={!examples[exampleIndex]
             ? handleSkip
             : exampleIndex === examples.length - 1
@@ -174,15 +148,6 @@ const RecordSentenceAudio = ({
           icon={<ArrowForwardIcon />}
           aria-label="Next sentence"
           disabled={exampleIndex === examples.length - 1}
-          _hover={{
-            backgroundColor: 'white',
-          }}
-          _active={{
-            backgroundColor: 'white',
-          }}
-          _focus={{
-            backgroundColor: 'white',
-          }}
         />
       </Box>
       <Box
@@ -206,19 +171,14 @@ const RecordSentenceAudio = ({
         >
           <Tooltip label={isCompleteDisabled ? 'Please record at least one audio to complete this section' : ''}>
             <Box>
-              <Button
-                colorScheme="green"
+              <PrimaryButton
                 onClick={!isCompleteDisabled ? handleComplete : noop}
                 rightIcon={(() => <>💾</>)()}
                 aria-label="Complete recordings"
                 disabled={isCompleteDisabled}
-                borderRadius="full"
-                fontFamily="Silka"
-                fontWeight="bold"
-                p={6}
               >
                 Complete
-              </Button>
+              </PrimaryButton>
             </Box>
           </Tooltip>
         </Box>
@@ -227,7 +187,12 @@ const RecordSentenceAudio = ({
   ) : noExamples ? (
     <EmptyExamples recording goHome={goHome} setIsDirty={setIsDirty} />
   ) : isComplete ? (
-    <Completed recording setIsComplete={setIsComplete} setIsDirty={setIsDirty} goHome={goHome} />
+    <Completed
+      type={CrowdsourcingType.RECORD_EXAMPLE_AUDIO}
+      setIsComplete={setIsComplete}
+      setIsDirty={setIsDirty}
+      goHome={goHome}
+    />
   ) : (
     <Box
       width="full"

--- a/src/Core/Collections/IgboSoundbox/VerifySentenceAudio.tsx
+++ b/src/Core/Collections/IgboSoundbox/VerifySentenceAudio.tsx
@@ -19,8 +19,9 @@ import {
 import { getRandomExampleSuggestionsToReview, putRandomExampleSuggestions } from 'src/shared/DataCollectionAPI';
 import { ExampleSuggestion } from 'src/backend/controllers/utils/interfaces';
 import ReviewActions from 'src/backend/shared/constants/ReviewActions';
+import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 import SandboxAudioRecorder from './SandboxAudioRecorder';
-import Completed from './Completed';
+import Completed from '../components/Completed';
 import EmptyExamples from './EmptyExamples';
 import ProgressCircles from './components/ProgressCircles';
 import CardMessage from './constants/CardMessage';
@@ -274,7 +275,12 @@ const VerifySentenceAudio = ({
   ) : noExamples ? (
     <EmptyExamples setIsDirty={setIsDirty} goHome={goHome} />
   ) : isComplete ? (
-    <Completed setIsComplete={setIsComplete} setIsDirty={setIsDirty} goHome={goHome} />
+    <Completed
+      type={CrowdsourcingType.VERIFY_EXAMPLE_AUDIO}
+      setIsComplete={setIsComplete}
+      setIsDirty={setIsDirty}
+      goHome={goHome}
+    />
   ) : (
     <Box
       width="full"

--- a/src/Core/Collections/IgboSoundbox/components/Navbar.tsx
+++ b/src/Core/Collections/IgboSoundbox/components/Navbar.tsx
@@ -8,6 +8,7 @@ import {
 import IgboSoundboxViews from 'src/shared/constants/IgboSoundboxViews';
 import ConfirmModal from 'src/shared/components/ConfirmModal';
 import { ArrowBackIcon } from '@chakra-ui/icons';
+import NavbarWrapper from '../../components/NavbarWrapper';
 
 const Navbar = ({
   currentView,
@@ -49,11 +50,8 @@ const Navbar = ({
       >
         <Text>Leaving this page without submitting your work will lead to your current work to be lost.</Text>
       </ConfirmModal>
-      <Box
-        className={`bg-white w-full h-16 flex flex-row 
-        ${currentView === IgboSoundboxViews.HOME ? 'justify-center' : 'justify-start'} items-center`}
-        borderBottomColor="gray.200"
-        borderBottomWidth="1px"
+      <NavbarWrapper
+        className={currentView === IgboSoundboxViews.HOME ? 'justify-center' : 'justify-start'}
       >
         {currentView === IgboSoundboxViews.HOME ? (
           <Heading fontFamily="Silka" textAlign="center">Igbo Soundbox</Heading>
@@ -128,7 +126,7 @@ const Navbar = ({
             </Button>
           </Box>
         )}
-      </Box>
+      </NavbarWrapper>
     </>
   );
 };

--- a/src/Core/Collections/components/Completed.tsx
+++ b/src/Core/Collections/components/Completed.tsx
@@ -5,17 +5,18 @@ import {
   Heading,
   Text,
 } from '@chakra-ui/react';
+import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 
 const Completed = (
   {
     setIsComplete,
-    recording = false,
     setIsDirty,
     goHome,
+    type,
   }
   : {
     setIsComplete: React.Dispatch<React.SetStateAction<boolean>>,
-    recording?: boolean,
+    type: CrowdsourcingType,
     setIsDirty: React.Dispatch<React.SetStateAction<boolean>>,
     goHome: () => void,
   },
@@ -38,7 +39,13 @@ const Completed = (
       <Box className="space-y-4">
         <Heading textAlign="center">Great work!</Heading>
         <Text textAlign="center">
-          {recording ? 'Your sentence recordings have been submitted.' : 'Your sentence reviews have been submitted.'}
+          {type === CrowdsourcingType.RECORD_EXAMPLE_AUDIO
+            ? 'Your sentence recordings have been submitted.'
+            : type === CrowdsourcingType.VERIFY_EXAMPLE_AUDIO
+              ? 'Your sentence reviews have been submitted.'
+              : type === CrowdsourcingType.INPUT_IGBO_DEFINITION
+                ? 'Your Igbo definitions have been submitted.'
+                : 'Your Igbo definition reviews have been submitted.'}
         </Text>
       </Box>
       <Box className="space-x-3">
@@ -58,7 +65,13 @@ const Completed = (
           fontWeight="bold"
           onClick={handleMore}
         >
-          {recording ? 'Record more sentences' : 'Review more sentences'}
+          {type === CrowdsourcingType.RECORD_EXAMPLE_AUDIO
+            ? 'Record more sentences'
+            : type === CrowdsourcingType.VERIFY_EXAMPLE_AUDIO
+              ? 'Review more sentences'
+              : type === CrowdsourcingType.INPUT_IGBO_DEFINITION
+                ? 'Add more Igbo definitions'
+                : 'Review more Igbo definitions'}
         </Button>
       </Box>
     </Box>

--- a/src/Core/Collections/components/NavbarWrapper.tsx
+++ b/src/Core/Collections/components/NavbarWrapper.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+import { Box, BoxProps } from '@chakra-ui/react';
+
+const NavbarWrapper = ({
+  children,
+  className,
+  ...props
+} : BoxProps): ReactElement => (
+  <Box
+    className={`bg-white w-full h-16 flex flex-row items-center ${className}`}
+    borderBottomColor="gray.200"
+    borderBottomWidth="1px"
+    {...props}
+  >
+    {children}
+  </Box>
+);
+
+export default NavbarWrapper;

--- a/src/__tests__/exampleSuggestions.test.ts
+++ b/src/__tests__/exampleSuggestions.test.ts
@@ -424,7 +424,6 @@ describe('MongoDB Example Suggestions', () => {
         }
         return { id, review: ReviewActions.SKIP };
       });
-      console.log(randomExampleSuggestionsRes.body);
       const updatedRandomExampleSuggestionRes = await putRandomExampleSuggestions(reviewedExampleSuggestions);
       expect(updatedRandomExampleSuggestionRes.status).toEqual(200);
       await Promise.all(updatedRandomExampleSuggestionRes.body.map(async (randomExampleSuggestionId, index) => {

--- a/src/__tests__/shared/commands.ts
+++ b/src/__tests__/shared/commands.ts
@@ -39,6 +39,13 @@ export const getWordSuggestions = (query = {}, options = { token: '' }): Request
     .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
 );
 
+export const getRandomWordSuggestions = (query = {}, options = { token: '' }): Request => (
+  chaiServer
+    .get('/wordSuggestions/random')
+    .query(query)
+    .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
+);
+
 export const getWordSuggestion = (id: mongoose.Types.ObjectId | string, options = { token: '' }): Request => (
   chaiServer
     .get(`/wordSuggestions/${id}`)
@@ -48,6 +55,16 @@ export const getWordSuggestion = (id: mongoose.Types.ObjectId | string, options 
 export const deleteWordSuggestion = (id: string, options = { token: '' }): Request => (
   chaiServer
     .delete(`/wordSuggestions/${id}`)
+    .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
+);
+
+export const putRandomWordSuggestions = (
+  data: { id: string, pronunciation?: string, review?: ReviewActions }[],
+  options = { token: '' },
+): Request => (
+  chaiServer
+    .put('/wordSuggestions/random')
+    .send(data)
     .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
 );
 

--- a/src/__tests__/shared/constants.ts
+++ b/src/__tests__/shared/constants.ts
@@ -34,6 +34,7 @@ export const EXAMPLE_SUGGESTION_KEYS = [
   'mergedBy',
   'type',
   'id',
+  'crowdsourcing',
 ];
 export const WORD_SUGGESTION_KEYS = [
   'originalWordId',

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -8,6 +8,7 @@ import { Request } from 'express';
 import UserRoles from 'src/backend/shared/constants/UserRoles';
 import Collections from 'src/shared/constants/Collections';
 import SentenceType from 'src/backend/shared/constants/SentenceType';
+import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 
 export interface HandleQueries {
   searchWord: string,
@@ -24,13 +25,15 @@ export interface HandleQueries {
   uidQuery?: string,
 };
 
+export interface FirebaseUser {
+  uid?: string,
+  role?: UserRoles,
+  editingGroup?: number | undefined,
+};
+
 // @ts-expect-error EditorRequest
 export interface EditorRequest extends Request {
-  user: {
-    uid?: string,
-    role?: UserRoles,
-    editingGroup?: number | undefined,
-  },
+  user: FirebaseUser,
   query: {
     keyword?: string,
     page?: number | string,
@@ -147,6 +150,9 @@ export interface WordSuggestion extends Word, Suggestion {
   originalWordId?: Types.ObjectId,
   examples?: ExampleSuggestion[],
   twitterPollUrl?: string,
+  crowdsourcing: {
+    [key in CrowdsourcingType]: boolean;
+  },
 };
 
 export interface Example extends Document<any>, LeanDocument<any> {
@@ -164,6 +170,9 @@ export interface Example extends Document<any>, LeanDocument<any> {
 
 export interface ExampleSuggestion extends Example, Suggestion {
   exampleForSuggestion: boolean,
+  crowdsourcing: {
+    [key in CrowdsourcingType]: boolean;
+  }
 };
 
 export interface ExampleClientData {

--- a/src/backend/controllers/utils/nestedExampleSuggestionUtils.ts
+++ b/src/backend/controllers/utils/nestedExampleSuggestionUtils.ts
@@ -287,7 +287,7 @@ export const updateNestedExampleSuggestions = async (
     suggestionDocId: string,
     clientExamples: Interfaces.ExampleClientData[],
     mongooseConnection: Connection,
-    user: { uid: string },
+    user: Interfaces.FirebaseUser,
   },
 ): Promise<Interfaces.ExampleSuggestion[]> => {
   const existingExampleSuggestionIds = await generateExistingExampleSuggestionsObject({

--- a/src/backend/controllers/utils/queries.ts
+++ b/src/backend/controllers/utils/queries.ts
@@ -299,3 +299,8 @@ export const searchForAssociatedSuggestionsByTwitterId = (twitterPollId: string)
   twitterPollId,
   merged: { $eq: null },
 });
+export const searchWordsWithoutIgboDefinitions = (): {
+  [key: string]: { $exists: boolean },
+} => ({
+  'definitions.0.igboDefinitions.0': { $exists: false },
+});

--- a/src/backend/controllers/wordSuggestions.ts
+++ b/src/backend/controllers/wordSuggestions.ts
@@ -102,7 +102,7 @@ export const createWordSuggestion = async ({
     return savedWordSuggestion;
   } catch (err) {
     if (wordSuggestion) {
-      wordSuggestion.delete();
+      await wordSuggestion.delete();
     }
     throw err;
   };

--- a/src/backend/controllers/wordSuggestions.ts
+++ b/src/backend/controllers/wordSuggestions.ts
@@ -300,7 +300,7 @@ export const getWordSuggestion = async (
       .findById(id)
       .then(async (wordSuggestion: Interfaces.WordSuggestion) => {
         if (!wordSuggestion) {
-          throw new Error('No word suggestion exists with the provided id.');
+          throw new Error(`No word suggestion exists with the provided id: ${id}`);
         }
         const wordSuggestionWithExamples = (
           await placeExampleSuggestionsOnSuggestionDoc(wordSuggestion, mongooseConnection)
@@ -327,7 +327,7 @@ export const deleteWordSuggestion = async (
     const { mongooseConnection } = req;
     const { id } = req.params;
     const ExampleSuggestion = mongooseConnection.model<Interfaces.ExampleSuggestion>(
-      'ExampleSuggestionExampleSuggestion',
+      'ExampleSuggestion',
       exampleSuggestionSchema,
     );
     const WordSuggestion = mongooseConnection.model<Interfaces.WordSuggestion>('WordSuggestion', wordSuggestionSchema);

--- a/src/backend/middleware/validateRandomWordSuggestionBody.ts
+++ b/src/backend/middleware/validateRandomWordSuggestionBody.ts
@@ -1,0 +1,31 @@
+import { Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
+import Joi from 'joi';
+import * as Interfaces from 'src/backend/controllers/utils/interfaces';
+
+const { Types } = mongoose;
+export const randomWordSuggestionSchema = Joi.array().items(Joi.object().keys({
+  id: Joi.string().external(async (value) => {
+    if (value && !Types.ObjectId.isValid(value)) {
+      throw new Error('Invalid id provided');
+    }
+    return true;
+  }).allow(null).optional(),
+  igboDefinition: Joi.string(),
+}));
+
+export default async (req: Interfaces.EditorRequest, res: Response, next: NextFunction): Promise<Response | void> => {
+  const { body: finalData } = req;
+
+  try {
+    await randomWordSuggestionSchema.validateAsync(finalData, { abortEarly: false });
+    return next();
+  } catch (err) {
+    res.status(400);
+    if (err.details) {
+      const errorMessage = err.details.map(({ message }) => message).join('. ');
+      return res.send({ error: errorMessage });
+    }
+    return res.send({ error: err.message });
+  }
+};

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -5,6 +5,7 @@ import SentenceType from 'src/backend/shared/constants/SentenceType';
 import { toJSONPlugin, toObjectPlugin } from './plugins/index';
 import { uploadExamplePronunciation } from './plugins/pronunciationHooks';
 import { normalizeIgbo } from './plugins/normalizationHooks';
+import CrowdsourcingType from '../shared/constants/CrowdsourcingType';
 
 const { Schema, Types } = mongoose;
 // @ts-ignore
@@ -44,6 +45,20 @@ export const exampleSuggestionSchema = new Schema({
   merged: { type: Types.ObjectId, ref: 'Example', default: null },
   mergedBy: { type: String, default: null },
   userInteractions: { type: [{ type: String }], default: [] },
+  crowdsourcing: {
+    type: Object,
+    validate: (v) => {
+      const crowdsourcingKeys = Object.keys(CrowdsourcingType);
+      return Object.entries(v).map(([key, value]) => (
+        crowdsourcingKeys.includes(key) && typeof value === 'boolean'
+      ));
+    },
+    required: false,
+    default: Object.keys(CrowdsourcingType).reduce((finalCrowdsourcing, key) => ({
+      ...finalCrowdsourcing,
+      [key]: false,
+    }), {}),
+  },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 toJSONPlugin(exampleSuggestionSchema);

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -9,6 +9,7 @@ import Tense from '../shared/constants/Tense';
 import WordClass from '../shared/constants/WordClass';
 import WordAttributes from '../shared/constants/WordAttributes';
 import WordTags from '../shared/constants/WordTags';
+import CrowdsourcingType from '../shared/constants/CrowdsourcingType';
 
 const { Schema, Types } = mongoose;
 
@@ -100,8 +101,21 @@ export const wordSuggestionSchema = new Schema(
     userInteractions: { type: [{ type: String }], default: [] },
     frequency: { type: Number, default: 1 },
     twitterPollId: { type: String, default: '' },
-  },
-  { toObject: toObjectPlugin, timestamps: true },
+    crowdsourcing: {
+      type: Object,
+      validate: (v) => {
+        const crowdsourcingKeys = Object.keys(CrowdsourcingType);
+        return Object.entries(v).map(([key, value]) => (
+          crowdsourcingKeys.includes(key) && typeof value === 'boolean'
+        ));
+      },
+      required: false,
+      default: Object.keys(CrowdsourcingType).reduce((finalCrowdsourcing, key) => ({
+        ...finalCrowdsourcing,
+        [key]: false,
+      }), {}),
+    },
+  }, { toObject: toObjectPlugin, timestamps: true },
 );
 
 toJSONPlugin(wordSuggestionSchema);

--- a/src/backend/routers/transcriberRouter.ts
+++ b/src/backend/routers/transcriberRouter.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import UserRoles from 'src/backend/shared/constants/UserRoles';
+import { getRandomWordSuggestions, putRandomWordSuggestions } from 'src/backend/controllers/wordSuggestions';
 import {
   getRandomExampleSuggestions,
   postBulkUploadExampleSuggestions,
@@ -23,6 +24,7 @@ import authentication from 'src/backend/middleware/authentication';
 import authorization from 'src/backend/middleware/authorization';
 import validateCorpusBody from 'src/backend/middleware/validateCorpusBody';
 import validateRandomExampleSuggestionBody from 'src/backend/middleware/validateRandomExampleSuggestionBody';
+import validateRandomWordSuggestionBody from 'src/backend/middleware/validateRandomWordSuggestionBody';
 import validateBulkUploadExampleSuggestionBody from 'src/backend/middleware/validateBulkUploadExampleSuggestionBody';
 import interactWithSuggestion from 'src/backend/middleware/interactWithSuggestion';
 import resourcePermission from 'src/backend/middleware/resourcePermission';
@@ -36,6 +38,13 @@ transcriberRouter.post(
   authorization([UserRoles.ADMIN]),
   validateBulkUploadExampleSuggestionBody,
   postBulkUploadExamples,
+);
+
+transcriberRouter.get('/wordSuggestions/random', getRandomWordSuggestions);
+transcriberRouter.put(
+  '/wordSuggestions/random',
+  validateRandomWordSuggestionBody,
+  putRandomWordSuggestions,
 );
 
 transcriberRouter.get('/exampleSuggestions/random', getRandomExampleSuggestions);

--- a/src/backend/shared/constants/CrowdsourcingType.ts
+++ b/src/backend/shared/constants/CrowdsourcingType.ts
@@ -1,0 +1,8 @@
+enum CrowdsourcingType {
+  INPUT_IGBO_DEFINITION = 'input_igbo_definition',
+  REVIEW_IGBO_DEFINITION = 'review_igbo_definition',
+  RECORD_EXAMPLE_AUDIO = 'record_example_audio',
+  VERIFY_EXAMPLE_AUDIO = 'verify_example_audio',
+};
+
+export default CrowdsourcingType;

--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -213,3 +213,16 @@ export const combineDocument = (
   });
 
 export const submitConstructedTermPoll = (poll: Poll): Promise<any> => handleSubmitConstructedTermPoll(poll);
+
+export const getWordSuggestionsWithoutIgboDefinitions = async (): Promise<any> => (await request({
+  method: 'GET',
+  url: `${Collection.WORD_SUGGESTIONS}/random`,
+})).data;
+
+export const setWordSuggestionsWithoutIgboDefinitions = (
+  async (igboDefinitions: { id: string, igboDefinition: string }[]) : Promise<any> => (await request({
+    method: 'PUT',
+    url: `${Collection.WORD_SUGGESTIONS}/random`,
+    data: igboDefinitions,
+  })).data
+);

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -153,7 +153,7 @@ const WordEditForm = ({
 
   /* Prepares the data to be cached */
   const createCacheWordData = (data, record: Record | Word = { id: null, dialects: {} }) => {
-    const cleanedData = {
+    const cleanedData = omit({
       ...record,
       ...data,
       definitions: (data.definitions || []).map((definition) => ({
@@ -168,7 +168,7 @@ const WordEditForm = ({
       examples: sanitizeExamples(examples),
       pronunciation: getValues().pronunciation || '',
       tags: sanitizeTags(data.tags),
-    };
+    }, ['crowdsourcing']);
     return cleanedData;
   };
 

--- a/src/shared/primitives/ActivityButton.tsx
+++ b/src/shared/primitives/ActivityButton.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+import { IconButton, IconButtonProps, Tooltip } from '@chakra-ui/react';
+
+const ActivityButton = ({
+  tooltipLabel,
+  ...props
+}: IconButtonProps & { tooltipLabel?: string }): ReactElement => (
+  <Tooltip label={tooltipLabel}>
+    <IconButton
+      variant="ghost"
+      _hover={{
+        backgroundColor: 'white',
+      }}
+      _active={{
+        backgroundColor: 'white',
+      }}
+      _focus={{
+        backgroundColor: 'white',
+      }}
+      {...props}
+    />
+  </Tooltip>
+);
+
+export default ActivityButton;

--- a/src/shared/primitives/Card.tsx
+++ b/src/shared/primitives/Card.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { Box } from '@chakra-ui/react';
+
+const Card = ({ children } : { children: any }): ReactElement => (
+  <Box
+    backgroundColor="gray.100"
+    borderRadius="md"
+    borderColor="gray.300"
+    borderWidth="1px"
+    minHeight={32}
+    width={['full', 'lg']}
+    my="12"
+    display="flex"
+    flexDirection="column"
+    justifyContent="center"
+    alignItems="center"
+    p="6"
+    className="space-y-6"
+  >
+    {React.Children.map(children, (child) => (
+      React.cloneElement(child)
+    ))}
+  </Box>
+);
+
+export default Card;

--- a/src/shared/primitives/PrimaryButton.tsx
+++ b/src/shared/primitives/PrimaryButton.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement } from 'react';
+import { Button, ButtonProps } from '@chakra-ui/react';
+
+const PrimaryButton = ({
+  children,
+  ...props
+} : ButtonProps): ReactElement => (
+  <Button
+    {...props}
+    colorScheme="green"
+    rightIcon={(() => <>💾</>)()}
+    aria-label="Complete recordings"
+    borderRadius="full"
+    fontFamily="Silka"
+    fontWeight="bold"
+    p={6}
+  >
+    {children}
+  </Button>
+);
+
+export default PrimaryButton;

--- a/src/shared/primitives/index.ts
+++ b/src/shared/primitives/index.ts
@@ -1,11 +1,17 @@
+import ActivityButton from './ActivityButton';
+import Card from './Card';
 import CreateButton from './CreateButton';
 import Input from './Input';
+import PrimaryButton from './PrimaryButton';
 import Textarea from './Textarea';
 import WordPills from './WordPills';
 
 export {
+  ActivityButton,
+  Card,
   CreateButton,
   Input,
+  PrimaryButton,
   Textarea,
   WordPills,
 };

--- a/src/shared/utils/removePayloadFields.ts
+++ b/src/shared/utils/removePayloadFields.ts
@@ -22,6 +22,7 @@ const OMIT_KEYS = [
   'duration',
   'source',
   'twitterPollId',
+  'crowdsourcing',
 ];
 
 const removePayloadFields = (payload: any): any => {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -331,7 +331,7 @@ input#word, input#igbo {
 	background: linear-gradient(-45deg, #E5AEFF35, #FFFFFF35, #FFF7AE35, #FFFFFF35, #FFB3AE35, #FFFFFF35, #AEF5FF35);
 	background-size: 400% 400%;
 	animation: gradient 15s ease infinite;
-	height: 100vh;
+	min-height: 100vh;
 }
 
 @keyframes gradient {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,8 @@ module.exports = (_, argv) => ({
   },
   devServer: {
     port: clientPort,
-    liveReload: true,
-    watchContentBase: true,
+    liveReload: false,
+    watchContentBase: false,
     writeToDisk: true,
     publicPath: '/',
     contentBase: './public',


### PR DESCRIPTION
## Background
Creates a new Igbo Definitions page that makes it easier for crowdsourcers to add Igbo definitions to Word Suggestions.

## Implementation
A new `Resource` page called `IgboDefinitions` is created that will hit the `/wordsSuggestions/random` endpoint to get five random Word Suggestions. Under the hood, the `wordSuggestions` controller is first searching for Word documents that don't have any Igbo definitions. Then when it finds those Word documents, it determines whether or not a new Word suggestion needs to be created or an existing Word suggestion for the Word document already exists.

After finding all the valid Word Suggestions, only five will be returned back to the client to add the Igbo definitions. When the user provides up to all five Igbo definitions, they will make a POST request to the `/wordSuggestions/random` endpoint to save those changes on the Word Suggestions will be then reviewed by our lexicographers.

## Screenshot
![image](https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/614ed067-ef4d-41e3-8b07-f6346eac5fac)

## Next Steps
* Clean up designs
* Create a dashboard specifically for crowdsourcers