### PR TITLE
Attach id to payload for examples

### DIFF
--- a/src/__tests__/__mocks__/documentData.ts
+++ b/src/__tests__/__mocks__/documentData.ts
@@ -82,7 +82,9 @@ export const wordRecord = {
     nsibidiCharacters: [],
     igboDefinitions: [],
   }],
-  examples: [],
+  examples: [
+    { id: 'example-id', igbo: 'igbo', english: 'english' },
+  ],
 };
 
 export const exampleSuggestionData = {

--- a/src/backend/controllers/utils/nestedExampleSuggestionUtils.ts
+++ b/src/backend/controllers/utils/nestedExampleSuggestionUtils.ts
@@ -288,7 +288,7 @@ export const updateNestedExampleSuggestions = async (
         ...example,
         // If the example suggestion has an originalExampleId then it's not brand new and should
         // not be considered as such by attributing the user.uid as the author
-        authorId: !example.originalExampleId ? user.uid : example.authorId,
+        authorId: !example.originalExampleId ? user.uid : null,
         exampleForSuggestion: true,
         associatedWords: await generateAssociatedWords(example, suggestionDocId),
         // associatedDefinitionsSchemas: await generateAssociatedDefinitionsSchemas(example),

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
@@ -17,6 +17,7 @@ export const ExampleEditFormSchema = yup.object().shape({
   associatedWords: yup.array().min(0).of(yup.string()),
   associatedDefinitionsSchemas: yup.array().min(0).of(yup.string()),
   id: yup.string().optional(),
+  exampleId: yup.string().optional(),
   originalExampleId: yup.string().nullable().optional(),
   pronunciation: yup.string().optional(),
 });

--- a/src/shared/components/views/components/WordEditForm/__tests__/createDefaultWordValues.test.ts
+++ b/src/shared/components/views/components/WordEditForm/__tests__/createDefaultWordValues.test.ts
@@ -12,9 +12,10 @@ describe('WordEditForm utils', () => {
     expect(defaultValues.definitions[0].wordClass.label).toEqual('Active verb');
     expect(defaultValues.definitions[0].definitions[0].text).toEqual('first definition');
     expect(defaultValues.definitions[0].nsibidi).toEqual('first nsibidi');
-    expect(defaultValues.examples).toHaveLength(0);
+    expect(defaultValues.examples).toHaveLength(1);
     expect(defaultValues.stems).toHaveLength(0);
     expect(defaultValues.relatedTerms).toHaveLength(0);
     expect(defaultValues.pronunciation).toEqual('');
+    expect(defaultValues.examples[0]).toHaveProperty('exampleId');
   });
 });

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/Example/Example.tsx
@@ -27,7 +27,7 @@ const Example = ({
     meaning = '',
     pronunciation = '',
     nsibidi = '',
-    id = '',
+    exampleId = '',
     associatedWords = [],
     originalExampleId,
   } = example;
@@ -52,13 +52,25 @@ const Example = ({
   }, []);
 
   return originalRecord ? (
-    <Box className="list-container" key={`${id}-${igbo}-${english}`}>
+    <Box className="list-container" key={`${exampleId}-${igbo}-${english}`}>
       <Box
-        data-example-id={id}
+        data-example-id={exampleId}
         data-original-example-id={originalExampleId}
         data-associated-words={associatedWords}
         className="flex flex-col w-full space-y-3"
       >
+        <Controller
+          render={(props) => (
+            <input
+              {...props}
+              style={{ opacity: 0, pointerEvents: 'none', position: 'absolute' }}
+              data-test={`examples-${index}-igbo-id`}
+            />
+          )}
+          name={`examples.${index}.exampleId`}
+          defaultValue={exampleId}
+          control={control}
+        />
         <h3 className="text-gray-700">Igbo:</h3>
         <Controller
           render={(props) => (

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/__tests__/ExamplesForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/__tests__/ExamplesForm.test.tsx
@@ -9,8 +9,10 @@ import ExamplesForm from '../ExamplesForm';
 
 describe('ExamplesForm', () => {
   it('renders the examples', async () => {
+    const testRecord = cloneDeep(wordRecord);
+    testRecord.examples = [];
     const { findByText } = render(
-      <TestContext>
+      <TestContext record={testRecord}>
         <ExamplesForm />
       </TestContext>,
     );
@@ -27,7 +29,6 @@ describe('ExamplesForm', () => {
       </TestContext>,
     );
 
-    userEvent.click(await findByText('Add Example'));
     await findByText('Examples (1)');
     await findByTestId('examples-0-igbo-input');
     await findByTestId('examples-0-english-input');
@@ -49,7 +50,6 @@ describe('ExamplesForm', () => {
       </TestContext>,
     );
 
-    userEvent.click(await findByText('Add Example'));
     await findByText('Examples (1)');
     userEvent.type(await findByTestId('examples-0-igbo-input'), 'igbo input');
     userEvent.type(await findByTestId('examples-0-english-input'), 'english input');
@@ -78,14 +78,14 @@ describe('ExamplesForm', () => {
     );
 
     userEvent.click(await findByText('Add Example'));
-    await findByText('Examples (1)');
+    await findByText('Examples (2)');
     userEvent.type(await findByTestId('examples-0-igbo-input'), 'igbo input');
     userEvent.type(await findByTestId('examples-0-english-input'), 'english input');
     userEvent.type(await findByTestId('examples-0-meaning-input'), 'meaning input');
     userEvent.type(await findByTestId('examples-0-nsibidi-input'), 'nsibidi input');
 
     userEvent.click(await findByLabelText('Add Example'));
-    await findByText('Examples (2)');
+    await findByText('Examples (3)');
 
     userEvent.type(await findByTestId('examples-1-igbo-input'), 'second igbo input');
     userEvent.type(await findByTestId('examples-1-english-input'), 'second english input');

--- a/src/shared/components/views/components/WordEditForm/utils/createDefaultWordFormValues.ts
+++ b/src/shared/components/views/components/WordEditForm/utils/createDefaultWordFormValues.ts
@@ -15,6 +15,7 @@ const createDefaultWordFormValues = (record: Record): any => {
         ...example,
         pronunciation: example.pronunciation || '',
         nsibidiCharacters: (example.nsibidiCharacters || []).map((id) => ({ id })),
+        exampleId: example?.id,
       }))
       : [],
     variations: (record?.variations || []).map((variation) => ({ text: variation })),

--- a/src/shared/components/views/components/__tests__/utils.test.tsx
+++ b/src/shared/components/views/components/__tests__/utils.test.tsx
@@ -52,6 +52,7 @@ describe('Word Edit Form utils', () => {
   it('sanitizes an array of examples with correct example ids', () => {
     const mockData = [
       {
+        exampleId: '5f90c35f49f7e863e92b8b31',
         igbo: 'igbo',
         english: 'english',
         meaning: 'meaning',
@@ -122,7 +123,6 @@ describe('Word Edit Form utils', () => {
         '5f90c35f49f7e863e92b8b33',
         '5f90c35f49f7e863e92b8b34',
       ],
-      id: null,
       originalExampleId: '5f90c35f49f7e863e92b8b32',
     }]);
   });

--- a/src/shared/components/views/components/utils.ts
+++ b/src/shared/components/views/components/utils.ts
@@ -34,8 +34,9 @@ export const sanitizeExamples = (examples = []): ExampleClientData[] => {
       nsibidi,
       nsibidiCharacters,
       pronunciation,
+      exampleId,
     }, index) => {
-      const { originalExampleId, exampleId } = originalExamplesFromIds[index]?.dataset || {};
+      const { originalExampleId } = originalExamplesFromIds[index]?.dataset || {};
       return {
         igbo,
         english,
@@ -47,7 +48,7 @@ export const sanitizeExamples = (examples = []): ExampleClientData[] => {
           : {}
         ),
         ...(exampleId
-          ? { id: exampleId?.includes('-') ? null : exampleId }
+          ? { id: exampleId }
           : {}
         ),
         associatedWords: compact(examplesFromAssociatedWords[index]?.dataset?.associatedWords.split(',')),


### PR DESCRIPTION
## Background
Example suggestions nested wtihin word suggestions weren't getting their `id` included in the payload, causes the backend to not assign authorship to example suggestions.