### PR TITLE
Io/remember nsibidi characters in word edit

### DIFF
--- a/__mocks__/firebase/auth.ts
+++ b/__mocks__/firebase/auth.ts
@@ -8,6 +8,7 @@ export const getAuth = jest.fn(() => ({
 
 export const connectAuthEmulator = jest.fn();
 export const GoogleAuthProvider = jest.fn().mockImplementation();
+export const FacebookAuthProvider = jest.fn().mockImplementation();
 export const EmailAuthProvider = jest.fn().mockImplementation();
 export const signInWithPhoneNumber = jest.fn(async () => {
   return {

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -83,7 +83,7 @@ export interface WordDialect {
 export interface DefinitionSchema {
   wordClass: WordClassEnum | WordDialect;
   definitions: string[];
-  label: string;
+  label?: string;
   igboDefinitions: { igbo: string; nsibidi: string }[];
   nsibidi: string;
   nsibidiCharacters: (Types.ObjectId | string)[];

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditForm.tsx
@@ -14,6 +14,7 @@ import { Textarea, Input } from 'src/shared/primitives';
 import { handleUpdateDocument } from 'src/shared/constants/actionsMap';
 import ActionTypes from 'src/shared/constants/ActionTypes';
 import useFirebaseUid from 'src/hooks/useFirebaseUid';
+import createDefaultExampleFormValues from 'src/shared/components/views/components/WordEditForm/utils/createDefaultExampleFormValues';
 import ExampleEditFormResolver from './ExampleEditFormResolver';
 import { onCancel, sanitizeArray, sanitizeWith } from '../utils';
 import FormHeader from '../FormHeader';
@@ -34,12 +35,7 @@ const ExampleEditForm = ({
     ['value', 'label'],
   ) || { value: '', label: '' };
   const { handleSubmit, getValues, control, errors } = useForm({
-    defaultValues: {
-      ...omit(record, 'pronunciation'),
-      style,
-      nsibidiCharacters: (record?.nsibidiCharacters || []).map((nsibidiCharacterId) => ({ id: nsibidiCharacterId })),
-      associatedWords: (record?.associatedWords || []).map((associatedWordId) => ({ id: associatedWordId })),
-    },
+    defaultValues: createDefaultExampleFormValues(record),
     ...ExampleEditFormResolver,
     mode: 'onChange',
   });

--- a/src/shared/components/views/components/ExampleEditForm/__tests__/ExampleEditForm.test.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/__tests__/ExampleEditForm.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { last } from 'lodash';
 import TestContext from 'src/__tests__/components/TestContext';
-
 import Collections from 'src/shared/constants/Collections';
 import Views from 'src/shared/constants/Views';
 import ExampleEditForm from '../ExampleEditForm';
@@ -26,7 +26,23 @@ describe('Example Edit', () => {
     await findByText('English');
     await findByText('Nsịbịdị');
     await findByText('Associated Words');
-    await findByText('Editor\'s Comments');
+    await findByText("Editor's Comments");
+  });
+
+  it('add an associated word to word suggestion', async () => {
+    const { findByText, findAllByText, findByPlaceholderText } = render(
+      <TestContext view={Views.EDIT} resource={Collections.WORD_SUGGESTIONS} save={() => {}}>
+        <ExampleEditForm />
+      </TestContext>,
+    );
+
+    userEvent.type(await findByPlaceholderText('Search for associated word or use word id'), 'cat');
+    await findAllByText('retrieved word');
+    await findAllByText('NNC');
+    await findAllByText('first definition');
+    userEvent.click(last(await findAllByText('retrieved word')));
+    await findByText('ADJ');
+    await findByText('resolved word definition');
   });
 
   it.skip('submit example suggestions', async () => {

--- a/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/__tests__/WordEditForm.test.tsx
@@ -105,6 +105,22 @@ describe('Word Edit Form', () => {
     await findByText('resolved word definition');
   });
 
+  it('add a word nsibidi to word suggestion', async () => {
+    const { findByText, findAllByText, findByPlaceholderText } = render(
+      <TestContext view={Views.EDIT} resource={Collections.WORD_SUGGESTIONS} save={() => {}}>
+        <WordEditForm record={{ definitions: [{ nsibidi: '', nsibidiCharacters: [] }] }} />
+      </TestContext>,
+    );
+
+    userEvent.type(await findByPlaceholderText('Search for a related term or use word id'), 'cat');
+    await findAllByText('retrieved word');
+    await findAllByText('NNC');
+    await findAllByText('first definition');
+    userEvent.click(last(await findAllByText('retrieved word')));
+    await findByText('ADJ');
+    await findByText('resolved word definition');
+  });
+
   it("doesn't show tenses with a non-verb", async () => {
     const { queryByText, findByText, findByTestId } = render(
       <TestContext view={Views.EDIT} resource={Collections.WORD_SUGGESTIONS} save={() => {}}>

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
@@ -7,18 +7,18 @@ import FormHeader from '../../../FormHeader';
 import DefinitionsFormInterface from './DefinitionsFormInterface';
 import DefinitionForm from './DefinitionForm';
 
-const DefinitionsForm = ({
-  errors,
-  control,
-  record,
-}: DefinitionsFormInterface): ReactElement => {
-  const { fields: definitions, append, remove } = useFieldArray({
+const DefinitionsForm = ({ errors, control, record }: DefinitionsFormInterface): ReactElement => {
+  const {
+    fields: definitions,
+    append,
+    remove,
+  } = useFieldArray({
     control,
     name: 'definitions',
   });
   const handleAddDefinitionGroup = () => {
     append({
-      wordClass: '',
+      wordClass: null,
       definitions: [],
       igboDefinitions: [],
       nsibidi: '',
@@ -51,12 +51,7 @@ const DefinitionsForm = ({
       </Box>
       <Box className="w-full grid grid-flow-row grid-cols-1 gap-4 px-3">
         {definitions.map(({ id }, index) => (
-          <Box
-            borderBottomWidth="1px"
-            borderBottomColor="gray.300"
-            mb={4}
-            key={`definitions-${id}`}
-          >
+          <Box borderBottomWidth="1px" borderBottomColor="gray.300" mb={4} key={`definitions-${id}`}>
             {definitions.length > 1 ? (
               <Tooltip label="Delete Definition Group">
                 <Button
@@ -76,15 +71,8 @@ const DefinitionsForm = ({
                 </Button>
               </Tooltip>
             ) : null}
-            <DefinitionForm
-              errors={errors}
-              control={control}
-              groupIndex={index}
-              record={record}
-            />
-            {(errors.definitions || [])[index] ? (
-              <p className="error relative">Definition is required</p>
-            ) : null}
+            <DefinitionForm errors={errors} control={control} groupIndex={index} record={record} />
+            {(errors.definitions || [])[index] ? <p className="error relative">Definition is required</p> : null}
           </Box>
         ))}
       </Box>

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/__tests__/DefinitionsForm.test.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/__tests__/DefinitionsForm.test.tsx
@@ -51,6 +51,7 @@ describe('DefinitionsForm', () => {
     // First definition group
     await findByText('Active verb');
     await findByText('first nsibidi');
+    await findByText('first definition');
     await findByText(extendWordRecord.definitions[0].definitions[0]);
 
     // Second definition group

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiCharacters.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiCharacters.tsx
@@ -6,30 +6,26 @@ import { WordPills } from 'src/shared/primitives';
 import { resolveNsibidiCharacter } from 'src/shared/API';
 import { NsibidiCharacter } from 'src/backend/controllers/utils/interfaces';
 
-const NsibidiCharacters = (
-  {
-    nsibidiCharacterIds,
-    remove,
-    control,
-    nsibidiFormName,
-  }
-  : {
-    nsibidiCharacterIds: { id: string }[],
-    remove: (index: number) => void,
-    control: Control,
-    nsibidiFormName: string,
-  },
-): ReactElement => {
+const NsibidiCharacters = ({
+  nsibidiCharacterIds,
+  remove,
+  control,
+  nsibidiFormName,
+}: {
+  nsibidiCharacterIds: { text: string }[];
+  remove: (index: number) => void;
+  control: Control;
+  nsibidiFormName: string;
+}): ReactElement => {
   const [resolvedNsibidiCharacters, setResolvedNsibidiCharacters] = useState<NsibidiCharacter[]>([]);
   const [isLoadingNsibidiCharacters, setIsLoadingNsibidiCharacters] = useState(false);
 
   const resolveCharacters = async () => {
-    const shouldResolve = (
-      resolvedNsibidiCharacters?.length !== nsibidiCharacterIds.length
-      || !nsibidiCharacterIds.every(({ id }) => (
-        resolvedNsibidiCharacters.find(({ id: resolvedId }) => resolvedId === id)
-      ))
-    );
+    const shouldResolve =
+      resolvedNsibidiCharacters?.length !== nsibidiCharacterIds.length ||
+      !nsibidiCharacterIds.every(({ text }) =>
+        resolvedNsibidiCharacters.find(({ id: resolvedId }) => resolvedId === text),
+      );
     if (!shouldResolve) {
       return;
     }
@@ -41,10 +37,12 @@ const NsibidiCharacters = (
        * by its MongoDB Id or regular Nsibidi character search the compact array will omit null values.
        */
       const compactedResolvedNsibidiCharacters = compact(
-        await Promise.all(nsibidiCharacterIds.map(async ({ id: nsibidiCharacterId }) => {
-          const nsibidiCharacter = await resolveNsibidiCharacter(nsibidiCharacterId).catch(() => null);
-          return nsibidiCharacter;
-        })),
+        await Promise.all(
+          nsibidiCharacterIds.map(async ({ text: nsibidiCharacterId }) => {
+            const nsibidiCharacter = await resolveNsibidiCharacter(nsibidiCharacterId).catch(() => null);
+            return nsibidiCharacter;
+          }),
+        ),
       ) as NsibidiCharacter[];
       setResolvedNsibidiCharacters(compactedResolvedNsibidiCharacters);
     } finally {
@@ -60,12 +58,7 @@ const NsibidiCharacters = (
     <Spinner />
   ) : resolvedNsibidiCharacters?.length ? (
     <Box display="flex" flexDirection="column" className="space-y-3 py-4">
-      <WordPills
-        pills={resolvedNsibidiCharacters}
-        onDelete={remove}
-        control={control}
-        formName={nsibidiFormName}
-      />
+      <WordPills pills={resolvedNsibidiCharacters} onDelete={remove} control={control} formName={nsibidiFormName} />
     </Box>
   ) : (
     <Box className="flex w-full justify-center">

--- a/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiInput.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/NsibidiForm/NsibidiInput.tsx
@@ -44,8 +44,8 @@ const NsibidiInput = React.forwardRef(
 
     const updateNsibidiCharacters = (nsibidiCharacterId) => {
       // Avoids appending an Nsibidi character that's already in the array
-      if (!nsibidiCharacterIds.find(({ id }) => id === nsibidiCharacterId)) {
-        append({ id: nsibidiCharacterId });
+      if (!nsibidiCharacterIds.find(({ text }) => text === nsibidiCharacterId)) {
+        append({ text: nsibidiCharacterId });
       }
     };
 

--- a/src/shared/components/views/components/WordEditForm/components/PartOfSpeechForm/PartOfSpeechForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/PartOfSpeechForm/PartOfSpeechForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { values } from 'lodash';
+import { get, values } from 'lodash';
 import { Box } from '@chakra-ui/react';
 import { Controller } from 'react-hook-form';
 import Select from 'react-select';
@@ -23,7 +23,7 @@ const PartOfSpeechForm = ({ errors, control, groupIndex }: PartOfSpeechFormInter
         <Controller
           render={(props) => <Select {...props} options={options} />}
           name={`definitions[${groupIndex}].wordClass`}
-          defaultValue={getValues(`definitions[${groupIndex}].wordClass`) || null}
+          defaultValue={get(getValues(), `definitions[${groupIndex}].wordClass`)}
           control={control}
         />
       </Box>

--- a/src/shared/components/views/components/WordEditForm/components/PartOfSpeechForm/PartOfSpeechForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/PartOfSpeechForm/PartOfSpeechForm.tsx
@@ -23,7 +23,7 @@ const PartOfSpeechForm = ({ errors, control, groupIndex }: PartOfSpeechFormInter
         <Controller
           render={(props) => <Select {...props} options={options} />}
           name={`definitions[${groupIndex}].wordClass`}
-          defaultValue={getValues(`definitions[${groupIndex}].wordClass`)}
+          defaultValue={getValues(`definitions[${groupIndex}].wordClass`) || null}
           control={control}
         />
       </Box>

--- a/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/RelatedTermsForm/RelatedTermsForm.tsx
@@ -87,7 +87,7 @@ const RelatedTermsForm = ({ errors, control, record }: RelatedTermsFormInterface
     try {
       if (canAddRelatedTerm(userInput)) {
         const word = await getWord(userInput);
-        append({ id: word.id });
+        append({ text: word.id });
       } else {
         throw new Error('Invalid word id');
       }

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
@@ -87,7 +87,7 @@ const StemsForm = ({ errors, control, record }: StemsFormInterface): ReactElemen
     try {
       if (canAddStem(userInput)) {
         const word = await getWord(userInput);
-        append({ id: word.id });
+        append({ text: word.id });
       } else {
         throw new Error('Invalid word id');
       }

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
@@ -7,20 +7,22 @@ import { getWord, resolveWord } from 'src/shared/API';
 import FormHeader from '../../../FormHeader';
 import StemsFormInterface from './StemsFormInterface';
 
-const Stems = (
-  { stemIds, remove, control }
-  : { stemIds: { id: string }[], remove: (index: number) => void, control: Control },
-) => {
+const Stems = ({
+  stemIds,
+  remove,
+  control,
+}: {
+  stemIds: { text: string }[];
+  remove: (index: number) => void;
+  control: Control;
+}) => {
   const [resolvedStems, setResolvedStems] = useState(null);
   const [isLoadingStems, setIsLoadingStems] = useState(false);
 
   const resolveStems = async () => {
-    const shouldResolve = (
-      resolvedStems?.length !== stemIds.length
-      || !stemIds.every(({ id }) => (
-        resolvedStems.find(({ id: resolvedId }) => resolvedId === id)
-      ))
-    );
+    const shouldResolve =
+      resolvedStems?.length !== stemIds.length ||
+      !stemIds.every(({ text }) => resolvedStems.find(({ id: resolvedId }) => resolvedId === text));
     if (!shouldResolve) {
       return;
     }
@@ -31,10 +33,14 @@ const Stems = (
        * by its MongoDB Id or regular word search, the compact array will be used
        * to save the Word Suggestion, omitting the unwanted word.
        */
-      const compactedResolvedStems = compact(await Promise.all(stemIds.map(async ({ id: stemId }) => {
-        const word = await resolveWord(stemId).catch(() => null);
-        return word;
-      })));
+      const compactedResolvedStems = compact(
+        await Promise.all(
+          stemIds.map(async ({ text: stemId }) => {
+            const word = await resolveWord(stemId).catch(() => null);
+            return word;
+          }),
+        ),
+      );
       setResolvedStems(compactedResolvedStems);
     } finally {
       setIsLoadingStems(false);
@@ -53,12 +59,7 @@ const Stems = (
     <Spinner />
   ) : resolvedStems && resolvedStems.length ? (
     <Box display="flex" flexDirection="column" className="space-y-3 py-4">
-      <WordPills
-        pills={resolvedStems}
-        onDelete={handleDeleteStems}
-        control={control}
-        formName="stems"
-      />
+      <WordPills pills={resolvedStems} onDelete={handleDeleteStems} control={control} formName="stems" />
     </Box>
   ) : (
     <Box className="flex w-full justify-center">
@@ -67,23 +68,20 @@ const Stems = (
   );
 };
 
-const StemsForm = ({
-  errors,
-  control,
-  record,
-} : StemsFormInterface): ReactElement => {
-  const { fields: stems, append, remove } = useFieldArray({
+const StemsForm = ({ errors, control, record }: StemsFormInterface): ReactElement => {
+  const {
+    fields: stems,
+    append,
+    remove,
+  } = useFieldArray({
     control,
     name: 'stems',
   });
   const [input, setInput] = useState('');
   const toast = useToast();
 
-  const canAddStem = (userInput) => (
-    !stems.includes(userInput)
-    && userInput !== record.id
-    && userInput !== record.originalWordId
-  );
+  const canAddStem = (userInput) =>
+    !stems.includes(userInput) && userInput !== record.id && userInput !== record.originalWordId;
 
   const handleAddStem = async (userInput = input) => {
     try {
@@ -96,7 +94,7 @@ const StemsForm = ({
     } catch (err) {
       toast({
         title: 'Unable to add stem',
-        description: 'You have provided either an invalid word id or a the current word\'s or parent word\'s id.',
+        description: "You have provided either an invalid word id or a the current word's or parent word's id.",
         status: 'warning',
         duration: 4000,
         isClosable: true,
@@ -125,14 +123,8 @@ const StemsForm = ({
           onSelect={(e) => handleAddStem(e.id)}
         />
       </Box>
-      <Stems
-        stemIds={stems}
-        remove={remove}
-        control={control}
-      />
-      {errors.stems && (
-        <p className="error">{errors.stems.message || errors.stems[0]?.message}</p>
-      )}
+      <Stems stemIds={stems} remove={remove} control={control} />
+      {errors.stems && <p className="error">{errors.stems.message || errors.stems[0]?.message}</p>}
     </Box>
   );
 };

--- a/src/shared/components/views/components/WordEditForm/utils/createDefaultExampleFormValues.ts
+++ b/src/shared/components/views/components/WordEditForm/utils/createDefaultExampleFormValues.ts
@@ -1,0 +1,16 @@
+import { Record } from 'react-admin';
+import { omit, pick } from 'lodash';
+import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
+
+const createDefaultExampleFormValues = (record: Record): any => ({
+  ...omit(record, 'pronunciation'),
+  pronunciations: (record?.pronunciations || []).map((pronunciation) => omit(pronunciation, ['id'])),
+  style: pick(
+    Object.values(ExampleStyle).find(({ value }) => value === record.style),
+    ['value', 'label'],
+  ) || { value: '', label: '' },
+  nsibidiCharacters: (record?.nsibidiCharacters || []).map((nsibidiCharacterId) => ({ text: nsibidiCharacterId })),
+  associatedWords: (record?.associatedWords || []).map((associatedWordId) => ({ text: associatedWordId })),
+});
+
+export default createDefaultExampleFormValues;

--- a/src/shared/components/views/components/WordEditForm/utils/createDefaultWordFormValues.ts
+++ b/src/shared/components/views/components/WordEditForm/utils/createDefaultWordFormValues.ts
@@ -1,14 +1,23 @@
 import { Record } from 'react-admin';
+import { omit } from 'lodash';
 import WordClass from 'src/backend/shared/constants/WordClass';
 import WordAttributeEnum from 'src/backend/shared/constants/WordAttributeEnum';
 
 const createDefaultWordFormValues = (record: Record): any => {
   const defaultValues = {
-    definitions: (record?.definitions || []).map((definition) => ({
-      ...definition,
-      definitions: (definition?.definitions || []).map((text) => ({ text })),
-      wordClass: WordClass[definition?.wordClass] || null,
-    })),
+    definitions: (record?.definitions || []).map((definition) =>
+      omit(
+        {
+          ...definition,
+          definitions: (definition?.definitions || []).map((text) => ({ text })),
+          wordClass: WordClass[definition?.wordClass] || null,
+          nsibidiCharacters: (definition?.nsibidiCharacters || []).map((nsibidiCharacterId) => ({
+            text: nsibidiCharacterId,
+          })),
+        },
+        ['id'],
+      ),
+    ),
     dialects: record?.dialects || [],
     examples: record?.examples
       ? record.examples.map(({ id, ...example }) => ({
@@ -20,8 +29,8 @@ const createDefaultWordFormValues = (record: Record): any => {
         }))
       : [],
     variations: (record?.variations || []).map((variation) => ({ text: variation })),
-    relatedTerms: (record?.relatedTerms || []).map((relatedTerm) => ({ id: relatedTerm })),
-    stems: (record?.stems || []).map((stem) => ({ id: stem })),
+    relatedTerms: (record?.relatedTerms || []).map((relatedTerm) => ({ text: relatedTerm })),
+    stems: (record?.stems || []).map((stem) => ({ text: stem })),
     tenses: record?.tenses || {},
     pronunciation: record?.pronunciation || '',
     attributes:


### PR DESCRIPTION
## Background
When a translator saves their work of adding Nsịbịdị characters, leave the page, and come back to the edit page, their Nsịbịdị characters seemed to be wiped out. This PR fixes this visual bug while also addressing react-hook-form errors.