### PR TITLE
Extend nsibidi search by handing tone marks

### DIFF
--- a/src/backend/controllers/nsibidiCharacters.ts
+++ b/src/backend/controllers/nsibidiCharacters.ts
@@ -2,6 +2,7 @@ import { Response, NextFunction } from 'express';
 import { packageResponse, handleQueries } from './utils';
 import * as Interfaces from './utils/interfaces';
 import { nsibidiCharacterSchema } from '../models/NsibidiCharacter';
+import createRegExp from '../shared/utils/createRegExp';
 
 /* Returns all matching Nsibidi documents */
 export const getNsibidiCharacters = (
@@ -17,7 +18,7 @@ export const getNsibidiCharacters = (
     } = handleQueries(req);
 
     // Loosely matches with an included Nsibidi character
-    const regex = new RegExp(searchWord);
+    const regex = createRegExp(searchWord).wordReg;
     const query = { nsibidi: { $regex: regex } };
     const NsibidiCharacter = mongooseConnection.model('NsibidiCharacter', nsibidiCharacterSchema);
 


### PR DESCRIPTION
## Background
Nsịbịdị pronunciations that include diacritic marks were impossible to have included in search results. This PR use the `createRegExp` helper function to automatically generate a regular expression needed to accurately pattern match Nsịbịdị entries.