### PR TITLE
Fix showing already reviewed example sentences

### DIFF
--- a/src/__tests__/exampleSuggestions.test.ts
+++ b/src/__tests__/exampleSuggestions.test.ts
@@ -437,11 +437,13 @@ describe('MongoDB Example Suggestions', () => {
       });
       const res = await getRandomExampleSuggestions({ range: '[0, 4]' });
       expect(res.status).toEqual(200);
-      expect(res.body.length).toBeLessThanOrEqual(5);
+      expect(res.body).toHaveLength(5);
       res.body.forEach((exampleSuggestion) => {
         expect(exampleSuggestion.userInteractions).not.toContain(AUTH_TOKEN.ADMIN_AUTH_TOKEN);
         expect(exampleSuggestion.pronunciations.every(({ speaker }) => speaker !== AUTH_TOKEN.ADMIN_AUTH_TOKEN))
           .toBeTruthy();
+        expect(exampleSuggestion.approvals).not.toContain(AUTH_TOKEN.ADMIN_AUTH_TOKEN);
+        expect(exampleSuggestion.denials).not.toContain(AUTH_TOKEN.ADMIN_AUTH_TOKEN);
         expect(exampleSuggestion.approvals.length).toBeLessThanOrEqual(1);
         expect(exampleSuggestion.denials.length).toBeLessThanOrEqual(1);
       });

--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -351,9 +351,9 @@ export const getRandomExampleSuggestionsToReview = async (
   next: NextFunction,
 ): Promise<any | void> => {
   try {
-    const { limit, mongooseConnection } = await handleQueries(req);
+    const { limit, user, mongooseConnection } = await handleQueries(req);
 
-    const query = searchRandomExampleSuggestionsToReviewRegexQuery();
+    const query = searchRandomExampleSuggestionsToReviewRegexQuery(user.uid);
     const ExampleSuggestion = (
       mongooseConnection.model<Interfaces.ExampleSuggestion>(
         'ExampleSuggestion',

--- a/src/backend/controllers/utils/queries.ts
+++ b/src/backend/controllers/utils/queries.ts
@@ -205,18 +205,23 @@ export const searchRandomExampleSuggestionsRegexQuery = (uid: string) : {
   ],
 });
 // TODO: will need to extend functionality to review individual audio sentences
-export const searchRandomExampleSuggestionsToReviewRegexQuery = () : {
+export const searchRandomExampleSuggestionsToReviewRegexQuery = (uid: string) : {
   merged: null,
   exampleForSuggestion: { $ne: true },
   'pronunciations.0.audio': { $exists: boolean, $type: string, $ne: string },
   'approvals.1': { $exists: boolean },
   'denials.1': { $exists: boolean },
+  $and: { [key: string]: { $nin: [string] } }[]
 } => ({
   merged: null,
   exampleForSuggestion: { $ne: true },
   'pronunciations.0.audio': { $exists: true, $type: 'string', $ne: '' },
   'approvals.1': { $exists: false },
   'denials.1': { $exists: false },
+  $and: [
+    { 'pronunciations.speaker': { $nin: [uid] } },
+    { userInteractions: { $nin: [uid] } },
+  ],
 });
 export const searchPreExistingExampleSuggestionsRegexQuery = (
   { igbo, english, associatedWordId }: { igbo: string, english: string, associatedWordId: string },


### PR DESCRIPTION
## Background
The sentence to be reviewed on the platform show sentences that a user has already approved or denied. This PR updates the search query to prevent already reviewed sentences from being returned to the user.