### PR TITLE
Io/update leaderboard

### DIFF
--- a/src/Core/Collections/IgboSoundbox/IgboSoundbox.tsx
+++ b/src/Core/Collections/IgboSoundbox/IgboSoundbox.tsx
@@ -2,7 +2,7 @@ import React, { useState, ReactElement, useEffect } from 'react';
 import queryString from 'query-string';
 import IgboSoundboxViews from 'src/shared/constants/IgboSoundboxViews';
 import useBeforeWindowUnload from 'src/hooks/useBeforeWindowUnload';
-import { Hide, useBreakpointValue } from '@chakra-ui/react';
+import { Hide } from '@chakra-ui/react';
 import RecordSentenceAudio from './RecordSentenceAudio';
 import VerifySentenceAudio from './VerifySentenceAudio';
 import IgboSoundboxHome from './components/Home';
@@ -11,15 +11,10 @@ import IgboSoundboxNavbar from './components/Navbar';
 const IgboSoundbox = (): ReactElement => {
   const [currentView, setCurrentView] = useState<IgboSoundboxViews>();
   const [isDirty, setIsDirty] = useState(false);
-  const isMobile = useBreakpointValue({ base: true, lg: false });
 
   const goHome = () => {
-    if (isMobile) {
-      window.location.search = '';
-      window.location.hash = '#/';
-    } else {
-      setCurrentView(IgboSoundboxViews.HOME);
-    }
+    window.location.search = '';
+    window.location.hash = '#/';
   };
 
   useEffect(() => {

--- a/src/Login/GoogleLogin.tsx
+++ b/src/Login/GoogleLogin.tsx
@@ -24,12 +24,15 @@ const GoogleLogin = ({
   const signInWithGoogle = () => {
     setErrorMessage('');
     return signInWithPopup(auth, googleProvider)
-      .then(() => {
+    // @ts-expect-error
+      .then((({ _tokenResponse } = { _tokenResponse: { isNewUser: false } }) => {
+        const { isNewUser } = _tokenResponse;
         handleUserResult({
           toast,
           setErrorMessage,
+          isNewUser,
         });
-      }).catch((error) => {
+      })).catch((error) => {
         console.log(error);
         setErrorMessage(error.message);
       });

--- a/src/Login/handleUserResult.ts
+++ b/src/Login/handleUserResult.ts
@@ -13,9 +13,11 @@ const auth = getAuth();
 export const handleUserResult = async ({
   toast,
   setErrorMessage,
+  isNewUser = false,
 } : {
   toast: any,
   setErrorMessage: (err: string) => void,
+  isNewUser?: boolean,
 }): Promise<any> => {
   const { currentUser } = auth;
   if (!currentUser) {
@@ -48,11 +50,22 @@ export const handleUserResult = async ({
 
   setErrorMessage('');
 
-  const rawRedirectUrl = localStorage.getItem(LocalStorageKeys.REDIRECT_URL);
-  const hash = (
-    hasTranscriberPermissions(permissions, '#/igboSoundbox')
-    || hasCrowdsourcerPermission(permissions, '#/')
-    || (rawRedirectUrl || '#/') || '#/'
-  );
-  window.location.href = `${window.location.origin}/${hash}`;
+  if (isNewUser) {
+    authProvider.logout();
+    toast({
+      title: 'Account created',
+      description: 'Please refresh the page and log in to access the platform',
+      status: 'success',
+      duration: 4000,
+      isClosable: true,
+    });
+  } else {
+    const rawRedirectUrl = localStorage.getItem(LocalStorageKeys.REDIRECT_URL);
+    const hash = (
+      hasTranscriberPermissions(permissions, '#/igboSoundbox')
+      || hasCrowdsourcerPermission(permissions, '#/')
+      || (rawRedirectUrl || '#/') || '#/'
+    );
+    window.location.href = `${window.location.origin}/${hash}`;
+  }
 };

--- a/src/backend/controllers/leaderboard/__tests__/utils.test.ts
+++ b/src/backend/controllers/leaderboard/__tests__/utils.test.ts
@@ -1,0 +1,90 @@
+import { cloneDeep, times } from 'lodash';
+import { sortLeaderboards, sortRankings, splitRankings } from '../utils';
+
+const rankings = [
+  { uid: 'second user', count: 45, position: 0 },
+  { uid: 'first user', count: 123, position: 2 },
+  { uid: 'third user', count: 3, position: 1 },
+];
+const manyRankings = times(434, (index) => ({
+  uid: `${index} user`,
+  count: Math.floor(Math.random() * 1000),
+  position: Math.floor(Math.random() * 434),
+}));
+
+describe('leaderboard utils', () => {
+  describe('sortRankings', () => {
+    it('sorts the rankings in the correct order with the same user count', () => {
+      const clonedRankings = cloneDeep(rankings);
+      const updatedRankings = sortRankings({ leaderboardRankings: clonedRankings, uid: 'second user', count: 45 });
+      expect(updatedRankings).toEqual([
+        { uid: 'first user', count: 123, position: 1 },
+        { uid: 'second user', count: 45, position: 2 },
+        { uid: 'third user', count: 3, position: 3 },
+      ]);
+    });
+    it('sorts the rankings in the correct order with a different user count', () => {
+      const clonedRankings = cloneDeep(rankings);
+      const updatedRankings = sortRankings({ leaderboardRankings: clonedRankings, uid: 'second user', count: 300 });
+      expect(updatedRankings).toEqual([
+        { uid: 'second user', count: 300, position: 1 },
+        { uid: 'first user', count: 123, position: 2 },
+        { uid: 'third user', count: 3, position: 3 },
+      ]);
+    });
+    it('sorts the rankings in the correct order with new user', () => {
+      const clonedRankings = cloneDeep(rankings);
+      const updatedRankings = sortRankings({ leaderboardRankings: clonedRankings, uid: 'fourth user', count: 50 });
+      expect(updatedRankings).toEqual([
+        { uid: 'first user', count: 123, position: 1 },
+        { uid: 'fourth user', count: 50, position: 2 },
+        { uid: 'second user', count: 45, position: 3 },
+        { uid: 'third user', count: 3, position: 4 },
+      ]);
+    });
+    it('returns an empty array with no leaderboard rankings', () => {
+      const updatedRankings = sortRankings({ leaderboardRankings: null, uid: 'fourth user', count: 50 });
+      expect(updatedRankings).toEqual([]);
+    });
+    it('returns an empty array with no uid', () => {
+      const updatedRankings = sortRankings({ leaderboardRankings: [], uid: '', count: 50 });
+      expect(updatedRankings).toEqual([]);
+    });
+    it('returns an empty array with no count', () => {
+      const updatedRankings = sortRankings({ leaderboardRankings: [], uid: 'fourth user', count: null });
+      expect(updatedRankings).toEqual([]);
+    });
+  });
+
+  describe('splitRankings', () => {
+    it('splits 434 unorganized rankings', () => {
+      const rankingGroups = splitRankings(manyRankings);
+      expect(rankingGroups).toHaveLength(3);
+    });
+    it('splits 434 organized rankings', () => {
+      const rankingGroups = splitRankings(sortRankings({
+        leaderboardRankings: manyRankings,
+        uid: '0 user',
+        count: 10,
+      }));
+      rankingGroups.forEach((rankingGroup) => {
+        rankingGroup.forEach((ranking, index) => {
+          if (index + 1 < rankingGroup.length) {
+            expect(ranking.position).toBeLessThan(rankingGroup[index + 1].position);
+            expect(ranking.count).toBeGreaterThanOrEqual(rankingGroup[index + 1].count);
+          }
+        });
+      });
+      expect(rankingGroups).toHaveLength(3);
+    });
+  });
+
+  describe('sortLeaderboards', () => {
+    it('sorts an array of leaderboards', () => {
+      const leaderboards = [{ page: 1 }, { page: 2 }, { page: 0 }];
+      // @ts-expect-error
+      sortLeaderboards(leaderboards);
+      expect(leaderboards).toEqual([{ page: 0 }, { page: 1 }, { page: 2 }]);
+    });
+  });
+});

--- a/src/backend/controllers/leaderboard/index.ts
+++ b/src/backend/controllers/leaderboard/index.ts
@@ -1,0 +1,175 @@
+import { Connection } from 'mongoose';
+import { Response, NextFunction } from 'express';
+import * as Interfaces from 'src/backend/controllers/utils/interfaces';
+import { exampleSuggestionSchema } from 'src/backend/models/ExampleSuggestion';
+import { leaderboardSchema } from 'src/backend/models/Leaderboard';
+import LeaderboardType from 'src/backend/shared/constants/LeaderboardType';
+import {
+  searchExampleAudioPronunciationsRecordedByUser,
+  searchExampleAudioPronunciationsReviewedByUser,
+} from '../utils/queries';
+import { handleQueries } from '../utils';
+import {
+  sortRankings,
+  splitRankings,
+  assignRankings,
+  sortLeaderboards,
+} from './utils';
+
+const updateUserLeaderboardStat = async ({
+  leaderboardType,
+  query,
+  mongooseConnection,
+  uid,
+} : {
+  leaderboardType: LeaderboardType,
+  query: any,
+  mongooseConnection: Connection,
+  uid: string,
+}) => {
+  const ExampleSuggestion = (
+    mongooseConnection.model<Interfaces.ExampleSuggestion>('ExampleSuggestion', exampleSuggestionSchema)
+  );
+  const Leaderboard = mongooseConnection.model<Interfaces.Leaderboard>('Leaderboard', leaderboardSchema);
+
+  let leaderboards = await Leaderboard.find({ type: leaderboardType });
+  if (!leaderboards || !leaderboards.length) {
+    const newLeaderboard = new Leaderboard({
+      type: leaderboardType,
+      page: 0,
+    });
+    leaderboards = [await newLeaderboard.save()];
+  }
+  sortLeaderboards(leaderboards);
+
+  const allRankings = leaderboards.map(({ rankings }) => rankings).flat();
+
+  const exampleSuggestionsByUser = await ExampleSuggestion.find(query);
+
+  if (!exampleSuggestionsByUser) {
+    throw new Error('No example suggestion associated with the user.');
+  }
+
+  const updatedRankings = sortRankings({
+    leaderboardRankings: allRankings,
+    uid,
+    count: exampleSuggestionsByUser.length,
+  });
+
+  const rankingsGroups = splitRankings(updatedRankings);
+
+  await assignRankings({
+    rankingsGroups,
+    leaderboards,
+    Leaderboard,
+  });
+};
+
+/* Gets the specified page of users in the leaderboard */
+export const getLeaderboard = async (
+  req: Interfaces.EditorRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<any> => {
+  const {
+    skip,
+    limit,
+    user,
+    leaderboard,
+    mongooseConnection,
+  } = handleQueries(req);
+  const Leaderboard = (
+    mongooseConnection.model<Interfaces.Leaderboard>('Leaderboard', leaderboardSchema)
+  );
+  if (!leaderboard) {
+    throw new Error('Please provide a leaderboard to view');
+  }
+
+  try {
+    // @ts-expect-error
+    let leaderboards = await Leaderboard.find({ type: leaderboard });
+    if (!leaderboards || !leaderboards.length) {
+      leaderboards = [];
+    }
+    sortLeaderboards(leaderboards);
+
+    const allRankings = leaderboards.map(({ rankings }) => rankings).flat();
+    const userIndex = allRankings.findIndex(({ uid }) => uid === user.uid);
+    let userRanking = {};
+    if (userIndex === -1) {
+      // If the user hasn't contributed anything yet, they don't have a position;
+      userRanking = { uid: user.uid, position: null, count: -1 };
+    } else {
+      userRanking = allRankings[userIndex];
+    }
+    res.setHeader('Content-Range', allRankings.length);
+    return res.send({
+      userRanking,
+      rankings: allRankings.slice(skip, skip + limit - 1),
+    });
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const calculateRecordingExampleLeaderboard = async (
+  req: Interfaces.EditorRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<any> => {
+  const {
+    user,
+    error,
+    response,
+    mongooseConnection,
+  } = req;
+  const { uid } = user;
+
+  if (error) {
+    return next(error);
+  }
+
+  try {
+    await updateUserLeaderboardStat({
+      leaderboardType: LeaderboardType.RECORD_EXAMPLE_AUDIO,
+      query: searchExampleAudioPronunciationsRecordedByUser(uid),
+      mongooseConnection,
+      uid,
+    });
+
+    return res.send(response);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const calculateReviewingExampleLeaderboard = async (
+  req: Interfaces.EditorRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<any> => {
+  const {
+    user,
+    error,
+    response,
+    mongooseConnection,
+  } = req;
+  const { uid } = user;
+
+  if (error) {
+    return next(error);
+  }
+
+  try {
+    await updateUserLeaderboardStat({
+      leaderboardType: LeaderboardType.VERIFY_EXAMPLE_AUDIO,
+      query: searchExampleAudioPronunciationsReviewedByUser(uid),
+      mongooseConnection,
+      uid,
+    });
+
+    return res.send(response);
+  } catch (err) {
+    return next(err);
+  }
+};

--- a/src/backend/controllers/leaderboard/utils.ts
+++ b/src/backend/controllers/leaderboard/utils.ts
@@ -1,0 +1,86 @@
+import { cloneDeep } from 'lodash';
+import { Model } from 'mongoose';
+import * as Interfaces from 'src/backend/controllers/utils/interfaces';
+import LeaderboardType from 'src/backend/shared/constants/LeaderboardType';
+
+export const sortRankings = ({
+  leaderboardRankings,
+  uid,
+  count,
+} : {
+  leaderboardRankings: Interfaces.Leaderboard['rankings'],
+  uid: string,
+  count: number,
+}): Interfaces.Leaderboard['rankings'] => {
+  if (!Array.isArray(leaderboardRankings) || !uid || typeof count !== 'number') {
+    return leaderboardRankings || [];
+  }
+  let rankings = cloneDeep(leaderboardRankings);
+  const userRankingIndex = rankings.findIndex((ranking) => ranking.uid === uid);
+  if (userRankingIndex === -1) {
+    rankings.push({ count, uid, position: -1 });
+  } else {
+    rankings[userRankingIndex] = { count, uid, position: -1 };
+  }
+  rankings.sort((firstRanking, secondRanking) => {
+    if (firstRanking.count > secondRanking.count) {
+      return -1;
+    }
+    if (firstRanking.count < secondRanking.count) {
+      return 1;
+    }
+    return 0;
+  });
+  rankings = rankings.map((ranking, index) => {
+    const updatedRanking = cloneDeep(ranking);
+    updatedRanking.position = index + 1;
+    return updatedRanking;
+  });
+  return rankings;
+};
+
+export const splitRankings = (rankings: Interfaces.Leaderboard['rankings']): Interfaces.Leaderboard['rankings'][] => {
+  const GROUP_LIMIT = 200;
+  let index = 0;
+  const rankingsGroups = [];
+  while (index < rankings.length) {
+    rankingsGroups.push(rankings.slice(index, index + GROUP_LIMIT));
+    index += GROUP_LIMIT;
+  }
+  return rankingsGroups;
+};
+
+export const assignRankings = async ({
+  rankingsGroups,
+  leaderboards,
+  Leaderboard,
+} : {
+  rankingsGroups: Interfaces.Leaderboard['rankings'][],
+  leaderboards: Interfaces.Leaderboard[],
+  Leaderboard: Model<Interfaces.Leaderboard, unknown, unknown>,
+}): Promise<void> => {
+  await Promise.all(rankingsGroups.map(async (rankings, index) => {
+    const leaderboard = leaderboards[index];
+    if (!leaderboard) {
+      const newLeaderboard = new Leaderboard({
+        type: LeaderboardType.RECORD_EXAMPLE_AUDIO,
+        page: index,
+      });
+      await newLeaderboard.save();
+    }
+    leaderboard.rankings = rankings;
+    await leaderboard.save();
+  }));
+};
+
+export const sortLeaderboards = (leaderboards: Interfaces.Leaderboard[]): void => {
+  leaderboards.sort((firstLeaderboard, secondLeaderboard) => {
+    if (firstLeaderboard.page < secondLeaderboard.page) {
+      return -1;
+    }
+    if (firstLeaderboard.page > secondLeaderboard.page) {
+      return 1;
+    }
+    return 0;
+  });
+};

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -10,6 +10,7 @@ import Collections from 'src/shared/constants/Collections';
 import SentenceType from 'src/backend/shared/constants/SentenceType';
 import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 import { User } from 'firebase/auth';
+import LeaderboardType from 'src/backend/shared/constants/LeaderboardType';
 
 export interface HandleQueries {
   searchWord: string,
@@ -23,6 +24,7 @@ export interface HandleQueries {
   strict: boolean,
   body: EditorRequest['body'],
   mongooseConnection: EditorRequest['mongooseConnection'],
+  leaderboard: undefined | Leaderboard,
   uidQuery?: string,
 };
 
@@ -40,10 +42,13 @@ export interface EditorRequest extends Request {
     filter?: string,
     strict?: string,
     uid?: string,
+    leaderboard?: LeaderboardType,
   },
   suggestionDoc?: Suggestion,
   body: any,
   word?: Word,
+  response?: any,
+  error?: Error,
   mongooseConnection: Connection,
 };
 
@@ -207,6 +212,14 @@ export interface NsibidiCharacter {
 
 export interface CachedDocument extends WordSuggestion, ExampleSuggestion {
   cachedAt: Date,
+}
+
+export interface Leaderboard extends Document<any>, LeanDocument<any> {
+  id: Types.ObjectId,
+  rankings: { uid: string, count: number, position: number }[],
+  type: LeaderboardType,
+  page: number,
+  updatedAt: Date,
 }
 
 export interface MergedOrRejectedEmailData {

--- a/src/backend/controllers/utils/queries.ts
+++ b/src/backend/controllers/utils/queries.ts
@@ -332,3 +332,31 @@ export const searchWordsWithoutIgboDefinitions = (): {
 } => ({
   'definitions.0.igboDefinitions.0': { $exists: false },
 });
+
+// Stats
+export const searchExampleAudioPronunciationsReviewedByUser = (uid: string): {
+  pronunciations: {
+    $elemMatch: {
+      $or: { [key: string]: { $in: [string] } }[],
+    }
+  }
+} => ({
+  pronunciations: {
+    $elemMatch: {
+      $or: [
+        { approvals: { $in: [uid] } },
+        { denials: { $in: [uid] } },
+      ],
+    },
+  },
+});
+
+export const searchExampleAudioPronunciationsRecordedByUser = (uid: string): {
+  pronunciations: {
+    $elemMatch: { [key: string]: { $eq: string } }
+  }
+} => ({
+  pronunciations: {
+    $elemMatch: { speaker: { $eq: uid } },
+  },
+});

--- a/src/backend/models/Leaderboard.ts
+++ b/src/backend/models/Leaderboard.ts
@@ -5,27 +5,19 @@ import LeaderboardType from '../shared/constants/LeaderboardType';
 const userRankSchema = new Schema({
   uid: { type: String, required: true },
   count: { type: Number, default: -1 },
-  ranking: { type: Number, default: -1 },
+  position: { type: Number, default: -1 },
 });
 
 export const leaderboardSchema = new Schema(
   {
-    ranks: { type: [{ type: userRankSchema }], default: [] },
+    rankings: { type: [{ type: userRankSchema }], default: [] },
     type: {
       type: String,
-      // Valid names: igbo_definitions or igbo_definitions_12
-      // Allowing _<number> at the end of the type supports creating
-      // multiple documents within the same type
-      validate: (type) => {
-        const regexes = Object.values(LeaderboardType).map((leaderboardType) => (
-          // eslint-disable-next-line
-          `(${leaderboardType}_\d*$)`
-        )).join('|');
-        return LeaderboardType[type] || new RegExp(regexes, 'g');
-      },
+      enum: Object.values(LeaderboardType),
       required: true,
       index: true,
     },
+    page: { type: Number, required: true },
   },
   { toObject: toObjectPlugin, timestamps: true },
 );

--- a/src/backend/routers/crowdsourcerRouter.ts
+++ b/src/backend/routers/crowdsourcerRouter.ts
@@ -10,6 +10,10 @@ import {
   putAudioForRandomExampleSuggestions,
   putReviewForRandomExampleSuggestions,
 } from 'src/backend/controllers/exampleSuggestions';
+import {
+  calculateReviewingExampleLeaderboard,
+  calculateRecordingExampleLeaderboard,
+} from 'src/backend/controllers/leaderboard';
 import authentication from 'src/backend/middleware/authentication';
 import authorization from 'src/backend/middleware/authorization';
 import validateAudioRandomExampleSuggestionBody from 'src/backend/middleware/validateAudioRandomExampleSuggestionBody';
@@ -31,15 +35,20 @@ crowdsourcerRouter.put(
 );
 
 crowdsourcerRouter.get('/exampleSuggestions/random', getRandomExampleSuggestions);
+
+// Records audio for example suggestion
 crowdsourcerRouter.put(
   '/exampleSuggestions/random/audio',
   validateAudioRandomExampleSuggestionBody,
   putAudioForRandomExampleSuggestions,
+  calculateRecordingExampleLeaderboard,
 );
+// Reviews audio for example suggestion
 crowdsourcerRouter.put(
   '/exampleSuggestions/random/review',
   validateReviewRandomExampleSuggestionBody,
   putReviewForRandomExampleSuggestions,
+  calculateReviewingExampleLeaderboard,
 );
 crowdsourcerRouter.post(
   '/exampleSuggestions/upload',


### PR DESCRIPTION
## Background
Updates the `'/exampleSuggestions/random/review'` and `'/exampleSuggestions/random/audio'` routes with new final middleware:
* `calculateReviewingExampleLeaderboard`
* `calculateRecordingExampleLeaderboard`

This final middleware will update the corresponding `Leaderboard` collection documents with the user's stats so that this information can be quickly presented on the UI.

## Fix Google Login flow
Crowdsourcers would notice that after they were granted access to the platform, they would see an error message saying that there was an error while retrieving data. This has been fixed by requiring the user to log in again after signing up so they don't see that error. Not the most ideal flow, but at least there are on-screen instructions to guide the new user.