### PR TITLE
Extend example suggestion for multiple reviews

### DIFF
--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -37,7 +37,7 @@ export const exampleSuggestionSchema = new Schema({
     type: [{
       audio: { type: String, default: '' },
       speaker: { type: String, default: '' },
-      review: { type: Boolean, default: false },
+      review: { type: Boolean, default: true },
       approvals: { type: [{ type: String }], default: [] },
       denials: { type: [{ type: String }], default: [] },
     }],

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -37,6 +37,9 @@ export const exampleSuggestionSchema = new Schema({
     type: [{
       audio: { type: String, default: '' },
       speaker: { type: String, default: '' },
+      review: { type: Boolean, default: false },
+      approvals: { type: [{ type: String }], default: [] },
+      denials: { type: [{ type: String }], default: [] },
     }],
     default: [],
   },

--- a/src/shared/components/views/components/ExampleEditForm/__tests__/ExampleEditFormSubmit.test.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/__tests__/ExampleEditFormSubmit.test.tsx
@@ -34,6 +34,42 @@ describe('Submit ExampleEditForm', () => {
       { onFailure: expect.any(Function), onSuccess: expect.any(Function) },
     ));
   });
+
+  it('submits example edit form with approvals, denials, and review', async () => {
+    const mockSave = jest.fn();
+    const testExample = cloneDeep(wordRecord.examples[0]);
+    delete testExample.id;
+    testExample.associatedDefinitionsSchemas = [];
+    testExample.editorsNotes = '';
+    testExample.pronunciations[0] = {
+      audio: '',
+      speaker: '',
+      // @ts-expect-error
+      review: false,
+      approvals: [],
+      denials: [],
+    };
+
+    const { findByText } = render(
+      <TestContext
+        view={Views.EDIT}
+        resource={Collections.WORD_SUGGESTIONS}
+        record={testExample}
+      >
+        <ExampleEditForm save={mockSave} />
+      </TestContext>,
+    );
+    fireEvent.submit(await findByText('Update'));
+
+    const finalExample = cloneDeep(testExample);
+    finalExample.pronunciations[0] = { audio: '', speaker: '' };
+    await waitFor(() => expect(mockSave).toBeCalledWith(
+      finalExample,
+      Views.SHOW,
+      { onFailure: expect.any(Function), onSuccess: expect.any(Function) },
+    ));
+  });
+
   it('submits example edit form with multiple audio pronunciations', async () => {
     const mockSave = jest.fn();
     const testExample = cloneDeep(wordRecord.examples[0]);

--- a/src/shared/components/views/components/WordEditForm/__tests__/WordEditFormSubmit.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/__tests__/WordEditFormSubmit.test.tsx
@@ -59,6 +59,43 @@ describe('Submit WordEditForm', () => {
     await waitFor(() => expect(mockSave).not.toBeCalled());
   });
 
+  it('submits word edit for with audio pronunciations approvals, denials, and review', async () => {
+    const mockSave = jest.fn();
+    const testWord = cloneDeep(wordRecord);
+    delete testWord.id;
+    delete testWord.dialects[0].id;
+    testWord.examples[0].pronunciations[0] = {
+      audio: 'recording',
+      speaker: '',
+      // @ts-expect-error
+      review: false,
+      denials: [],
+      approvals: [],
+    };
+
+    const { findByText } = render(
+      <TestContext
+        view={Views.EDIT}
+        resource={Collections.WORD_SUGGESTIONS}
+        record={testWord}
+      >
+        <WordEditForm save={mockSave} />
+      </TestContext>,
+    );
+    fireEvent.submit(await findByText('Update'));
+
+    const finalWord = cloneDeep(testWord);
+    finalWord.examples[0].pronunciations[0] = {
+      audio: 'recording',
+      speaker: '',
+    };
+    await waitFor(() => expect(mockSave).toBeCalledWith(
+      finalWord,
+      Views.SHOW,
+      { onFailure: expect.any(Function), onSuccess: expect.any(Function) },
+    ));
+  });
+
   it('submits word edit form with an extra example sentence', async () => {
     const mockSave = jest.fn();
     const testWord = cloneDeep(wordRecord);

--- a/src/shared/utils/removePayloadFields.ts
+++ b/src/shared/utils/removePayloadFields.ts
@@ -45,7 +45,9 @@ const removePayloadFields = (payload: RemovePayload): any => {
     cleanedPayload.examples = cleanedPayload.examples.map((example) => (
       omit({
         ...example,
-        pronunciations: (example.pronunciations || []).map((pronunciation) => omit(pronunciation, ['_id'])),
+        pronunciations: (example.pronunciations || []).map((pronunciation) => (
+          omit(pronunciation, ['_id', 'approvals', 'denials', 'review'])
+        )),
       }, ['authorId', 'archived'])
     ));
   }


### PR DESCRIPTION
## Background
The Igbo API Editor Platform will support multiple audio pronunciation approvals and denials. To support this new functionality, this PR is taking the first step by expanding the ExampleSuggestion model to handle the new fields `review`, `approvals`, and `denials`