### PR TITLE
Create tests for combining words and update complete determining logic and tests

### DIFF
--- a/src/backend/controllers/utils/__tests__/determineDocumentCompleteness.test.ts
+++ b/src/backend/controllers/utils/__tests__/determineDocumentCompleteness.test.ts
@@ -40,6 +40,14 @@ describe('determineDocumentCompleteness', () => {
     const result = await determineDocumentCompleteness(word);
     expect(result.completeWordRequirements).toHaveLength(2);
   });
+
+  it('determines word is not complete because it has no example audio', async () => {
+    const updatedWord = cloneDeep(word);
+    updatedWord.examples[0].pronunciations = [];
+    // @ts-expect-error
+    const result = await determineDocumentCompleteness(updatedWord);
+    expect(result.completeWordRequirements).toHaveLength(3);
+  });
   it('determines word is complete', async () => {
     const testWord = cloneDeep(word);
     testWord.stems = ['first stem'];

--- a/src/backend/controllers/utils/__tests__/determineExampleCompleteness.test.ts
+++ b/src/backend/controllers/utils/__tests__/determineExampleCompleteness.test.ts
@@ -23,6 +23,13 @@ describe('determineExampleCompleteness', () => {
     const result = await determineExampleCompleteness(testExample);
     expect(result.completeExampleRequirements).toHaveLength(1);
   });
+  it('determines example is not complete with no pronunciations', async () => {
+    const testExample = cloneDeep(example);
+    testExample.pronunciations = [];
+    // @ts-expect-error
+    const result = await determineExampleCompleteness(testExample);
+    expect(result.completeExampleRequirements).toHaveLength(1);
+  });
   it('determines example is complete', async () => {
     // @ts-expect-error
     const result = await determineExampleCompleteness(example);

--- a/src/backend/controllers/utils/__tests__/determineIsAsCompleteAsPossible.test.ts
+++ b/src/backend/controllers/utils/__tests__/determineIsAsCompleteAsPossible.test.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import determineIsAsCompleteAsPossible from '../determineIsAsCompleteAsPossible';
 
 const word = {
@@ -31,5 +32,11 @@ describe('determineIsAsCompleteAsPossible', () => {
   it('determines if word is as complete as possible', () => {
     // @ts-expect-error
     expect(determineIsAsCompleteAsPossible(word)).toBe(true);
+  });
+  it('determines if word is not as complete as possible because example doesn\'t have pronunciations', () => {
+    const testWord = cloneDeep(word);
+    testWord.examples[0].pronunciations = [];
+    // @ts-expect-error
+    expect(determineIsAsCompleteAsPossible(testWord)).toBe(false);
   });
 });

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -72,7 +72,9 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
       ? 'All verb tenses are needed'
       : null,
     Array.isArray(examples)
-      && examples.some(({ pronunciations }) => pronunciations.some((pronunciation) => !pronunciation))
+      && examples.some(({ pronunciations }) => (
+        !pronunciations.length || pronunciations.some((pronunciation) => !pronunciation?.audio)
+      ))
       && 'All example sentences need pronunciations',
     Array.isArray(dialects) && !dialects.length && 'A dialectal variation is needed',
     (Array.isArray(dialects)

--- a/src/backend/controllers/utils/determineExampleCompleteness.ts
+++ b/src/backend/controllers/utils/determineExampleCompleteness.ts
@@ -43,7 +43,8 @@ export default async (record: Example | Record, skipAudioCheck = false) : Promis
 
   const completeExampleRequirements = compact([
     ...sufficientExampleRequirements,
-    pronunciations.some((pronunciation) => (!pronunciation || !isAudioAvailable)) && 'An audio pronunciation is needed',
+    (pronunciations.some((pronunciation) => (!pronunciation || !isAudioAvailable)) || !pronunciations.length)
+    && 'An audio pronunciation is needed',
     style === ExampleStyle.PROVERB.value && !meaning && 'Meaning is required for proverb',
   ]);
 

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -23,7 +23,9 @@ export default (word: Word | Record): boolean => !!(
   && (
     Array.isArray(word.examples)
     && word.examples.length
-    && word.examples.every(({ pronunciations }) => pronunciations.every((pronunciation) => !!pronunciation?.audio))
+    && word.examples.every(({ pronunciations }) => (
+      pronunciations.length && pronunciations.every((pronunciation) => !!pronunciation?.audio)
+    ))
   )
   && (
     word.dialects && typeof word.dialects === 'object'

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -88,6 +88,7 @@ export interface Word extends Document<any>, LeanDocument<any> {
   normalized: string,
   frequency: number,
   stems: string[],
+  tags: string[],
   attributes: {
     isStandardIgbo: boolean,
     isAccented: boolean,

--- a/src/backend/controllers/words/__tests__/helpers.test.ts
+++ b/src/backend/controllers/words/__tests__/helpers.test.ts
@@ -1,0 +1,179 @@
+import { cloneDeep } from 'lodash';
+import WordTags from 'src/backend/shared/constants/WordTags';
+import { combineWords, replaceWordIdsFromExampleAssociatedWords } from '../helpers';
+
+const firstWord = {
+  word: 'first word',
+  definitions: [{
+    definitions: ['first word definition'],
+    wordClass: 'NNC',
+    toObject: () => ({
+      definitions: ['first word definition'],
+      wordClass: 'NNC',
+    }),
+  }],
+  wordPronunciation: 'first word word pronunciation',
+  conceptualWord: 'first word conceptual word',
+  stems: ['first word stem'],
+  relatedTerms: ['first word related term'],
+  variations: ['first word variation'],
+  hypernyms: ['first word hypernym'],
+  hyponyms: ['first word hyponym'],
+  nsibidi: 'first word nsibidi',
+  dialects: [{
+    dialects: ['ANI'],
+    word: 'first word dialect',
+  }],
+  attributes: {
+    isStandardIgbo: true,
+    isAccented: true,
+  },
+  tags: [WordTags.BOTANY.value],
+};
+
+const secondWord = {
+  word: 'second word',
+  definitions: [{
+    definitions: ['second word definition'],
+    wordClass: 'ADV',
+    toObject: () => ({
+      definitions: ['second word definition'],
+      wordClass: 'ADV',
+    }),
+  }],
+  wordPronunciation: 'second word word pronunciation',
+  conceptualWord: 'second word conceptual word',
+  stems: ['second word stem'],
+  relatedTerms: ['second word related term'],
+  variations: ['second word variation'],
+  hypernyms: ['second word hypernym'],
+  hyponyms: ['second word hyponym'],
+  nsibidi: 'second word nsibidi',
+  dialects: [{
+    dialects: ['ANI'],
+    word: 'second word dialect',
+  }],
+  attributes: {
+    isStandardIgbo: true,
+    isAccented: false,
+  },
+  tags: [WordTags.BOTANY.value],
+};
+
+describe('word helpers', () => {
+  it('combines a word object into another with different word classes', () => {
+    const updatedWord = combineWords({
+      // @ts-expect-error
+      wordToCombine: cloneDeep(firstWord),
+      // @ts-expect-error
+      wordToDelete: cloneDeep(secondWord),
+    });
+
+    expect(updatedWord.word).toEqual('first word');
+    expect(updatedWord.definitions).toHaveLength(2);
+    expect(updatedWord.definitions[0].definitions).toEqual(['first word definition']);
+    expect(updatedWord.definitions[0].wordClass).toEqual('NNC');
+    // @ts-expect-error
+    expect(updatedWord.definitions[1].definitions).toEqual(['second word definition']);
+    // @ts-expect-error
+    expect(updatedWord.definitions[1].wordClass).toEqual('ADV');
+    expect(updatedWord.wordPronunciation).toEqual('first word word pronunciation');
+    expect(updatedWord.conceptualWord).toEqual('first word conceptual word');
+    expect(updatedWord.stems).toEqual(['first word stem', 'second word stem']);
+    expect(updatedWord.relatedTerms).toEqual(['first word related term', 'second word related term']);
+    expect(updatedWord.variations).toEqual(['first word variation', 'second word variation']);
+    expect(updatedWord.hypernyms).toEqual(['first word hypernym', 'second word hypernym']);
+    expect(updatedWord.hyponyms).toEqual(['first word hyponym', 'second word hyponym']);
+    expect(updatedWord.nsibidi).toEqual('first word nsibidi');
+    expect(updatedWord.dialects).toHaveLength(2);
+    expect(updatedWord.dialects[0].dialects).toEqual(['ANI']);
+    expect(updatedWord.dialects[0].word).toEqual('first word dialect');
+    expect(updatedWord.dialects[1].dialects).toEqual(['ANI']);
+    expect(updatedWord.dialects[1].word).toEqual('second word dialect');
+    expect(updatedWord.attributes.isStandardIgbo).toEqual(true);
+    expect(updatedWord.attributes.isAccented).toEqual(true);
+    expect(updatedWord.tags).toEqual([WordTags.BOTANY.value]);
+    expect(updatedWord.pronunciation).toEqual('');
+  });
+
+  it('combines a word object into another with the same word classes', () => {
+    const updatedSecondDoc = {
+      word: 'second word',
+      definitions: [{
+        definitions: ['second word definition'],
+        wordClass: 'NNC',
+        toObject: () => ({
+          definitions: ['second word definition'],
+          wordClass: 'NNC',
+        }),
+      }],
+      wordPronunciation: 'second word word pronunciation',
+      conceptualWord: 'second word conceptual word',
+      stems: ['second word stem'],
+      relatedTerms: ['second word related term'],
+      variations: ['second word variation'],
+      hypernyms: ['second word hypernym'],
+      hyponyms: ['second word hyponym'],
+      nsibidi: 'second word nsibidi',
+      dialects: [{
+        dialects: ['ANI'],
+        word: 'second word dialect',
+      }],
+      attributes: {
+        isStandardIgbo: true,
+        isAccented: false,
+      },
+      tags: [WordTags.BOTANY.value],
+    };
+
+    const updatedWord = combineWords({
+      // @ts-expect-error
+      wordToCombine: cloneDeep(firstWord),
+      // @ts-expect-error
+      wordToDelete: updatedSecondDoc,
+    });
+
+    expect(updatedWord.word).toEqual('first word');
+    expect(updatedWord.definitions).toHaveLength(1);
+    expect(updatedWord.definitions[0].definitions).toEqual(['first word definition', 'second word definition']);
+    expect(updatedWord.definitions[0].wordClass).toEqual('NNC');
+    expect(updatedWord.wordPronunciation).toEqual('first word word pronunciation');
+    expect(updatedWord.conceptualWord).toEqual('first word conceptual word');
+    expect(updatedWord.stems).toEqual(['first word stem', 'second word stem']);
+    expect(updatedWord.relatedTerms).toEqual(['first word related term', 'second word related term']);
+    expect(updatedWord.variations).toEqual(['first word variation', 'second word variation']);
+    expect(updatedWord.hypernyms).toEqual(['first word hypernym', 'second word hypernym']);
+    expect(updatedWord.hyponyms).toEqual(['first word hyponym', 'second word hyponym']);
+    expect(updatedWord.nsibidi).toEqual('first word nsibidi');
+    expect(updatedWord.dialects).toHaveLength(2);
+    expect(updatedWord.dialects[0].dialects).toEqual(['ANI']);
+    expect(updatedWord.dialects[0].word).toEqual('first word dialect');
+    expect(updatedWord.dialects[1].dialects).toEqual(['ANI']);
+    expect(updatedWord.dialects[1].word).toEqual('second word dialect');
+    expect(updatedWord.attributes.isStandardIgbo).toEqual(true);
+    expect(updatedWord.attributes.isAccented).toEqual(true);
+    expect(updatedWord.tags).toEqual([WordTags.BOTANY.value]);
+    expect(updatedWord.pronunciation).toEqual('');
+  });
+
+  it('replaces the word ids with the new combined word id for example associate words', async () => {
+    const examples = [
+      {
+        igbo: 'first igbo',
+        english: 'first english',
+        associatedWords: ['first word'],
+        save: () => examples[0],
+      },
+      {
+        igbo: 'second igbo',
+        english: 'second english',
+        associatedWords: ['first word'],
+        save: () => examples[1],
+      },
+    ];
+    const result = await replaceWordIdsFromExampleAssociatedWords(examples, 'first word', 'new word');
+    expect(result).toHaveLength(2);
+    expect(result[0].associatedWords).toEqual(['new word']);
+    expect(result[1].associatedWords).toEqual(['new word']);
+  });
+});

--- a/src/backend/controllers/words/helpers.ts
+++ b/src/backend/controllers/words/helpers.ts
@@ -1,3 +1,9 @@
+import {
+  assign,
+  filter,
+  map,
+  uniqBy,
+} from 'lodash';
 import { Connection, Document } from 'mongoose';
 import { wordSchema } from 'src/backend/models/Word';
 import * as Interfaces from '../utils/interfaces';
@@ -69,3 +75,80 @@ export const handleSyncingAntonyms = async (
   }));
   return wordDoc;
 };
+
+/**
+ * Combines wordToDelete into wordToCombine.
+ * @param param0 wordToCombine and wordToDelete
+ * @returns updatedWord
+ */
+export const combineWords = ({
+  wordToCombine,
+  wordToDelete,
+} : {
+  wordToCombine: Interfaces.Word,
+  wordToDelete: Interfaces.Word,
+}): Interfaces.Word => {
+  const updatedWord = assign(wordToCombine);
+  const {
+    pronunciation = '',
+    definitions = [],
+    stems = [],
+    variations = [],
+    relatedTerms = [],
+    hypernyms = [],
+    hyponyms = [],
+    nsibidi = '',
+    dialects = [],
+    tags = [],
+  } = wordToDelete;
+  updatedWord.pronunciation = updatedWord.pronunciation || pronunciation;
+  // @ts-expect-error
+  const updatedDefinitions: Interfaces.Word['definitions'] = (
+    // @ts-expect-error
+    [...updatedWord.definitions].map((definitionGroup) => definitionGroup.toObject())
+  );
+  definitions.forEach((definitionGroup: Interfaces.DefinitionSchema) => {
+    const existingDefinitionGroupIndex = updatedDefinitions
+      .findIndex(({ wordClass }) => definitionGroup.wordClass === wordClass);
+    if (existingDefinitionGroupIndex !== -1) {
+      updatedDefinitions[existingDefinitionGroupIndex] = {
+        ...updatedDefinitions[existingDefinitionGroupIndex],
+        definitions: Array.from(
+          new Set([...updatedDefinitions[existingDefinitionGroupIndex].definitions,
+            ...definitionGroup.definitions]),
+        ),
+      };
+    } else {
+      updatedDefinitions.push(definitionGroup);
+    }
+  });
+  updatedWord.definitions = updatedDefinitions;
+  updatedWord.dialects = Array.from([...updatedWord.dialects, ...(dialects || [])]);
+  updatedWord.tags = Array.from(new Set([...updatedWord.tags, ...(tags || [])]));
+  updatedWord.variations = Array.from(new Set([...updatedWord.variations, ...variations]));
+  updatedWord.stems = Array.from(new Set([...(updatedWord.stems || []), ...(stems || [])]));
+  updatedWord.relatedTerms = Array.from(new Set([...updatedWord.relatedTerms, ...relatedTerms]));
+  updatedWord.hypernyms = Array.from(new Set([...updatedWord.hypernyms, ...hypernyms]));
+  updatedWord.hyponyms = Array.from(new Set([...updatedWord.hyponyms, ...hyponyms]));
+  updatedWord.nsibidi = updatedWord.nsibidi || nsibidi;
+
+  return updatedWord;
+};
+
+/* Replaces all instances of oldId inside all of the examples with
+ * with the newId */
+export const replaceWordIdsFromExampleAssociatedWords = (
+  examples: Interfaces.Example[],
+  oldId: string,
+  newId: string,
+): Promise<Interfaces.Example[]> => (
+  Promise.all(map(examples, (example) => {
+    const cleanedWordExample = assign(example);
+    cleanedWordExample.associatedWords.push(newId);
+    cleanedWordExample.associatedWords = uniqBy(
+      filter(cleanedWordExample.associatedWords, (associatedWord) => associatedWord.toString() !== oldId.toString()),
+      (associatedWord) => associatedWord.toString(),
+    );
+    return cleanedWordExample.save();
+  }))
+);


### PR DESCRIPTION
## Background
The PR addresses the following:
* Updates the combineWord logic to handle more fields and creates tests for the functionality
* Fixes the `determine*` helper methods that determine how complete words and examples
  * Created tests for this functionality.