### PR TITLE
Create new leaderboard route that is only available to admins

### DIFF
--- a/src/App/Resources.tsx
+++ b/src/App/Resources.tsx
@@ -28,6 +28,7 @@ import PollList from 'src/Core/Collections/Polls/PollList';
 import PollCreate from 'src/Core/Collections/Polls/PollCreate';
 import UserList from 'src/Core/Collections/Users/UserList';
 import UserShow from 'src/Core/Collections/Users/UserShow';
+import Leaderboard from 'src/Core/Collections/Leaderboard';
 import IgboSoundbox from 'src/Core/Collections/IgboSoundbox';
 import IgboDefinitions from 'src/Core/Collections/IgboDefinitions';
 import DataDump from 'src/Core/Collections/DataDump';
@@ -127,6 +128,13 @@ const adminRoutes = (permissions) => hasAdminPermissions(permissions, [
     options: { label: 'Data Dump' },
     list: DataDump,
     icon: () => <>🏋🏾‍♂️</>,
+  },
+  {
+    name: 'leaderboard',
+    key: 'leaderboard',
+    options: { label: 'Leaderboard' },
+    list: Leaderboard,
+    icon: () => <>🥇</>,
   },
 ]) || [];
 

--- a/src/Core/Collections/Leaderboard/Leaderboard.tsx
+++ b/src/Core/Collections/Leaderboard/Leaderboard.tsx
@@ -1,0 +1,7 @@
+import React, { ReactElement } from 'react';
+
+const Leaderboard = (): ReactElement => (
+  <div>this is the leader board page - this page is only visible to admins</div>
+);
+
+export default Leaderboard;

--- a/src/Core/Collections/Leaderboard/index.ts
+++ b/src/Core/Collections/Leaderboard/index.ts
@@ -1,0 +1,3 @@
+import Leaderboard from './Leaderboard';
+
+export default Leaderboard;


### PR DESCRIPTION
## Background
We are creating a leaderboard page for data collection. This is the first PR that creates a new route to render the contents of the page.

### Screenshot
<img width="1904" alt="Xnapper-2023-05-31-18 42 43" src="https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/a12e7201-00cc-4665-931b-cfd697c3baaf">
