### PR TITLE
Filter out archived example suggestions to show the correct audio pronunciations

### DIFF
--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -73,7 +73,8 @@ export default async (record: Word | Record, skipAudioCheck = false) : Promise<{
       : null,
     Array.isArray(examples)
       && examples.some(({ pronunciations }) => (
-        !pronunciations.length || pronunciations.some((pronunciation) => !pronunciation?.audio)
+        Array.isArray(pronunciations)
+        && (!pronunciations.length || pronunciations.some((pronunciation) => !pronunciation?.audio))
       ))
       && 'All example sentences need pronunciations',
     Array.isArray(dialects) && !dialects.length && 'A dialectal variation is needed',

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState, useEffect } from 'react';
-import { get } from 'lodash';
+import { assign, get } from 'lodash';
 import { ShowProps, useShowController } from 'react-admin';
 import {
   Box,
@@ -96,11 +96,23 @@ const WordShow = (props: ShowProps): ReactElement => {
   } = record;
 
   const examples = rawExamples.filter(({ archived = false }) => !archived);
+  examples.sort((prev, next) => prev.igbo.localeCompare(next.igbo));
   const archivedExamples = rawExamples.filter(({ archived = false }) => archived);
 
   const resourceTitle = {
     wordSuggestions: 'Word Suggestion',
     words: 'Word',
+  };
+
+  const prepareOriginalWordRecordForExamples = (): Interfaces.Word => {
+    if (!!originalWordRecord && 'examples' in originalWordRecord) {
+      // @ts-expect-error
+      return {
+        ...assign(originalWordRecord),
+        examples: originalWordRecord.examples.filter(({ archived = false }) => !archived),
+      };
+    }
+    return originalWordRecord;
   };
 
   /* Grabs the original word if it exists */
@@ -368,10 +380,10 @@ const WordShow = (props: ShowProps): ReactElement => {
                   recordField="examples"
                   recordFieldSingular="example"
                   record={{ examples } as Interfaces.Word}
-                  originalRecord={originalWordRecord}
+                  originalRecord={prepareOriginalWordRecordForExamples()}
                 >
                   <ExampleDiff
-                    record={record}
+                    record={{ examples } as Interfaces.Word}
                     diffRecord={diffRecord}
                     resource={resource}
                   />


### PR DESCRIPTION
## Issue
The WordShow component wasn't rendering audio pronunciations for example sentences. Additionally, when the pronunciations array is empty or not living on an example record, the `determineDocumentCompleteness` helper method throws an error.

## Reason
The WordShow was mixed in archived and non-archived example sentences into the show view.

## Solution
Filter out the archived sentences to show within the WordShow so that it only focused on non-archived example sentences which are sentences that will be public.

