### PR TITLE
Show the last updated date within the edit view

### DIFF
--- a/src/shared/components/views/components/DocumentIds.tsx
+++ b/src/shared/components/views/components/DocumentIds.tsx
@@ -1,18 +1,26 @@
 import React, { ReactElement } from 'react';
+import { get } from 'lodash';
+import { Record } from 'react-admin';
 import { Box, Heading, Text } from '@chakra-ui/react';
+import { determineDate } from '../shows/utils';
 
-const EditDocumentIds = ({
+const DocumentIds = ({
   collection,
   originalId,
+  record,
   id,
   title,
 } : {
   collection: string,
   originalId: string,
+  record: Record,
   id: string,
   title: string,
 }): ReactElement => (
   <Box className="flex flex-col my-2">
+    <Heading fontSize="lg" className="text-xl text-gray-700" mb="2">
+      {`Last Updated: ${determineDate(get(record, 'updatedAt'))}`}
+    </Heading>
     <Box className="flex items-center">
       <Heading fontSize="lg" className="text-l text-gray-600 mr-3">Id:</Heading>
       <Text fontSize="lg" fontFamily="monospace" className="text-l text-gray-800">{id}</Text>
@@ -35,4 +43,4 @@ const EditDocumentIds = ({
   </Box>
 );
 
-export default EditDocumentIds;
+export default DocumentIds;

--- a/src/shared/components/views/components/index.ts
+++ b/src/shared/components/views/components/index.ts
@@ -1,6 +1,6 @@
 import Comments from './Comments';
 import CorpusEditForm from './CorpusEditForm';
-import EditDocumentIds from './EditDocumentIds';
+import DocumentIds from './DocumentIds';
 import EditDocumentStats from './EditDocumentStats';
 import EditDocumentTopBar from './EditDocumentTopBar';
 import ExampleEditForm from './ExampleEditForm';
@@ -10,7 +10,7 @@ import WordEditForm from './WordEditForm';
 export {
   Comments,
   CorpusEditForm,
-  EditDocumentIds,
+  DocumentIds,
   EditDocumentStats,
   EditDocumentTopBar,
   ExampleEditForm,

--- a/src/shared/components/views/edits/CorpusSuggestionEdit.tsx
+++ b/src/shared/components/views/edits/CorpusSuggestionEdit.tsx
@@ -7,7 +7,7 @@ import Collection from 'src/shared/constants/Collections';
 import {
   CorpusEditForm,
   EditDocumentStats,
-  EditDocumentIds,
+  DocumentIds,
   EditDocumentTopBar,
 } from '../components';
 
@@ -21,12 +21,12 @@ const CorpusSuggestionEdit = (props: HistoryProps): ReactElement => {
   } = useEditController(props);
   const {
     id,
-    originalExampleId,
+    originalCorpusId,
     approvals,
     denials,
   } = record || {
     id: null,
-    originalExampleId: null,
+    originalCorpusId: null,
     approvals: [],
     denials: [],
   };
@@ -45,9 +45,10 @@ const CorpusSuggestionEdit = (props: HistoryProps): ReactElement => {
         id={id}
       />
       <Box className="flex flex-col lg:flex-row flex-auto justify-between items-start lg:items-center">
-        <EditDocumentIds
+        <DocumentIds
           collection={Collection.CORPORA}
-          originalId={originalExampleId}
+          originalId={originalCorpusId}
+          record={record}
           id={id}
           title="Parent Corpus Id:"
         />

--- a/src/shared/components/views/edits/ExampleSuggestionEdit.tsx
+++ b/src/shared/components/views/edits/ExampleSuggestionEdit.tsx
@@ -7,7 +7,7 @@ import Collection from 'src/shared/constants/Collections';
 import {
   ExampleEditForm,
   EditDocumentStats,
-  EditDocumentIds,
+  DocumentIds,
   EditDocumentTopBar,
 } from '../components';
 
@@ -45,9 +45,10 @@ const ExampleSuggestionEdit = (props: HistoryProps): ReactElement => {
         id={id}
       />
       <Box className="flex flex-col lg:flex-row flex-auto justify-between items-start lg:items-center">
-        <EditDocumentIds
+        <DocumentIds
           collection={Collection.EXAMPLES}
           originalId={originalExampleId}
+          record={record}
           id={id}
           title="Parent Example Id:"
         />

--- a/src/shared/components/views/edits/WordSuggestionEdit.tsx
+++ b/src/shared/components/views/edits/WordSuggestionEdit.tsx
@@ -7,7 +7,7 @@ import { HistoryProps } from 'src/shared/interfaces';
 import {
   WordEditForm,
   EditDocumentStats,
-  EditDocumentIds,
+  DocumentIds,
   EditDocumentTopBar,
 } from '../components';
 
@@ -45,7 +45,13 @@ const WordSuggestionEdit = (props: HistoryProps): ReactElement => {
         id={id}
       />
       <Box className="flex flex-col lg:flex-row flex-auto justify-between items-start lg:items-center">
-        <EditDocumentIds collection={Collections.WORDS} originalId={originalWordId} id={id} title="Parent Word Id:" />
+        <DocumentIds
+          collection={Collections.WORDS}
+          originalId={originalWordId}
+          record={record}
+          id={id}
+          title="Parent Word Id:"
+        />
         <EditDocumentStats approvals={approvals} denials={denials} />
       </Box>
       {record ? (

--- a/src/shared/components/views/shows/CorpusShow/CorpusShow.tsx
+++ b/src/shared/components/views/shows/CorpusShow/CorpusShow.tsx
@@ -11,10 +11,9 @@ import SourceField from 'src/shared/components/SourceField';
 import {
   EditDocumentTopBar,
   ShowDocumentStats,
-  EditDocumentIds,
+  DocumentIds,
   Comments,
 } from '../../components';
-import { determineDate } from '../utils';
 import DiffField from '../diffFields/DiffField';
 
 const DIFF_FILTER_KEYS = [
@@ -56,7 +55,6 @@ const CorpusShow = (props: ShowProps): ReactElement => {
     approvals,
     denials,
     originalWordId,
-    updatedAt,
   } = record;
 
   const resourceTitle = {
@@ -96,20 +94,13 @@ const CorpusShow = (props: ShowProps): ReactElement => {
         <Box className="flex flex-col lg:flex-row mb-1">
           <Box className="flex flex-col flex-auto justify-between items-start space-y-4 mr-4">
             <Box className="w-full flex flex-col lg:flex-row justify-between items-center">
-              <Box>
-                <Heading fontSize="lg" className="text-xl text-gray-700">
-                  <>
-                    {'Last Updated: '}
-                    {determineDate(updatedAt)}
-                  </>
-                </Heading>
-                <EditDocumentIds
-                  collection={Collection.WORDS}
-                  originalId={originalWordId}
-                  id={id}
-                  title="Parent Word Id:"
-                />
-              </Box>
+              <DocumentIds
+                collection={Collection.WORDS}
+                originalId={originalWordId}
+                record={record}
+                id={id}
+                title="Parent Word Id:"
+              />
             </Box>
             <Box className="flex flex-col mt-5">
               <Heading fontSize="lg" className="text-xl text-gray-600">Title</Heading>

--- a/src/shared/components/views/shows/ExampleShow/ExampleShow.tsx
+++ b/src/shared/components/views/shows/ExampleShow/ExampleShow.tsx
@@ -21,11 +21,10 @@ import ArrayDiffField from '../diffFields/ArrayDiffField';
 import ArrayDiff from '../diffFields/ArrayDiff';
 import {
   ShowDocumentStats,
-  EditDocumentIds,
+  DocumentIds,
   EditDocumentTopBar,
   Comments,
 } from '../../components';
-import { determineDate } from '../utils';
 
 const ExampleShow = (props: ShowProps): ReactElement => {
   const [isLoading, setIsLoading] = useState(true);
@@ -48,7 +47,6 @@ const ExampleShow = (props: ShowProps): ReactElement => {
     userComments,
     associatedWords,
     originalExampleId,
-    updatedAt,
   } = record || DEFAULT_EXAMPLE_RECORD;
 
   const DIFF_FILTER_KEYS = [
@@ -99,13 +97,10 @@ const ExampleShow = (props: ShowProps): ReactElement => {
         />
         <Box className="flex flex-col-reverse lg:flex-row mt-1">
           <Box className="flex flex-col flex-auto justify-between items-start">
-            <h3 className="text-xl text-gray-700">
-              {'Last Updated: '}
-              {determineDate(updatedAt)}
-            </h3>
-            <EditDocumentIds
+            <DocumentIds
               collection={Collection.EXAMPLES}
               originalId={originalExampleId}
+              record={record}
               id={id}
               title="Parent Example Id:"
             />

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -26,10 +26,9 @@ import isVerb from 'src/backend/shared/utils/isVerb';
 import {
   EditDocumentTopBar,
   ShowDocumentStats,
-  EditDocumentIds,
+  DocumentIds,
   Comments,
 } from '../../components';
-import { determineDate } from '../utils';
 import DialectDiff from '../diffFields/DialectDiff';
 import DiffField from '../diffFields/DiffField';
 import ArrayDiffField from '../diffFields/ArrayDiffField';
@@ -89,7 +88,6 @@ const WordShow = (props: ShowProps): ReactElement => {
     merged,
     pronunciation,
     originalWordId,
-    updatedAt,
     wordPronunciation,
     conceptualWord,
     examples: rawExamples,
@@ -156,20 +154,13 @@ const WordShow = (props: ShowProps): ReactElement => {
         <Box className="flex flex-col lg:flex-row mb-1">
           <Box className="flex flex-col flex-auto justify-start items-start">
             <Box className="w-full flex flex-col lg:flex-row justify-between items-center">
-              <Box>
-                <Heading fontSize="lg" className="text-xl text-gray-700">
-                  <>
-                    {'Last Updated: '}
-                    {determineDate(updatedAt)}
-                  </>
-                </Heading>
-                <EditDocumentIds
-                  collection={Collection.WORDS}
-                  originalId={originalWordId}
-                  id={id}
-                  title="Parent Word Id:"
-                />
-              </Box>
+              <DocumentIds
+                collection={Collection.WORDS}
+                originalId={originalWordId}
+                record={record}
+                id={id}
+                title="Parent Word Id:"
+              />
             </Box>
             <Box className="flex flex-row items-center space-x-6 mt-5">
               <Box className="flex flex-col">


### PR DESCRIPTION
## Background
Editors have requested to know when the current suggestion that they are updated has been last updated. This PR adds the timestamp to the edit view for Word, Example, and Corpus Suggestions.

### Screenshot
<img width="810" alt="Xnapper-2023-05-31-18 13 17" src="https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/43e58dd8-e972-4e36-b0a6-5c8823ef267d">
