### PR TITLE
Move list action options to the left

### DIFF
--- a/src/Core/Collections/Corpora/CorpusList.tsx
+++ b/src/Core/Collections/Corpora/CorpusList.tsx
@@ -1,19 +1,6 @@
 import React from 'react';
-import {
-  List,
-  Datagrid,
-  TextField,
-  Responsive,
-  ListProps,
-  UrlField,
-} from 'react-admin';
-import {
-  BulkSuggestionActions,
-  IdField,
-  Select,
-  ListActions,
-  Pagination,
-} from 'src/shared/components';
+import { List, Datagrid, TextField, Responsive, ListProps, UrlField } from 'react-admin';
+import { BulkSuggestionActions, IdField, Select, ListActions, Pagination } from 'src/shared/components';
 import Collection from 'src/shared/constants/Collections';
 import { hasAdminOrMergerPermissions } from 'src/shared/utils/permissions';
 import Empty from '../../Empty';
@@ -31,21 +18,21 @@ const CorpusSuggestionList = (props: ListProps): React.ReactElement => {
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Responsive
-        small={(
+        small={
           <Datagrid>
+            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
             <TextField label="Title" source="title" />
             <UrlField label="Media URL" source="media" />
-            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid>
+            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
             <TextField label="Title" source="title" />
             <UrlField label="Media URL" source="media" />
             <IdField label="Id" source="id" />
-            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/CorpusSuggestions/CorpusSuggestionList.tsx
+++ b/src/Core/Collections/CorpusSuggestions/CorpusSuggestionList.tsx
@@ -1,21 +1,6 @@
 import React from 'react';
-import {
-  List,
-  Datagrid,
-  TextField,
-  FunctionField,
-  Responsive,
-  ListProps,
-  UrlField,
-} from 'react-admin';
-import {
-  BulkSuggestionActions,
-  IdField,
-  Select,
-  ReviewPreview,
-  ListActions,
-  Pagination,
-} from 'src/shared/components';
+import { List, Datagrid, TextField, FunctionField, Responsive, ListProps, UrlField } from 'react-admin';
+import { BulkSuggestionActions, IdField, Select, ReviewPreview, ListActions, Pagination } from 'src/shared/components';
 import Collection from 'src/shared/constants/Collections';
 import { hasAdminOrMergerPermissions } from 'src/shared/utils/permissions';
 import Empty from '../../Empty';
@@ -33,35 +18,31 @@ const ExampleSuggestionList = (props: ListProps): React.ReactElement => {
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Responsive
-        small={(
+        small={
           <Datagrid>
+            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
             <ReviewPreview label="You Reviewed" />
             <TextField label="Title" source="title" />
             <UrlField label="Media URL" source="media" />
-            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid>
+            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
             <ReviewPreview label="You Reviewed" />
             <TextField label="Title" source="title" />
             <UrlField label="Media URL" source="media" />
             <FunctionField
               label="Approvals"
-              render={(record) => (
-                <span data-test="approval">{record.approvals?.length}</span>
-              )}
+              render={(record) => <span data-test="approval">{record.approvals?.length}</span>}
             />
             <FunctionField
               label="Denials"
-              render={(record) => (
-                <span data-test="denial">{record.denials?.length}</span>
-              )}
+              render={(record) => <span data-test="denial">{record.denials?.length}</span>}
             />
             <IdField label="Id" source="id" />
-            <Select collection={Collection.CORPORA} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/ExampleSuggestions/ExampleSuggestionList.tsx
+++ b/src/Core/Collections/ExampleSuggestions/ExampleSuggestionList.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  List,
-  Datagrid,
-  TextField,
-  FunctionField,
-  Responsive,
-  ListProps,
-} from 'react-admin';
+import { List, Datagrid, TextField, FunctionField, Responsive, ListProps } from 'react-admin';
 import {
   CompleteExamplePreview,
   BulkSuggestionActions,
@@ -35,17 +28,18 @@ const ExampleSuggestionList = (props: ListProps): React.ReactElement => {
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Responsive
-        small={(
+        small={
           <Datagrid>
+            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
             <CompleteExamplePreview label="Example Status" />
             <ReviewPreview label="You Reviewed" />
             <TextField label="Igbo" source="igbo" />
             <TextField label="English" source="english" />
-            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid>
+            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
             <CompleteExamplePreview label="Example Status" />
             <SourceField label="Source" source="source" />
             <ReviewPreview label="You Reviewed" />
@@ -54,20 +48,15 @@ const ExampleSuggestionList = (props: ListProps): React.ReactElement => {
             <ArrayPreview label="Associated Words" source="associatedWords" />
             <FunctionField
               label="Approvals"
-              render={(record) => (
-                <span data-test="approval">{record.approvals.length}</span>
-              )}
+              render={(record) => <span data-test="approval">{record.approvals.length}</span>}
             />
             <FunctionField
               label="Denials"
-              render={(record) => (
-                <span data-test="denial">{record.denials.length}</span>
-              )}
+              render={(record) => <span data-test="denial">{record.denials.length}</span>}
             />
             <IdField label="Id" source="id" />
-            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/Examples/ExampleList.tsx
+++ b/src/Core/Collections/Examples/ExampleList.tsx
@@ -1,11 +1,5 @@
 import React, { ReactElement } from 'react';
-import {
-  List,
-  Datagrid,
-  TextField,
-  Responsive,
-  ListProps,
-} from 'react-admin';
+import { List, Datagrid, TextField, Responsive, ListProps } from 'react-admin';
 import {
   CompleteExamplePreview,
   ArrayPreview,
@@ -21,33 +15,27 @@ import Empty from '../../Empty';
 const ExampleList = (props: ListProps): ReactElement => {
   const { permissions } = props;
   return (
-    <List
-      {...props}
-      actions={<ListActions />}
-      bulkActionButtons={false}
-      pagination={<Pagination />}
-      empty={<Empty />}
-    >
+    <List {...props} actions={<ListActions />} bulkActionButtons={false} pagination={<Pagination />} empty={<Empty />}>
       <Responsive
-        small={(
+        small={
           <Datagrid>
+            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
             <CompleteExamplePreview label="Example Status" />
             <TextField label="Igbo" source="igbo" />
             <TextField label="English" source="english" />
-            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid>
+            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
             <CompleteExamplePreview label="Example Status" />
             <StyleField label="Style" source="style" />
             <TextField label="Igbo" source="igbo" />
             <TextField label="English" source="english" />
             <ArrayPreview label="Associated Words" source="associatedWords" />
             <IdField label="Id" source="id" />
-            <Select collection={Collection.EXAMPLES} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/Notifications/NotificationList.tsx
+++ b/src/Core/Collections/Notifications/NotificationList.tsx
@@ -1,17 +1,6 @@
 import React from 'react';
-import {
-  List,
-  Datagrid,
-  TextField,
-  Responsive,
-  ListProps,
-  BooleanField,
-} from 'react-admin';
-import {
-  ListActions,
-  Pagination,
-  ShowNotificationButtonField,
-} from 'src/shared/components';
+import { List, Datagrid, TextField, Responsive, ListProps, BooleanField } from 'react-admin';
+import { ListActions, Pagination, ShowNotificationButtonField } from 'src/shared/components';
 import Empty from '../../Empty';
 
 const NotificationList = (props: ListProps): React.ReactElement => (
@@ -24,22 +13,22 @@ const NotificationList = (props: ListProps): React.ReactElement => (
     sort={{ field: 'approvals', order: 'DESC' }}
   >
     <Responsive
-      small={(
+      small={
         <Datagrid>
+          <ShowNotificationButtonField source="link" />
           <TextField label="Title" source="title" />
           <TextField label="Sender" source="initiator.displayName" />
-          <ShowNotificationButtonField source="link" />
         </Datagrid>
-      )}
-      medium={(
+      }
+      medium={
         <Datagrid>
+          <ShowNotificationButtonField source="link" />
           <TextField label="Title" source="title" />
           <TextField label="Message" source="message" defaultValue="N/A" />
           <BooleanField label="Opened" source="opened" defaultValue="Platform" />
           <TextField label="Sender" source="initiator.displayName" />
-          <ShowNotificationButtonField source="link" />
         </Datagrid>
-      )}
+      }
     />
   </List>
 );

--- a/src/Core/Collections/NsibidiCharacters/NsibidiCharacterList.tsx
+++ b/src/Core/Collections/NsibidiCharacters/NsibidiCharacterList.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
-import {
-  List,
-  Datagrid,
-  TextField,
-  Responsive,
-  ListProps,
-} from 'react-admin';
-import {
-  ArrayPreview,
-  BulkSuggestionActions,
-  Select,
-  ListActions,
-  Pagination,
-} from 'src/shared/components';
+import { List, Datagrid, TextField, Responsive, ListProps } from 'react-admin';
+import { ArrayPreview, BulkSuggestionActions, Select, ListActions, Pagination } from 'src/shared/components';
 import Collection from 'src/shared/constants/Collections';
 import { hasAdminOrMergerPermissions } from 'src/shared/utils/permissions';
 import Empty from '../../Empty';
@@ -30,23 +18,23 @@ const NsibidiCharacterList = (props: ListProps): React.ReactElement => {
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Responsive
-        small={(
+        small={
           <Datagrid>
+            <Select collection={Collection.NSIBIDI_CHARACTERS} label="Editor's Actions" permissions={permissions} />
             <TextField label="Nsịbịdị" source="nsibidi" className="akagu" />
             <ArrayPreview label="Definitions" source="definitions" />
             <TextField label="Word Class" source="wordClass" className="akagu" />
-            <Select collection={Collection.NSIBIDI_CHARACTERS} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid>
+            <Select collection={Collection.NSIBIDI_CHARACTERS} label="Editor's Actions" permissions={permissions} />
             <TextField label="Nsịbịdị" source="nsibidi" className="akagu" />
             <ArrayPreview label="Definitions" source="definitions" />
             <TextField label="Pronunciation" source="pronunciation" />
             <TextField label="Word Class" source="wordClass" className="akagu" />
-            <Select collection={Collection.NSIBIDI_CHARACTERS} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/Polls/PollList.tsx
+++ b/src/Core/Collections/Polls/PollList.tsx
@@ -1,16 +1,6 @@
 import React, { ReactElement } from 'react';
-import {
-  ListProps,
-  List,
-  Datagrid,
-  TextField,
-  usePermissions,
-} from 'react-admin';
-import {
-  Select,
-  Pagination,
-  ListActions,
-} from 'src/shared/components';
+import { ListProps, List, Datagrid, TextField, usePermissions } from 'react-admin';
+import { Select, Pagination, ListActions } from 'src/shared/components';
 import { hasAdminOrMergerPermissions } from 'src/shared/utils/permissions';
 import Collection from 'src/shared/constants/Collections';
 import Empty from '../../Empty';
@@ -29,9 +19,9 @@ const PollList = (props: ListProps): ReactElement => {
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Datagrid>
+        <Select collection={Collection.POLLS} label="Editor's Actions" permissions={permissions} />
         <TextField label="Igbo Word" source="igboWord" />
         <TextField label="Tweet body" source="text" />
-        <Select collection={Collection.POLLS} label="Editor's Actions" permissions={permissions} />
       </Datagrid>
     </List>
   );

--- a/src/Core/Collections/Users/UserList.tsx
+++ b/src/Core/Collections/Users/UserList.tsx
@@ -1,41 +1,25 @@
 import React, { ReactElement } from 'react';
-import {
-  List,
-  Datagrid,
-  DateField,
-  EmailField,
-  TextField,
-  Responsive,
-  ListProps,
-} from 'react-admin';
-import {
-  ListActions,
-  Pagination,
-  Select,
-} from 'src/shared/components';
+import { List, Datagrid, DateField, EmailField, TextField, Responsive, ListProps } from 'react-admin';
+import { ListActions, Pagination, Select } from 'src/shared/components';
 import Collection from 'src/shared/constants/Collections';
 
 const UserList = (props: ListProps): ReactElement => {
   const { permissions } = props;
   return (
-    <List
-      {...props}
-      actions={<ListActions />}
-      bulkActionButtons={false}
-      pagination={<Pagination />}
-    >
+    <List {...props} actions={<ListActions />} bulkActionButtons={false} pagination={<Pagination />}>
       <Responsive
-        small={(
+        small={
           <Datagrid>
+            <Select collection={Collection.USERS} label="Admin's Actions" permissions={permissions} />
             <TextField label="Name" source="displayName" defaultValue="No name" />
             <EmailField label="email" source="Email" />
             <TextField label="Role" source="role" />
             <TextField label="Editing Group" source="editingGroup" />
-            <Select collection={Collection.USERS} label="Admin's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid>
+            <Select collection="user" label="Admin's Actions" permissions={permissions} />
             <TextField label="Name" source="displayName" defaultValue="No name" />
             <EmailField label="Email" source="email" />
             <TextField label="Role" source="role" />
@@ -51,9 +35,8 @@ const UserList = (props: ListProps): ReactElement => {
                 day: 'numeric',
               }}
             />
-            <Select collection="user" label="Admin's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/WordSuggestions/WordSuggestionList.tsx
+++ b/src/Core/Collections/WordSuggestions/WordSuggestionList.tsx
@@ -1,11 +1,5 @@
 import React, { ReactElement } from 'react';
-import {
-  List,
-  Datagrid,
-  FunctionField,
-  Responsive,
-  ListProps,
-} from 'react-admin';
+import { List, Datagrid, FunctionField, Responsive, ListProps } from 'react-admin';
 import {
   ArrayPreview,
   BulkSuggestionActions,
@@ -36,16 +30,17 @@ const WordSuggestionList = (props: ListProps): ReactElement => {
       sort={{ field: 'approvals', order: 'DESC' }}
     >
       <Responsive
-        small={(
+        small={
           <Datagrid expand={<WordPanel />}>
+            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
             <CompleteWordPreview label="Word Status" />
             <ReviewPreview label="You Reviewed" />
             <HeadwordField label="Headword" source="word" />
-            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid expand={<WordPanel />}>
+            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
             <SourceField label="Source" source="source" />
             <CompleteWordPreview label="Word Status" />
             <ReviewPreview label="You Reviewed" />
@@ -55,21 +50,16 @@ const WordSuggestionList = (props: ListProps): ReactElement => {
             {/* TODO: move these out to reusable component */}
             <FunctionField
               label="Approvals"
-              render={(record) => (
-                <span data-test="approval">{record.approvals.length}</span>
-              )}
+              render={(record) => <span data-test="approval">{record.approvals.length}</span>}
             />
             <FunctionField
               label="Denials"
-              render={(record) => (
-                <span data-test="denial">{record.denials.length}</span>
-              )}
+              render={(record) => <span data-test="denial">{record.denials.length}</span>}
             />
             <IdField label="Id" source="id" />
             <IdField label="Parent Word Id" source="originalWordId" />
-            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );

--- a/src/Core/Collections/Words/WordList.tsx
+++ b/src/Core/Collections/Words/WordList.tsx
@@ -1,10 +1,5 @@
 import React, { ReactElement } from 'react';
-import {
-  List,
-  Datagrid,
-  Responsive,
-  ListProps,
-} from 'react-admin';
+import { List, Datagrid, Responsive, ListProps } from 'react-admin';
 import {
   ArrayPreview,
   CompleteWordPreview,
@@ -21,32 +16,26 @@ import Empty from '../../Empty';
 export const WordList = (props: ListProps): ReactElement => {
   const { permissions } = props;
   return (
-    <List
-      {...props}
-      actions={<ListActions />}
-      bulkActionButtons={false}
-      pagination={<Pagination />}
-      empty={<Empty />}
-    >
+    <List {...props} actions={<ListActions />} bulkActionButtons={false} pagination={<Pagination />} empty={<Empty />}>
       <Responsive
-        small={(
+        small={
           <Datagrid expand={<WordPanel />}>
+            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
             <CompleteWordPreview label="Word Status" />
             <HeadwordField label="Headword" source="word" />
-            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
-        medium={(
+        }
+        medium={
           <Datagrid expand={<WordPanel />}>
+            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
             <CompleteWordPreview label="Word Status" />
             <HeadwordField label="Headword" source="word" />
             <ArrayPreview label="Definitions" source="definitions" />
             <ArrayPreview label="Variations" source="variations" />
             <ArrayPreview label="Stems" source="stems" />
             <IdField label="Id" source="id" />
-            <Select collection={Collection.WORDS} label="Editor's Actions" permissions={permissions} />
           </Datagrid>
-        )}
+        }
       />
     </List>
   );


### PR DESCRIPTION
## Background
Moves the Editor's Actions and Admin's Action dropdown to the left side to make it easier for editors to access those actions without having to horizontally scroll to the right.

## Screenshot
<img width="1644" alt="Xnapper-2023-07-04-00 15 13" src="https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/e4e86b2a-e072-4701-87d6-4daf76c6a491">
