### PR TITLE
build: update actions/checkout version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 40
     steps:
     - name: Checkout Igbo API Admin Code 🛎
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Use Node.js 16.17.0
       uses: actions/setup-node@v2.1.2
       with:


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready | Refactor | No | N/A |

## Problem

The version 2 of Github actions checkout uses node 12 which is no longer a supported version of NodeJs and is also deprecated for Github Action.


## Solution

The PR upgrades the actions checkout from version 2 to version 3.
