### PR TITLE
style: remove border on the appbar

### DIFF
--- a/src/Core/Layout/components/AppBar/AppBar.tsx
+++ b/src/Core/Layout/components/AppBar/AppBar.tsx
@@ -14,6 +14,9 @@ const AppBar = ({ notifications, ...props }: { notifications: Interfaces.Notific
         whiteSpace: 'nowrap',
         overflow: 'hidden',
       },
+      '& .RaUserMenu-userButton': {
+        border: 'none',
+      },
     }}
     {...props}
     userMenu={<UserMenu />}


### PR DESCRIPTION
## Problem

Remove the border outline on the button on the appbar. Issue #442


## Solution

I used the in build class name of 'react-admin' to specify the border removal 

## Before & After Screenshots


**BEFORE**:
![before border removal](https://github.com/nkowaokwu/igbo-api-admin/assets/94802946/00d2ee48-9dbd-4120-9683-64822b01aa1a)

**AFTER**:
![border removed from appbar](https://github.com/nkowaokwu/igbo-api-admin/assets/94802946/53ac8c02-a467-4ec6-9fcd-0f13df2ea1ae)

  
## QA
n/a
<!-- How did you test your solution? -->
  
<!-- - [ ] Wrote or updated Jest or Cypress test(s)? -->
<!-- - [ ] Manually QA'd the solution -->
<!-- - [ ] etc. -->
