### PR TITLE
Io/split put random example suggestions api

### DIFF
--- a/__mocks__/firebase/auth.ts
+++ b/__mocks__/firebase/auth.ts
@@ -1,6 +1,6 @@
 export const getAuth = jest.fn(() => ({
   currentUser: {
-    getIdToken: jest.fn(async () => ''),
+    getIdToken: jest.fn(async () => 'user-access'),
     displayName: 'Testing user',
   },
 }));

--- a/src/Core/Collections/IgboSoundbox/RecordSentenceAudio.tsx
+++ b/src/Core/Collections/IgboSoundbox/RecordSentenceAudio.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 import { ExampleSuggestion } from 'src/backend/controllers/utils/interfaces';
-import { getRandomExampleSuggestions, putRandomExampleSuggestions } from 'src/shared/DataCollectionAPI';
+import { getRandomExampleSuggestions, putAudioForRandomExampleSuggestions } from 'src/shared/DataCollectionAPI';
 import { ActivityButton, Card, PrimaryButton } from 'src/shared/primitives';
 import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 import SandboxAudioRecorder from './SandboxAudioRecorder';
@@ -66,11 +66,11 @@ const RecordSentenceAudio = ({
   const handleUploadAudio = async () => {
     try {
       const payload = examples.map((example, exampleIndex) => ({
-        id: example.id,
+        id: example.id.toString(),
         pronunciation: pronunciations[exampleIndex],
       }));
       setIsLoading(true);
-      await putRandomExampleSuggestions(payload);
+      await putAudioForRandomExampleSuggestions(payload);
     } catch (err) {
       toast({
         title: 'An error occurred',

--- a/src/Core/Collections/IgboSoundbox/VerifySentenceAudio.tsx
+++ b/src/Core/Collections/IgboSoundbox/VerifySentenceAudio.tsx
@@ -16,7 +16,10 @@ import {
   CheckIcon,
   SmallCloseIcon,
 } from '@chakra-ui/icons';
-import { getRandomExampleSuggestionsToReview, putRandomExampleSuggestions } from 'src/shared/DataCollectionAPI';
+import {
+  getRandomExampleSuggestionsToReview,
+  putReviewForRandomExampleSuggestions,
+} from 'src/shared/DataCollectionAPI';
 import { ExampleSuggestion } from 'src/backend/controllers/utils/interfaces';
 import ReviewActions from 'src/backend/shared/constants/ReviewActions';
 import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
@@ -89,7 +92,7 @@ const VerifySentenceAudio = ({
         review: reviews[exampleIndex],
       }));
       setIsLoading(true);
-      await putRandomExampleSuggestions(payload);
+      await putReviewForRandomExampleSuggestions(payload);
     } catch (err) {
       toast({
         title: 'An error occurred',

--- a/src/__tests__/exampleSuggestions.test.ts
+++ b/src/__tests__/exampleSuggestions.test.ts
@@ -17,7 +17,6 @@ import {
   getExampleSuggestion,
   getRandomExampleSuggestions,
   getRandomExampleSuggestionsToReview,
-  putRandomExampleSuggestions,
   deleteExampleSuggestion,
   postBulkUploadExampleSuggestions,
   suggestNewWord,
@@ -25,6 +24,8 @@ import {
   getWords,
   getTotalVerifiedExampleSuggestions,
   getTotalRecordedExampleSuggestions,
+  putAudioForRandomExampleSuggestions,
+  putReviewForRandomExampleSuggestions,
 } from './shared/commands';
 import {
   wordSuggestionData,
@@ -401,7 +402,7 @@ describe('MongoDB Example Suggestions', () => {
         id,
         pronunciation: `pronunciation-${id}`,
       }));
-      const updatedExamplesRes = await putRandomExampleSuggestions(updateExamplePayload);
+      const updatedExamplesRes = await putAudioForRandomExampleSuggestions(updateExamplePayload);
       expect(updatedExamplesRes.status).toEqual(200);
       await Promise.all(updatedExamplesRes.body.map(async (id) => {
         const exampleSuggestionRes = await getExampleSuggestion(id);
@@ -412,7 +413,7 @@ describe('MongoDB Example Suggestions', () => {
       }));
 
       // Save again but with crowdsourcer permissions
-      const crowdsourcerUpdatedExamplesRes = await putRandomExampleSuggestions(
+      const crowdsourcerUpdatedExamplesRes = await putAudioForRandomExampleSuggestions(
         updateExamplePayload,
         { token: AUTH_TOKEN.CROWDSOURCER_AUTH_TOKEN },
       );
@@ -503,7 +504,7 @@ describe('MongoDB Example Suggestions', () => {
         }
         return { id, review: ReviewActions.SKIP };
       });
-      const updatedRandomExampleSuggestionRes = await putRandomExampleSuggestions(reviewedExampleSuggestions);
+      const updatedRandomExampleSuggestionRes = await putReviewForRandomExampleSuggestions(reviewedExampleSuggestions);
       expect(updatedRandomExampleSuggestionRes.status).toEqual(200);
       await Promise.all(reviewedExampleSuggestions.map(async ({ id: randomExampleSuggestionId }, index) => {
         const randomExampleSuggestion = await getExampleSuggestion(randomExampleSuggestionId);

--- a/src/__tests__/shared/commands.ts
+++ b/src/__tests__/shared/commands.ts
@@ -110,12 +110,21 @@ export const postBulkUploadExamples = (data: { igbo: string }[], options = { tok
     .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
 );
 
-export const putRandomExampleSuggestions = (
+export const putAudioForRandomExampleSuggestions = (
   data: { id: string, pronunciations?: { audio: string, speaker: string }[], review?: ReviewActions }[],
   options = { token: '' },
 ): Request => (
   chaiServer
-    .put('/exampleSuggestions/random')
+    .put('/exampleSuggestions/random/audio')
+    .send(data)
+    .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
+);
+export const putReviewForRandomExampleSuggestions = (
+  data: { id: string, pronunciations?: { audio: string, speaker: string }[], review?: ReviewActions }[],
+  options = { token: '' },
+): Request => (
+  chaiServer
+    .put('/exampleSuggestions/random/review')
     .send(data)
     .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`)
 );

--- a/src/backend/routers/crowdsourcerRouter.ts
+++ b/src/backend/routers/crowdsourcerRouter.ts
@@ -7,7 +7,8 @@ import {
   getRandomExampleSuggestionsToReview,
   getTotalVerifiedExampleSuggestions,
   getTotalRecordedExampleSuggestions,
-  putRandomExampleSuggestions,
+  putAudioForRandomExampleSuggestions,
+  putReviewForRandomExampleSuggestions,
 } from 'src/backend/controllers/exampleSuggestions';
 import authentication from 'src/backend/middleware/authentication';
 import authorization from 'src/backend/middleware/authorization';
@@ -29,9 +30,14 @@ crowdsourcerRouter.put(
 
 crowdsourcerRouter.get('/exampleSuggestions/random', getRandomExampleSuggestions);
 crowdsourcerRouter.put(
-  '/exampleSuggestions/random',
+  '/exampleSuggestions/random/audio',
   validateRandomExampleSuggestionBody,
-  putRandomExampleSuggestions,
+  putAudioForRandomExampleSuggestions,
+);
+crowdsourcerRouter.put(
+  '/exampleSuggestions/random/review',
+  validateRandomExampleSuggestionBody,
+  putReviewForRandomExampleSuggestions,
 );
 crowdsourcerRouter.post(
   '/exampleSuggestions/upload',

--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -2,7 +2,7 @@ import { Record } from 'react-admin';
 import network from '../Core/Dashboard/network';
 import type { Poll } from '../backend/shared/types/Poll';
 import Collection from './constants/Collections';
-import request from './utils/request';
+import { request } from './utils/request';
 
 const handleSubmitConstructedTermPoll = (poll: Poll) => (
   request({

--- a/src/shared/DataCollectionAPI.ts
+++ b/src/shared/DataCollectionAPI.ts
@@ -1,7 +1,16 @@
 /* API for the Data Collection for IgboSpeech */
 import { BULK_UPLOAD_LIMIT } from 'src/Core/constants';
 import ReviewActions from 'src/backend/shared/constants/ReviewActions';
-import request from './utils/request';
+import { request } from './utils/request';
+
+interface ExampleAudioPayload {
+  id: string,
+  pronunciation: string | undefined,
+};
+interface ExampleReviewsPayload {
+  id: any,
+  review: ReviewActions,
+}
 
 export const getRandomExampleSuggestions = (
   count = 5,
@@ -23,21 +32,25 @@ export const getRandomExampleSuggestionsToReview = (
   },
 });
 
-export const putRandomExampleSuggestions = (rawData: {
-  id: any,
-  pronunciation?: string,
-  review?: ReviewActions,
-}[]): Promise<any> => {
+export const putAudioForRandomExampleSuggestions = (rawData: ExampleAudioPayload[]): Promise<any> => {
   const data = rawData.map(({ pronunciation, ...rest }) => ({
     ...rest,
     ...(pronunciation ? { pronunciation } : {}),
   }));
   return request({
     method: 'PUT',
-    url: 'exampleSuggestions/random',
+    url: 'exampleSuggestions/random/audio',
     data,
   });
 };
+
+export const putReviewForRandomExampleSuggestions = (data: ExampleReviewsPayload[]): Promise<any> => (
+  request({
+    method: 'PUT',
+    url: 'exampleSuggestions/random/review',
+    data,
+  })
+);
 
 export const bulkUploadExampleSuggestions = async (
   payload: { sentences: { igbo: string }[], isExample: boolean },

--- a/src/shared/__mocks__/DataCollectionAPI.ts
+++ b/src/shared/__mocks__/DataCollectionAPI.ts
@@ -44,7 +44,9 @@ export const getRandomExampleSuggestionsToReview = jest.fn(async () => ({
   })),
 }));
 
-export const putRandomExampleSuggestions = jest.fn(async () => {});
+export const putAudioForRandomExampleSuggestions = jest.fn(async () => {});
+
+export const putReviewForRandomExampleSuggestions = jest.fn(async () => {});
 
 export const getTotalRecordedExampleSuggestions = jest.fn(async () => ({
   count: 0,

--- a/src/shared/__tests__/DataCollectionAPI.test.tsx
+++ b/src/shared/__tests__/DataCollectionAPI.test.tsx
@@ -1,0 +1,95 @@
+import * as requestModule from 'src/shared/utils/request';
+import ReviewActions from 'src/backend/shared/constants/ReviewActions';
+import {
+  putAudioForRandomExampleSuggestions,
+  putReviewForRandomExampleSuggestions,
+} from '../DataCollectionAPI';
+
+describe('Commands', () => {
+  const response = new Promise((resolve) => resolve({ data: 'success' }));
+  it('sends a PUT request with putAudioForRandomExampleSuggestions with all pronunciations present', () => {
+    const requestSpy = jest.spyOn(requestModule, 'request').mockReturnValue(response);
+    const data = [
+      { id: 'first id', pronunciation: 'first pronunciation' },
+      { id: 'second id', pronunciation: 'second pronunciation' },
+      { id: 'third id', pronunciation: 'third pronunciation' },
+      { id: 'fourth id', pronunciation: 'fourth pronunciation' },
+      { id: 'fifth id', pronunciation: 'fifth pronunciation' },
+    ];
+    putAudioForRandomExampleSuggestions(data);
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'PUT',
+      url: 'exampleSuggestions/random/audio',
+      data,
+    });
+  });
+
+  it('sends a PUT request with putAudioForRandomExampleSuggestions with some pronunciations present', () => {
+    const requestSpy = jest.spyOn(requestModule, 'request').mockReturnValue(response);
+    const data = [
+      { id: 'first id', pronunciation: 'first pronunciation' },
+      { id: 'second id', pronunciation: '' },
+      { id: 'third id', pronunciation: '' },
+      { id: 'fourth id', pronunciation: 'fourth pronunciation' },
+      { id: 'fifth id', pronunciation: 'fifth pronunciation' },
+    ];
+    putAudioForRandomExampleSuggestions(data);
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'PUT',
+      url: 'exampleSuggestions/random/audio',
+      data: [
+        { id: 'first id', pronunciation: 'first pronunciation' },
+        { id: 'second id' },
+        { id: 'third id' },
+        { id: 'fourth id', pronunciation: 'fourth pronunciation' },
+        { id: 'fifth id', pronunciation: 'fifth pronunciation' },
+      ],
+    });
+  });
+
+  it('sends a PUT request with putAudioForRandomExampleSuggestions with no pronunciations present', () => {
+    const requestSpy = jest.spyOn(requestModule, 'request').mockReturnValue(response);
+    const data = [
+      { id: 'first id', pronunciation: '' },
+      { id: 'second id', pronunciation: '' },
+      { id: 'third id', pronunciation: '' },
+      { id: 'fourth id', pronunciation: '' },
+      { id: 'fifth id', pronunciation: '' },
+    ];
+    putAudioForRandomExampleSuggestions(data);
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'PUT',
+      url: 'exampleSuggestions/random/audio',
+      data: [
+        { id: 'first id' },
+        { id: 'second id' },
+        { id: 'third id' },
+        { id: 'fourth id' },
+        { id: 'fifth id' },
+      ],
+    });
+  });
+
+  it('sends a PUT request with putReviewForRandomExampleSuggestions with all reviews', () => {
+    const requestSpy = jest.spyOn(requestModule, 'request').mockReturnValue(response);
+    const data = [
+      { id: 'first id', review: ReviewActions.APPROVE },
+      { id: 'second id', review: ReviewActions.DENY },
+      { id: 'third id', review: ReviewActions.SKIP },
+      { id: 'fourth id', review: ReviewActions.APPROVE },
+      { id: 'fifth id', review: ReviewActions.APPROVE },
+    ];
+    putReviewForRandomExampleSuggestions(data);
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'PUT',
+      url: 'exampleSuggestions/random/review',
+      data: [
+        { id: 'first id', review: ReviewActions.APPROVE },
+        { id: 'second id', review: ReviewActions.DENY },
+        { id: 'third id', review: ReviewActions.SKIP },
+        { id: 'fourth id', review: ReviewActions.APPROVE },
+        { id: 'fifth id', review: ReviewActions.APPROVE },
+      ],
+    });
+  });
+});

--- a/src/shared/utils/__tests__/request.test.tsx
+++ b/src/shared/utils/__tests__/request.test.tsx
@@ -1,0 +1,40 @@
+import axios from 'axios';
+import { createAuthorizationHeader, request } from '../request';
+
+describe('request', () => {
+  it('creates a new authorizationHeader with createAuthorizationHeader', async () => {
+    const response = await createAuthorizationHeader();
+
+    expect(response).toEqual('Bearer user-access');
+  });
+
+  it('makes a request using axios to the backend', async () => {
+    const response = new Promise((resolve) => resolve({ data: 'success' }));
+
+    const requestSpy = jest.spyOn(axios, 'request').mockReturnValue(response);
+    await request({ data: 'test data', url: 'test' });
+
+    expect(requestSpy).toBeCalledWith({
+      data: 'test data',
+      url: 'https://localhost/test',
+      headers: {
+        Authorization: 'Bearer user-access',
+      },
+    });
+  });
+
+  it('makes a request using axios to the backend with no url', async () => {
+    const response = new Promise((resolve) => resolve({ data: 'success' }));
+
+    const requestSpy = jest.spyOn(axios, 'request').mockReturnValue(response);
+    await request({ data: 'test data' });
+
+    expect(requestSpy).toBeCalledWith({
+      data: 'test data',
+      url: 'https://localhost/undefined',
+      headers: {
+        Authorization: 'Bearer user-access',
+      },
+    });
+  });
+});

--- a/src/shared/utils/request.ts
+++ b/src/shared/utils/request.ts
@@ -16,13 +16,11 @@ const createHeaders = async () => ({
   Authorization: await createAuthorizationHeader(),
 });
 
-const request = async (requestObject: AxiosRequestConfig): Promise<any> => {
+export const request = async (requestObject: AxiosRequestConfig): Promise<any> => {
   const headers = await createHeaders();
-  return axios({
+  return axios.request({
     ...requestObject,
     url: `${API_ROUTE}/${requestObject.url}`,
     headers,
   });
 };
-
-export default request;


### PR DESCRIPTION
## Background
The `putRandomExampleSuggestions` DataCollectionAPI method to update example suggestions became too overloaded by handling both uploading audio pronunciations for example suggestions alongside reviewing each example suggestion. This PR splits up `putRandomExampleSuggestions` to create two new DataCollectionAPI methods:
* `putAudioForRandomExampleSuggestions`
* `putReviewForRandomExampleSuggestions`

These functions are dedicated to either uploading audio or applying reviews to example sentences.