### PR TITLE
Avoid duplicating the first audio record for example suggestion pronunciations

### DIFF
--- a/src/Login/components/FacebookLogin.tsx
+++ b/src/Login/components/FacebookLogin.tsx
@@ -7,7 +7,6 @@ import {
   signInWithPopup,
   fetchSignInMethodsForEmail,
   linkWithPopup,
-  linkWithCredential,
 } from 'firebase/auth';
 import getAWSAsset from 'src/utils/getAWSAsset';
 import UserLoginState from 'src/backend/shared/constants/UserLoginState';
@@ -44,7 +43,6 @@ const FacebookLogin = ({
           if (error.code === 'auth/account-exists-with-different-credential') {
             const {
               customData: { email: existingEmail },
-              // credential: existingCredential,
             } = error;
             const providers = await fetchSignInMethodsForEmail(auth, existingEmail);
             // Links Facebook account to Google account if a Google account already exists
@@ -60,7 +58,6 @@ const FacebookLogin = ({
                 isNewUser: false,
               });
               linkWithPopup(result.user, facebookProvider);
-              // linkWithCredential(result.user, existingCredential);
             }
             return null;
           }

--- a/src/__tests__/components/TestContext.tsx
+++ b/src/__tests__/components/TestContext.tsx
@@ -12,6 +12,7 @@ import Collections from 'src/shared/constants/Collections';
 import Views from 'src/shared/constants/Views';
 import { ExampleSuggestion } from 'src/backend/controllers/utils/interfaces';
 import { SentenceVerification } from 'src/Core/Collections/IgboSoundbox/types/SentenceVerification';
+import createDefaultExampleFormValues from 'src/shared/components/views/components/WordEditForm/utils/createDefaultExampleFormValues';
 
 configure({ testIdAttribute: 'data-test' });
 
@@ -64,6 +65,7 @@ const TestContext = ({
   record,
   index,
   basePath = '/',
+  resource,
   ...rest
 }: {
   view?: Views;
@@ -88,10 +90,14 @@ const TestContext = ({
   const history = jest.fn(() => ({
     listen: jest.fn(),
   }));
-  const staticWordRecord = cloneDeep(record || wordRecord);
+  const staticRecord = cloneDeep(record || wordRecord);
   const { control, watch } = useForm({
-    // @ts-expect-error
-    defaultValues: createDefaultWordFormValues(staticWordRecord),
+    defaultValues:
+      resource === Collections.EXAMPLE_SUGGESTIONS
+        ? // @ts-expect-error
+          createDefaultExampleFormValues(staticRecord)
+        : // @ts-expect-error
+          createDefaultWordFormValues(staticRecord),
     mode: 'onChange',
   });
 
@@ -104,13 +110,13 @@ const TestContext = ({
           React.cloneElement(child, {
             control,
             errors: {},
-            record: staticWordRecord,
-            originalWordRecord: staticWordRecord,
+            record: staticRecord,
+            originalWordRecord: staticRecord,
             getValues: jest.fn(),
             setValue: jest.fn(),
             setDialects: jest.fn(),
             // TODO: useFieldArray for dialects
-            dialects: staticWordRecord.dialects,
+            dialects: staticRecord.dialects,
             options: Object.entries(WordClass),
             history,
             watch,
@@ -118,6 +124,7 @@ const TestContext = ({
             index,
             setIsDirty,
             basePath,
+            resource,
             ...rest,
             ...child.props,
           }),

--- a/src/backend/models/Example.ts
+++ b/src/backend/models/Example.ts
@@ -9,6 +9,7 @@ const audioPronunciationSchema = new Schema(
   {
     audio: { type: String, default: '' },
     speaker: { type: String, default: '' },
+    archived: { type: Boolean, default: false },
   },
   { toObject: toObjectPlugin, timestamps: true },
 );

--- a/src/backend/models/ExampleSuggestion.ts
+++ b/src/backend/models/ExampleSuggestion.ts
@@ -13,6 +13,7 @@ const audioPronunciationSuggestionSchema = new Schema(
   {
     audio: { type: String, default: '' },
     speaker: { type: String, default: '' },
+    archived: { type: Boolean, default: false },
     review: { type: Boolean, default: true },
     approvals: { type: [{ type: String }], default: [] },
     denials: { type: [{ type: String }], default: [] },

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -31,6 +31,8 @@ const useRecorder = (): [string, boolean, () => void, () => void, number] => {
         const stream = await window.navigator.mediaDevices.getUserMedia({ audio: true }).catch(() => {
           toast({
             title: 'Microphone access denied',
+            position: 'top-right',
+            variant: 'left-accent',
             description: 'You must grant microphone permission to record',
             status: 'error',
             duration: 30000,
@@ -61,6 +63,8 @@ const useRecorder = (): [string, boolean, () => void, () => void, number] => {
     } else if (isBlocked) {
       toast({
         title: 'Microphone access denied',
+        position: 'top-right',
+        variant: 'left-accent',
         description: 'You must grant microphone permission to record',
         status: 'error',
         duration: 30000,
@@ -85,6 +89,8 @@ const useRecorder = (): [string, boolean, () => void, () => void, number] => {
             if (typeof e.target.result !== 'string' || !e.target.result.includes('data:audio/mp3')) {
               return toast({
                 title: 'Unable to record',
+                position: 'top-right',
+                variant: 'left-accent',
                 description: 'Invalid file type. Must be .mp3',
                 status: 'warning',
                 duration: 9000,
@@ -94,6 +100,8 @@ const useRecorder = (): [string, boolean, () => void, () => void, number] => {
             if (e.target.result?.length > MAX_AUDIO_SIZE) {
               return toast({
                 title: 'Unable to record',
+                position: 'top-right',
+                variant: 'left-accent',
                 description: 'Audio is too large - 500Kb maximum. Shorten your recording.',
                 status: 'warning',
                 duration: 9000,
@@ -110,6 +118,8 @@ const useRecorder = (): [string, boolean, () => void, () => void, number] => {
     } else if (!isBlocked) {
       toast({
         title: 'Microphone access denied',
+        position: 'top-right',
+        variant: 'left-accent',
         description: 'Unable to stop recording. You must grant microphone permission to record',
         status: 'error',
         duration: 30000,

--- a/src/shared/components/views/components/AudioRecorder/RecorderBase.tsx
+++ b/src/shared/components/views/components/AudioRecorder/RecorderBase.tsx
@@ -35,16 +35,10 @@ const RecorderBase = ({
   const shouldRenderNewPronunciationLabel = () => pronunciationValue && pronunciationValue.startsWith('data');
 
   const renderStatusLabel = () => (
-    <Box className="text-center flex flex-row justify-center">
+    <Box className="text-center flex flex-row justify-center" data-test={`${path}-audio-playback-container`}>
       {pronunciationValue && !isRecording ? (
-        <Box className="flex flex-col">
-          <ReactAudioPlayer
-            data-test={`${path}-audio-playback`}
-            style={{ height: '40px', width: '250px' }}
-            id="audio"
-            src={pronunciationValue}
-            controls
-          />
+        <Box className="flex flex-col" data-test={`${path}-audio-playback`}>
+          <ReactAudioPlayer style={{ height: '40px', width: '250px' }} id="audio" src={pronunciationValue} controls />
           {shouldRenderNewPronunciationLabel() && (
             <chakra.span className="text-green-500 mt-2" fontFamily="Silka">
               New pronunciation recorded

--- a/src/shared/components/views/components/ExampleEditForm/components/AddAudioPronunciationButton.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/components/AddAudioPronunciationButton.tsx
@@ -2,20 +2,13 @@ import React, { ReactElement } from 'react';
 import { Box, Button } from '@chakra-ui/react';
 import { AddIcon } from '@chakra-ui/icons';
 
-const AddAudioPronunciationButton = (
-  { append }:
-  {
-    append: (value: Partial<Record<string, any>> | Partial<Record<string, any>>[], shouldFocus?: boolean) => void
-  },
-): ReactElement => (
+const AddAudioPronunciationButton = ({
+  onClick,
+}: {
+  onClick: (value: Partial<Record<string, any>> | Partial<Record<string, any>>[], shouldFocus?: boolean) => void;
+}): ReactElement => (
   <Box className="w-full flex flex-row justify-end" my={6}>
-    <Button
-      width="full"
-      colorScheme="green"
-      aria-label="Add Example"
-      onClick={append}
-      leftIcon={<AddIcon />}
-    >
+    <Button width="full" colorScheme="green" aria-label="Add Example" onClick={onClick} leftIcon={<AddIcon />}>
       Add Audio Pronunciation
     </Button>
   </Box>

--- a/src/shared/components/views/components/ExampleEditForm/components/ExampleAudioPronunciationsForm.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/components/ExampleAudioPronunciationsForm.tsx
@@ -24,6 +24,16 @@ const ExampleAudioPronunciationsForm = ({
   });
   const { getValues, setValue } = control;
 
+  const handleAppend = () =>
+    append({
+      audio: '',
+      speaker: uid,
+      approvals: [],
+      denials: [],
+      archived: false,
+      review: true,
+    });
+
   return (
     <>
       <FormHeader
@@ -47,11 +57,11 @@ const ExampleAudioPronunciationsForm = ({
               defaultValue={pronunciation.speaker}
             />
             <AudioRecorder
-              path="pronunciations.0.audio"
-              getFormValues={() => get(getValues(), 'pronunciations.0.audio')}
+              path={`pronunciations.${index}.audio`}
+              getFormValues={() => get(getValues(), `pronunciations.${index}.audio`)}
               setPronunciation={(_, value) => {
-                setValue('pronunciations.0.audio', value);
-                setValue('pronunciations.0.speaker', uid);
+                setValue(`pronunciations[${index}].audio`, value);
+                setValue(`pronunciations[${index}].speaker`, uid);
               }}
               record={record}
               originalRecord={originalRecord}
@@ -67,7 +77,7 @@ const ExampleAudioPronunciationsForm = ({
           </Text>
         </Box>
       )}
-      <AddAudioPronunciationButton append={append} />
+      <AddAudioPronunciationButton onClick={handleAppend} />
     </>
   );
 };

--- a/src/shared/components/views/components/ExampleEditForm/components/__tests__/ExampleAudioPronunciationsForm.test.tsx
+++ b/src/shared/components/views/components/ExampleEditForm/components/__tests__/ExampleAudioPronunciationsForm.test.tsx
@@ -1,16 +1,35 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import TestContext from 'src/__tests__/components/TestContext';
+import Collections from 'src/shared/constants/Collections';
 import ExampleAudioPronunciationsForm from '../ExampleAudioPronunciationsForm';
 
 describe('ExampleAudioPronunciationsForm', () => {
   it('render ExampleAudioPronunciationsForm', async () => {
     const { findByText } = render(
-      <TestContext groupIndex={0}>
+      <TestContext>
         <ExampleAudioPronunciationsForm />
       </TestContext>,
     );
     await findByText('Igbo Sentence Recordings');
     await findByText('Add Audio Pronunciation');
+  });
+
+  it('adds a new audio recording', async () => {
+    const { findByText, findByTestId, queryByTestId } = render(
+      <TestContext
+        record={{ pronunciations: [{ audio: 'first-audio', speaker: 'first-speaker' }] }}
+        resource={Collections.EXAMPLE_SUGGESTIONS}
+      >
+        <ExampleAudioPronunciationsForm />
+      </TestContext>,
+    );
+    await findByTestId('pronunciations.0.audio-audio-playback-container');
+    await findByText('Igbo Sentence Recordings');
+    userEvent.click(await findByText('Add Audio Pronunciation'));
+    await findByTestId('pronunciations.1.audio-audio-playback-container');
+    expect(queryByTestId('pronunciations.1.audio-audio-playback')).toBeNull();
+    await findByText('No audio pronunciation');
   });
 });


### PR DESCRIPTION
## Background
This PR addresses the following bugs:
* When a translator clicks on the Add Pronunciation button for an example suggestion, the first audio clip would be used as a duplicate audio track
* If a translator attempted to re-record audio, the audio wouldn't update