### PR TITLE
Delete year+ old word suggestions and create new word suggestions for Igbo definitions, five at a time

### DIFF
--- a/src/App/__tests__/App.test.tsx
+++ b/src/App/__tests__/App.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as reactAdmin from 'react-admin';
+import UserRoles from 'src/backend/shared/constants/UserRoles';
 import App from '../App';
 
 jest.mock('firebase/firestore');
@@ -51,7 +52,7 @@ describe('App', () => {
     expect(await queryByText('Loading the page, please wait a moment')).toBeNull();
   });
   it('render the Igbo API Editor Platform with merger role', async () => {
-    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: 'merger' });
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: UserRoles.MERGER });
     const { queryByText, findByText, findAllByText } = render(<App />);
 
     await findAllByText('Dashboard');
@@ -75,7 +76,7 @@ describe('App', () => {
   });
 
   it('render the Igbo API Editor Platform with editor role', async () => {
-    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: 'editor' });
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: UserRoles.EDITOR });
     const { queryByText, findByText, findAllByText } = render(<App />);
 
     await findAllByText('Dashboard');
@@ -98,8 +99,8 @@ describe('App', () => {
     expect(await queryByText('Loading the page, please wait a moment')).toBeNull();
   });
 
-  it('render the Igbo API Editor Platform with editor role', async () => {
-    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: 'transcriber' });
+  it('render the Igbo API Editor Platform with transcriber role', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: UserRoles.TRANSCRIBER });
     const { queryByText, findByText, findAllByText } = render(<App />);
 
     await findAllByText('Dashboard');
@@ -122,7 +123,7 @@ describe('App', () => {
     expect(await queryByText('Loading the page, please wait a moment')).toBeNull();
   });
   it('render the Igbo API Editor Platform with editor crowdsourcer', async () => {
-    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: 'crowdsourcer' });
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ role: UserRoles.CROWDSOURCER });
     const { queryByText, findByText, findAllByText } = render(<App />);
 
     await findAllByText('Dashboard');

--- a/src/Core/Collections/IgboDefinitions/IgboDefinitions.tsx
+++ b/src/Core/Collections/IgboDefinitions/IgboDefinitions.tsx
@@ -2,14 +2,17 @@ import React, { useState, useEffect, useRef, ReactElement } from 'react';
 import { compact, noop } from 'lodash';
 import { Box, Heading, Input, Link, Spinner, Text, useToast } from '@chakra-ui/react';
 import { ArrowBackIcon, ArrowForwardIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { usePermissions } from 'react-admin';
 import { ActivityButton, Card, PrimaryButton } from 'src/shared/primitives';
 import { IGBO_DEFINITIONS_STANDARDS_DOC } from 'src/Core/constants';
 import WordClass from 'src/backend/shared/constants/WordClass';
 import useBeforeWindowUnload from 'src/hooks/useBeforeWindowUnload';
 import CrowdsourcingType from 'src/backend/shared/constants/CrowdsourcingType';
 import { getWordSuggestionsWithoutIgboDefinitions, putWordSuggestionsWithoutIgboDefinitions } from 'src/shared/API';
+import { hasAdminPermissions } from 'src/shared/utils/permissions';
 import NavbarWrapper from '../components/NavbarWrapper';
 import Completed from '../components/Completed';
+import GenerateMoreWordsButton from './components/GenerateMoreWordsButton';
 
 const IgboDefinitions = (): ReactElement => {
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
@@ -23,6 +26,8 @@ const IgboDefinitions = (): ReactElement => {
   const toast = useToast();
   const currentCard = wordSuggestions[currentCardIndex];
   const showSubmitButton = visitedLastWordSuggestionIndex && igboDefinitions.some((igboDefinition) => !!igboDefinition);
+  const permissions = usePermissions();
+  const isAdmin = hasAdminPermissions(permissions?.permissions, true);
 
   const handleSubmit = async () => {
     setIsLoading(true);
@@ -108,6 +113,7 @@ const IgboDefinitions = (): ReactElement => {
             Igbo Definitions
           </Heading>
         </NavbarWrapper>
+        {isAdmin ? <GenerateMoreWordsButton isDisabled={!!wordSuggestions?.length} /> : null}
         <Text fontFamily="Silka" mt={4} textAlign="center">
           Each Igbo definition must follow our{' '}
           <Link textDecoration="underline" href={IGBO_DEFINITIONS_STANDARDS_DOC} target="_blank">
@@ -141,6 +147,10 @@ const IgboDefinitions = (): ReactElement => {
           {currentCard ? (
             <Text fontFamily="Silka" fontWeight="bold">
               {`${currentCardIndex + 1} / ${wordSuggestions.length}`}
+            </Text>
+          ) : !wordSuggestions?.length && !isLoading ? (
+            <Text my={12} fontSize="lg" color="gray.500" fontStyle="italic" fontFamily="heading">
+              No available words. Please request more.
             </Text>
           ) : null}
           <PrimaryButton

--- a/src/Core/Collections/IgboDefinitions/__tests__/IgboDefinitions.test.tsx
+++ b/src/Core/Collections/IgboDefinitions/__tests__/IgboDefinitions.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import TestContext from 'src/__tests__/components/TestContext';
+import * as reactAdmin from 'react-admin';
 import { putWordSuggestionsWithoutIgboDefinitions } from 'src/shared/API';
+import UserRoles from 'src/backend/shared/constants/UserRoles';
 import IgboDefinitions from '../IgboDefinitions';
 
 describe('IgboDefinitions', () => {
@@ -100,5 +102,25 @@ describe('IgboDefinitions', () => {
       { id: '456', igboDefinition: 'fourth igbo definition' },
       { id: '567', igboDefinition: 'fifth igbo definition' },
     ]);
+  });
+
+  it('render generate more words button if admin', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.ADMIN } });
+    const { findByText } = render(
+      <TestContext>
+        <IgboDefinitions />
+      </TestContext>,
+    );
+    await findByText('Get more words');
+  });
+
+  it('does not render generate more words button if not admin', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.MERGER } });
+    const { queryByText } = render(
+      <TestContext>
+        <IgboDefinitions />
+      </TestContext>,
+    );
+    expect(queryByText('Get more words')).toBeNull();
   });
 });

--- a/src/Core/Collections/IgboDefinitions/components/GenerateMoreWordsButton.tsx
+++ b/src/Core/Collections/IgboDefinitions/components/GenerateMoreWordsButton.tsx
@@ -1,0 +1,60 @@
+import React, { useState, ReactElement } from 'react';
+import { Button, useToast, useDisclosure, Tooltip, Box } from '@chakra-ui/react';
+import { postWordSuggestionsForIgboDefinitions } from 'src/shared/DataCollectionAPI';
+// eslint-disable-next-line max-len
+import GenerateMoreWordsConfirmationModal from 'src/Core/Collections/IgboDefinitions/components/GenerateMoreWordsConfirmationModal';
+
+const GenerateMoreWordsButton = ({ isDisabled = false }: { isDisabled?: boolean }): ReactElement => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+  const handleRequestMoreWords = async (limit: string) => {
+    try {
+      setIsLoading(true);
+      const { message } = await postWordSuggestionsForIgboDefinitions({ limit: parseInt(limit, 10) });
+      toast({
+        title: 'Success',
+        description: `${message}. Refresh the page.`,
+        status: 'success',
+        duration: 4000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Unable to create word suggestions',
+        description: 'Unable to create word suggestions. Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+      onClose();
+    }
+  };
+  return (
+    <>
+      <GenerateMoreWordsConfirmationModal
+        isLoading={isLoading}
+        isOpen={isOpen}
+        onClose={handleRequestMoreWords}
+        onCancel={onClose}
+      />
+      <Tooltip label={isDisabled ? 'There are word suggestions that need Igbo definitions.' : ''}>
+        <Box>
+          <Button
+            position={{ base: 'relative', md: 'absolute' }}
+            top="4rem"
+            right="0"
+            isLoading={isLoading}
+            onClick={onOpen}
+          >
+            Get more words
+          </Button>
+        </Box>
+      </Tooltip>
+    </>
+  );
+};
+
+export default GenerateMoreWordsButton;

--- a/src/Core/Collections/IgboDefinitions/components/GenerateMoreWordsConfirmationModal.tsx
+++ b/src/Core/Collections/IgboDefinitions/components/GenerateMoreWordsConfirmationModal.tsx
@@ -1,0 +1,75 @@
+import React, { useState, ReactElement } from 'react';
+import {
+  Button,
+  Input,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+  Box,
+  Tooltip,
+  chakra,
+} from '@chakra-ui/react';
+
+const GenerateMoreWordsConfirmationModal = ({
+  isOpen,
+  onClose,
+  onCancel,
+  isLoading,
+}: {
+  isOpen: boolean;
+  onClose: (limit: string) => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}): ReactElement => {
+  const [limit, setLimit] = useState('5');
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Get More Words</ModalHeader>
+        <ModalCloseButton onClick={onCancel} />
+        <ModalBody className="space-y-2">
+          <Text>Get more word suggestions from existing words that don&apos;t have Igbo definitions.</Text>
+          <Text>
+            Please enter the number of word suggestions to get.{' '}
+            <chakra.span fontWeight="bold">The limit is 10.</chakra.span>
+          </Text>
+          <Input
+            type="number"
+            value={limit}
+            placeholder="Number of word suggestions to create. i.e. 10"
+            onChange={(e) => setLimit(e.target.value)}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Tooltip label={!limit ? 'Please specify a number of word suggestions to create' : ''}>
+            <Box>
+              <Button
+                colorScheme="blue"
+                mr={3}
+                onClick={() => {
+                  console.log('okay', limit);
+                  onClose(limit);
+                }}
+                isDisabled={!limit}
+                isLoading={isLoading}
+              >
+                Get words
+              </Button>
+            </Box>
+          </Tooltip>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default GenerateMoreWordsConfirmationModal;

--- a/src/Core/Collections/IgboDefinitions/components/__tests__/GenerateMoreWordsButton.test.tsx
+++ b/src/Core/Collections/IgboDefinitions/components/__tests__/GenerateMoreWordsButton.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TestContext from 'src/__tests__/components/TestContext';
+import * as DataCollectionAPI from 'src/shared/DataCollectionAPI';
+import GenerateMoreWordsButton from '../GenerateMoreWordsButton';
+
+describe('GenerateMoreWordsButton', () => {
+  it('render button', async () => {
+    const { findByText } = render(
+      <TestContext>
+        <GenerateMoreWordsButton />
+      </TestContext>,
+    );
+
+    await findByText('Get more words');
+  });
+
+  it('open and closes confirmation modal', async () => {
+    const { findByText, queryByText } = render(
+      <TestContext>
+        <GenerateMoreWordsButton />
+      </TestContext>,
+    );
+
+    expect(queryByText('Get More Words')).toBeNull();
+    userEvent.click(await findByText('Get more words'));
+    await findByText('Get More Words');
+    userEvent.click(await findByText('Get words'));
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(queryByText('Get More Words')).toBeNull();
+  });
+
+  it('sends request to create more word suggestions', async () => {
+    const postSpy = jest.spyOn(DataCollectionAPI, 'postWordSuggestionsForIgboDefinitions').mockReturnValue({});
+
+    const { findByText, findByPlaceholderText } = render(
+      <TestContext>
+        <GenerateMoreWordsButton />
+      </TestContext>,
+    );
+
+    userEvent.click(await findByText('Get more words'));
+    userEvent.clear(await findByPlaceholderText('Number of word suggestions to create. i.e. 10'));
+    userEvent.type(await findByPlaceholderText('Number of word suggestions to create. i.e. 10'), '7');
+    userEvent.click(await findByText('Get words'));
+    expect(postSpy).toHaveBeenCalledWith({
+      limit: 7,
+    });
+  });
+});

--- a/src/Core/Collections/IgboDefinitions/components/__tests__/GenerateMoreWordsConfirmationModal.test.tsx
+++ b/src/Core/Collections/IgboDefinitions/components/__tests__/GenerateMoreWordsConfirmationModal.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TestContext from 'src/__tests__/components/TestContext';
+import GenerateMoreWordsConfirmationModal from '../GenerateMoreWordsConfirmationModal';
+
+describe('GenerateMoreWordsConfirmationModal', () => {
+  it('renders the modal', async () => {
+    const mockClose = jest.fn();
+    const mockCancel = jest.fn();
+    const { findByText } = render(
+      <TestContext index={0}>
+        <GenerateMoreWordsConfirmationModal isOpen onClose={mockClose} onCancel={mockCancel} isLoading={false} />
+      </TestContext>,
+    );
+    await findByText('Get More Words');
+    await findByText(/Get more word suggestions/);
+    await findByText(/Please enter the number/);
+    await findByText('Cancel');
+    await findByText('Get words');
+  });
+
+  it('triggers cancel and close the dialect', async () => {
+    const mockClose = jest.fn();
+    const mockCancel = jest.fn();
+    const { findByText } = render(
+      <TestContext index={0}>
+        <GenerateMoreWordsConfirmationModal isOpen onClose={mockClose} onCancel={mockCancel} isLoading={false} />
+      </TestContext>,
+    );
+    fireEvent.click(await findByText('Get words'));
+    expect(mockClose).toHaveBeenCalled();
+    fireEvent.click(await findByText('Cancel'));
+    expect(mockCancel).toHaveBeenCalled();
+  });
+});

--- a/src/Core/Collections/components/NavbarWrapper.tsx
+++ b/src/Core/Collections/components/NavbarWrapper.tsx
@@ -3,7 +3,7 @@ import { Box, BoxProps } from '@chakra-ui/react';
 
 const NavbarWrapper = ({ children, className, ...props }: BoxProps): ReactElement => (
   <Box
-    className={`bg-white w-full h-16 flex flex-row items-center ${className}`}
+    className={`bg-white w-full h-16 flex flex-col lg:flex-row items-center ${className}`}
     borderBottomColor="gray.200"
     borderBottomWidth="1px"
     {...props}

--- a/src/__tests__/components/TestContext.tsx
+++ b/src/__tests__/components/TestContext.tsx
@@ -12,6 +12,7 @@ import Collections from 'src/shared/constants/Collections';
 import Views from 'src/shared/constants/Views';
 import { ExampleSuggestion } from 'src/backend/controllers/utils/interfaces';
 import { SentenceVerification } from 'src/Core/Collections/IgboSoundbox/types/SentenceVerification';
+// eslint-disable-next-line max-len
 import createDefaultExampleFormValues from 'src/shared/components/views/components/WordEditForm/utils/createDefaultExampleFormValues';
 
 configure({ testIdAttribute: 'data-test' });

--- a/src/__tests__/shared/commands.ts
+++ b/src/__tests__/shared/commands.ts
@@ -49,6 +49,11 @@ export const deleteWordSuggestion = (id: string, options: OptionsType = { token:
     .delete(`/wordSuggestions/${id}`)
     .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`);
 
+export const deleteOldWordSuggestions = (options: OptionsType = { token: '' }): Request =>
+  chaiServer
+    .delete('/wordSuggestions/old')
+    .set('Authorization', `Bearer ${options.token || AUTH_TOKEN.ADMIN_AUTH_TOKEN}`);
+
 export const putRandomWordSuggestions = (
   data: { id: string; pronunciation?: string; review?: ReviewActions }[] | { id: string; igboDefinition: string }[],
   options: OptionsType = { token: '' },

--- a/src/__tests__/wordSuggestions.test.ts
+++ b/src/__tests__/wordSuggestions.test.ts
@@ -17,6 +17,7 @@ import {
   getExample,
   getRandomWordSuggestions,
   putRandomWordSuggestions,
+  deleteOldWordSuggestions,
 } from './shared/commands';
 import {
   wordSuggestionData,
@@ -702,6 +703,14 @@ describe('MongoDB Word Suggestions', () => {
       const result = await deleteWordSuggestion(res.body.id);
       expect(result.status).toEqual(404);
       expect(result.body.error).not.toEqual(undefined);
+    });
+
+    it('should delete all old word suggestions', async () => {
+      const res = await suggestNewWord(wordSuggestionData);
+      expect(res.status).toEqual(200);
+      const result = await deleteOldWordSuggestions();
+      expect(result.status).toEqual(200);
+      console.log(result.body);
     });
   });
 

--- a/src/backend/controllers/__tests__/stats.test.ts
+++ b/src/backend/controllers/__tests__/stats.test.ts
@@ -44,6 +44,7 @@ describe('Stats', () => {
     await audioPronunciation.save();
     expect((await onUpdateTotalAudioDashboardStats())[0].totalExampleAudio).toBeGreaterThanOrEqual(1);
     expect((await onUpdateTotalAudioDashboardStats())[1].totalExampleSuggestionAudio).toBeLessThanOrEqual(0);
+    await disconnectDatabase();
   });
 
   it('calculates the total number of hours of example suggestion audio', async () => {

--- a/src/backend/controllers/__tests__/wordSuggestions.test.ts
+++ b/src/backend/controllers/__tests__/wordSuggestions.test.ts
@@ -1,0 +1,183 @@
+import { compact, times } from 'lodash';
+import moment from 'moment';
+import {
+  deleteOldWordSuggestions,
+  postRandomWordSuggestionsForIgboDefinitions,
+} from 'src/backend/controllers/wordSuggestions';
+import { wordSchema } from 'src/backend/models/Word';
+import { wordSuggestionSchema } from 'src/backend/models/WordSuggestion';
+import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
+import { connectDatabase, disconnectDatabase } from 'src/backend/utils/database';
+import { dropMongoDBCollections } from 'src/__tests__/shared';
+import * as Interfaces from '../utils/interfaces';
+
+describe('WordSuggestions', () => {
+  beforeEach(async () => {
+    // Clear out database to start with a clean slate
+    await dropMongoDBCollections();
+  });
+
+  describe('DELETE word suggestions', () => {
+    it('deletes word suggestions', async () => {
+      const connection = await connectDatabase();
+      const WordSuggestion = connection.model<Interfaces.WordSuggestion>('WordSuggestion', wordSuggestionSchema);
+      const wordSuggestion = new WordSuggestion({
+        word: 'testing',
+        definitions: [],
+        pronunciation: 'pronunciation',
+        createdAt: moment().subtract(2, 'year'),
+      });
+      const savedWordSuggestion = await wordSuggestion.save();
+      const mockReq = { mongooseConnection: connection };
+      const mockRes = {
+        send: jest.fn(),
+      };
+      const mockNext = jest.fn();
+      await deleteOldWordSuggestions(mockReq, mockRes, mockNext);
+      const nonExistentWordSuggestion = await WordSuggestion.findById(savedWordSuggestion.id);
+      expect(nonExistentWordSuggestion).toBeNull();
+      await disconnectDatabase();
+    });
+
+    it('does not delete word suggestions created by community users', async () => {
+      const connection = await connectDatabase();
+      const WordSuggestion = connection.model<Interfaces.WordSuggestion>('WordSuggestion', wordSuggestionSchema);
+      const communityWordSuggestion = new WordSuggestion({
+        word: 'community',
+        definitions: [],
+        pronunciation: 'pronunciation',
+        source: SuggestionSourceEnum.COMMUNITY,
+        createdAt: moment().subtract(2, 'year'),
+      });
+      const wordSuggestion = new WordSuggestion({
+        word: 'testing',
+        definitions: [],
+        pronunciation: 'pronunciation',
+        createdAt: moment().subtract(2, 'year'),
+      });
+      const [savedCommunityWordSuggestion, savedWordSuggestion] = await Promise.all([
+        communityWordSuggestion.save(),
+        wordSuggestion.save(),
+      ]);
+      const mockReq = { mongooseConnection: connection };
+      const mockRes = {
+        send: jest.fn(),
+      };
+      const mockNext = jest.fn();
+      await deleteOldWordSuggestions(mockReq, mockRes, mockNext);
+      const nonExistentWordSuggestion = await WordSuggestion.findById(savedWordSuggestion.id);
+      const existingCommunityWordSuggestion = await WordSuggestion.findById(savedCommunityWordSuggestion.id);
+      expect(nonExistentWordSuggestion).toBeNull();
+      expect(existingCommunityWordSuggestion.id).toEqual(savedCommunityWordSuggestion.id);
+      await disconnectDatabase();
+    });
+  });
+
+  describe('POST word suggestions', () => {
+    it("creates new word suggestions from words that don't have Igbo definitions", async () => {
+      const connection = await connectDatabase();
+      const Word = connection.model<Interfaces.Word>('Word', wordSchema);
+      const WordSuggestion = connection.model<Interfaces.WordSuggestion>('WordSuggestion', wordSuggestionSchema);
+      const savedWordIds = await Promise.all(
+        times(5, async (index) => {
+          const word = new Word({
+            word: `testing-${index}`,
+            definitions: [],
+            pronunciation: 'pronunciation',
+            createdAt: moment().subtract(2, 'year'),
+          });
+          const savedWord = await word.save();
+          return savedWord.id.toString();
+        }),
+      );
+      let savedWordSuggestionIds = [];
+      const mockReq = { mongooseConnection: connection, data: { limit: 5 } };
+      const mockSend = jest.fn(({ ids }) => {
+        savedWordSuggestionIds = ids.map((id) => id.toString());
+      });
+      const mockRes = {
+        status: () => ({
+          send: mockSend,
+        }),
+        send: mockSend,
+      };
+      const mockNext = jest.fn();
+      await postRandomWordSuggestionsForIgboDefinitions(mockReq, mockRes, mockNext);
+      expect(mockSend).toHaveBeenCalledWith({
+        message: 'Created up to 5 word suggestions',
+        ids: savedWordSuggestionIds,
+      });
+
+      const wordSuggestions = await Promise.all(savedWordSuggestionIds.map(async (id) => WordSuggestion.findById(id)));
+      wordSuggestions.forEach(({ originalWordId }) => expect(savedWordIds).toContain(originalWordId.toString()));
+      await disconnectDatabase();
+    });
+
+    it('does not create new word suggestion from word with Igbo definition', async () => {
+      const connection = await connectDatabase();
+      const Word = connection.model<Interfaces.Word>('Word', wordSchema);
+      await Promise.all(
+        times(5, async (index) => {
+          const word = new Word({
+            word: `testing-${index}`,
+            definitions: [{ igboDefinitions: { igbo: 'first igbo definition' } }],
+            pronunciation: 'pronunciation',
+            createdAt: moment().subtract(2, 'year'),
+          });
+          const savedWord = await word.save();
+          return savedWord.id.toString();
+        }),
+      );
+      const mockReq = { mongooseConnection: connection, data: { limit: 5 } };
+      const mockSend = jest.fn();
+      const mockRes = {
+        status: () => ({
+          send: mockSend,
+        }),
+        send: mockSend,
+      };
+      const mockNext = jest.fn();
+      await postRandomWordSuggestionsForIgboDefinitions(mockReq, mockRes, mockNext);
+      expect(mockSend).toHaveBeenCalledWith({ message: 'No word suggestion created' });
+      await disconnectDatabase();
+    });
+
+    it('create one new word suggestion from word without an Igbo definition', async () => {
+      const connection = await connectDatabase();
+      const Word = connection.model<Interfaces.Word>('Word', wordSchema);
+      const WordSuggestion = connection.model<Interfaces.WordSuggestion>('WordSuggestion', wordSuggestionSchema);
+      const savedWordIds = await Promise.all(
+        times(5, async (index) => {
+          const word = new Word({
+            word: `testing-${index}`,
+            definitions: compact([index === 0 ? null : { igboDefinitions: { igbo: 'first igbo definition' } }]),
+            pronunciation: 'pronunciation',
+            createdAt: moment().subtract(2, 'year'),
+          });
+          const savedWord = await word.save();
+          return savedWord.id.toString();
+        }),
+      );
+      let savedWordSuggestionIds = [];
+      const mockReq = { mongooseConnection: connection, data: { limit: 5 } };
+      const mockSend = jest.fn(({ ids }) => {
+        savedWordSuggestionIds = ids.map((id) => id.toString());
+      });
+      const mockRes = {
+        status: () => ({
+          send: mockSend,
+        }),
+        send: mockSend,
+      };
+      const mockNext = jest.fn();
+      await postRandomWordSuggestionsForIgboDefinitions(mockReq, mockRes, mockNext);
+      expect(mockSend).toHaveBeenCalledWith({
+        message: 'Created up to 1 word suggestions',
+        ids: savedWordSuggestionIds,
+      });
+      const wordSuggestions = await Promise.all(savedWordSuggestionIds.map(async (id) => WordSuggestion.findById(id)));
+      wordSuggestions.forEach(({ originalWordId }) => expect(savedWordIds).toContain(originalWordId.toString()));
+      await disconnectDatabase();
+    });
+  });
+});

--- a/src/backend/controllers/utils/queries/__tests__/queries.test.ts
+++ b/src/backend/controllers/utils/queries/__tests__/queries.test.ts
@@ -1,0 +1,13 @@
+import { searchWordSuggestionsOlderThanAYear } from 'src/backend/controllers/utils/queries/queries';
+import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
+
+describe('queries', () => {
+  it('searchWordSuggestionsOlderThanAYear', () => {
+    const query = searchWordSuggestionsOlderThanAYear();
+    expect(query).toStrictEqual({
+      createdAt: query.createdAt,
+      source: { $ne: SuggestionSourceEnum.COMMUNITY },
+      merged: null,
+    });
+  });
+});

--- a/src/backend/controllers/utils/queries/queries.ts
+++ b/src/backend/controllers/utils/queries/queries.ts
@@ -415,7 +415,13 @@ export const searchWordSuggestionsWithoutIgboDefinitionsFromLastMonth = (): {
   updatedAt: { $gte: moment().subtract(1, 'months').startOf('month').valueOf() },
   merged: null,
 });
-
+export const searchWordSuggestionsOlderThanAYear = (): {
+  [key: string]: { $lte: number } | { $ne: SuggestionSourceEnum } | null;
+} => ({
+  createdAt: { $lte: moment().subtract(1, 'year').valueOf() },
+  source: { $ne: SuggestionSourceEnum.COMMUNITY }, // Do not delete Word Suggestions from Nkọwa okwu users
+  merged: null,
+});
 /**
  * Gets example suggestions where the user's audio has been approved
  */

--- a/src/backend/routers/editorRouter.ts
+++ b/src/backend/routers/editorRouter.ts
@@ -2,12 +2,14 @@ import express from 'express';
 import UserRoles from 'src/backend/shared/constants/UserRoles';
 import {
   deleteWordSuggestion,
+  deleteOldWordSuggestions,
   getWordSuggestion,
   getWordSuggestions,
   putWordSuggestion,
   postWordSuggestion,
   approveWordSuggestion,
   denyWordSuggestion,
+  postRandomWordSuggestionsForIgboDefinitions,
 } from 'src/backend/controllers/wordSuggestions';
 import { deleteCorpusSuggestion } from 'src/backend/controllers/corpusSuggestions';
 import {
@@ -85,6 +87,11 @@ editorRouter.post(
   resolveWordDocument,
   postWordSuggestion,
 );
+editorRouter.delete(
+  '/wordSuggestions/igbo-definitions',
+  authorization([UserRoles.ADMIN]),
+  postRandomWordSuggestionsForIgboDefinitions,
+);
 editorRouter.put(
   '/wordSuggestions/:id',
   validId,
@@ -96,6 +103,7 @@ editorRouter.put(
 editorRouter.get('/wordSuggestions/:id', validId, getWordSuggestion);
 editorRouter.put('/wordSuggestions/:id/approve', validId, approveWordSuggestion);
 editorRouter.put('/wordSuggestions/:id/deny', validId, denyWordSuggestion);
+editorRouter.delete('/wordSuggestions/old', authorization([UserRoles.ADMIN]), deleteOldWordSuggestions);
 editorRouter.delete(
   '/wordSuggestions/:id',
   validId,

--- a/src/shared/API.ts
+++ b/src/shared/API.ts
@@ -183,3 +183,9 @@ export const putWordSuggestionsWithoutIgboDefinitions = async (
       data: igboDefinitions,
     })
   ).data;
+
+export const deleteOldWordSuggestions = async (): Promise<any> =>
+  request({
+    method: 'DELETE',
+    url: `${Collection.WORD_SUGGESTIONS}/old`,
+  });

--- a/src/shared/DataCollectionAPI.ts
+++ b/src/shared/DataCollectionAPI.ts
@@ -142,3 +142,6 @@ export const getLeaderboardStats = async ({
       params: { leaderboard, timeRange },
     })
   ).data;
+
+export const postWordSuggestionsForIgboDefinitions = async (data: { limit: number }): Promise<{ message: string }> =>
+  (await request({ method: 'POST', url: `${Collections.WORD_SUGGESTIONS}/igbo-definitions`, data })).data;

--- a/src/shared/__mocks__/API.ts
+++ b/src/shared/__mocks__/API.ts
@@ -121,3 +121,5 @@ export const getWordSuggestionsWithoutIgboDefinitions = jest.fn(async () => [
 ]);
 
 export const putWordSuggestionsWithoutIgboDefinitions = jest.fn();
+
+export const deleteOldWordSuggestions = jest.fn();

--- a/src/shared/__mocks__/DataCollectionAPI.ts
+++ b/src/shared/__mocks__/DataCollectionAPI.ts
@@ -123,3 +123,5 @@ export const getRandomExampleSuggestionsToTranslate = jest.fn(async () => ({
 export const putRandomExampleSuggestionsToTranslate = jest.fn(async () => {});
 
 export const getRandomExampleSuggestionsToRecord = jest.fn(async () => ({ data: exampleSuggestions }));
+
+export const postWordSuggestionsForIgboDefinitions = jest.fn(async () => ({ message: 'Success' }));

--- a/src/shared/__tests__/API.test.tsx
+++ b/src/shared/__tests__/API.test.tsx
@@ -1,0 +1,14 @@
+import { deleteOldWordSuggestions } from 'src/shared/API';
+import * as requestModule from 'src/shared/utils/request';
+import Collections from 'src/shared/constants/Collections';
+
+describe('API', () => {
+  it('sends a DELETE request to delete all old word suggestions', async () => {
+    const requestSpy = jest.spyOn(requestModule, 'request').mockReturnValue({});
+    await deleteOldWordSuggestions();
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'DELETE',
+      url: `${Collections.WORD_SUGGESTIONS}/old`,
+    });
+  });
+});

--- a/src/shared/__tests__/DataCollectionAPI.test.tsx
+++ b/src/shared/__tests__/DataCollectionAPI.test.tsx
@@ -3,12 +3,14 @@ import * as requestModule from 'src/shared/utils/request';
 import { v4 as uuidv4 } from 'uuid';
 import ReviewActions from 'src/backend/shared/constants/ReviewActions';
 import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
+import Collections from 'src/shared/constants/Collections';
 import {
   putAudioForRandomExampleSuggestions,
   putReviewForRandomExampleSuggestions,
   getRandomExampleSuggestionsToTranslate,
   putRandomExampleSuggestionsToTranslate,
   bulkUploadExampleSuggestions,
+  postWordSuggestionsForIgboDefinitions,
 } from '../DataCollectionAPI';
 
 describe('DataCollectionAPI', () => {
@@ -131,6 +133,17 @@ describe('DataCollectionAPI', () => {
       method: 'POST',
       url: 'exampleSuggestions/upload',
       data: payload.sentences,
+    });
+  });
+
+  it('sends a POST request to suggest new word suggestions with Igbo definitions', async () => {
+    const requestSpy = jest.spyOn(requestModule, 'request').mockReturnValue({});
+    const payload = { limit: 7 };
+    await postWordSuggestionsForIgboDefinitions(payload);
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'POST',
+      url: `${Collections.WORD_SUGGESTIONS}/igbo-definitions`,
+      data: payload,
     });
   });
 });

--- a/src/shared/components/actions/ListActions.tsx
+++ b/src/shared/components/actions/ListActions.tsx
@@ -22,9 +22,10 @@ import { CreateButton } from 'src/shared/primitives';
 import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
 import WordClass from 'src/backend/shared/constants/WordClass';
 import WordAttributeEnum from 'src/backend/shared/constants/WordAttributeEnum';
-import { hasAdminOrMergerPermissions } from 'src/shared/utils/permissions';
+import { hasAdminOrMergerPermissions, hasAdminPermissions } from 'src/shared/utils/permissions';
 import ExampleStyleEnum from 'src/backend/shared/constants/ExampleStyleEnum';
 import SentenceTypeEnum from 'src/backend/shared/constants/SentenceTypeEnum';
+import DeleteOldWordSuggestionsButton from 'src/shared/components/actions/components/DeleteOldWordSuggestionsButton';
 import Filter from '../Filter';
 
 /**
@@ -59,7 +60,9 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
   const [currentPartOfSpeechFilter, setCurrentPartOfSpeechFilter] = useState(
     getDefaultPartOfSpeechFilters(filterValues),
   );
-  const { permissions = {} } = usePermissions();
+  const permissions = usePermissions();
+  const isAdminOrMerger = hasAdminOrMergerPermissions(permissions?.permissions, true);
+  const isAdmin = hasAdminPermissions(permissions?.permissions, true);
 
   const selectedFilters = currentFilters.length > 1 || (currentFilters.length === 1 && currentFilters[0] !== 'word');
 
@@ -298,11 +301,10 @@ const ListActions = (props: CustomListActionProps): ReactElement => {
             </Box>
           ) : null}
         </Box>
-        {isSuggestionResource ||
-        (isPollResource && hasAdminOrMergerPermissions(permissions, true)) ||
-        resource === Collections.NSIBIDI_CHARACTERS ? (
+        {isSuggestionResource || (isPollResource && isAdminOrMerger) || resource === Collections.NSIBIDI_CHARACTERS ? (
           <CreateButton basePath={basePath} />
         ) : null}
+        {isAdmin && isWordResource && isSuggestionResource ? <DeleteOldWordSuggestionsButton /> : null}
       </Box>
     </TopToolbar>
   );

--- a/src/shared/components/actions/__tests__/ListActions.test.tsx
+++ b/src/shared/components/actions/__tests__/ListActions.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { render, configure } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TestContext from 'src/__tests__/components/TestContext';
+import * as reactAdmin from 'react-admin';
 import Collections from 'src/shared/constants/Collections';
+import UserRoles from 'src/backend/shared/constants/UserRoles';
 import ListActions from '../ListActions';
 
 configure({ testIdAttribute: 'data-test' });
@@ -130,5 +132,51 @@ describe('Render List Actions', () => {
     const isProverb = document.querySelector('[value="proverb"]');
     userEvent.click(isProverb);
     expect(isProverb.isSameNode(document.querySelector('[aria-checked="true"][value="proverb"]'))).toBe(true);
+  });
+
+  it('render the Delete old Word Suggestions button for only admins', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.ADMIN } });
+    const { findByText } = render(
+      <TestContext>
+        <ListActions resource={Collections.WORD_SUGGESTIONS} />
+      </TestContext>,
+    );
+
+    await findByText('Delete old Word Suggestions');
+  });
+
+  it('opens the Delete old Word Suggestions confirmation modal for only admins', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.ADMIN } });
+    const { findByText } = render(
+      <TestContext>
+        <ListActions resource={Collections.WORD_SUGGESTIONS} />
+      </TestContext>,
+    );
+
+    userEvent.click(await findByText('Delete old Word Suggestions'));
+    await findByText('Delete Old Word Suggestions');
+  });
+
+  it('does not render Delete old Word Suggestions button for non-admin', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.MERGER } });
+    const { queryByText } = render(
+      <TestContext>
+        <ListActions resource={Collections.WORD_SUGGESTIONS} />
+      </TestContext>,
+    );
+
+    expect(queryByText('Delete old Word Suggestions')).toBeNull();
+  });
+
+  it('does not render Delete old Word Suggestions button for non Word Suggestions', async () => {
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.ADMIN } });
+
+    const { queryByText } = render(
+      <TestContext>
+        <ListActions resource={Collections.EXAMPLE_SUGGESTIONS} />
+      </TestContext>,
+    );
+
+    expect(queryByText('Delete old Word Suggestions')).toBeNull();
   });
 });

--- a/src/shared/components/actions/components/DeleteOldWordSuggestionsButton.tsx
+++ b/src/shared/components/actions/components/DeleteOldWordSuggestionsButton.tsx
@@ -1,0 +1,53 @@
+import React, { ReactElement, useState } from 'react';
+import { Button, useDisclosure, useToast } from '@chakra-ui/react';
+// eslint-disable-next-line max-len
+import DeleteOldWordSuggestionsConfirmationModal from 'src/shared/components/actions/components/DeleteOldWordSuggestionsConfirmationModal';
+import { deleteOldWordSuggestions } from 'src/shared/API';
+
+const DeleteOldWordSuggestionsButton = (): ReactElement => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+
+  const handleDeleteWordSuggestions = async () => {
+    try {
+      setIsLoading(true);
+      const { data } = await deleteOldWordSuggestions();
+      console.log(`Total word suggestions delete: ${data.result.deletedCount}`);
+      toast({
+        title: 'Success',
+        description: 'Deleted all old word suggestions.',
+        status: 'success',
+        duration: 4000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: 'Unable to delete old word suggestions. Please try again.',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <DeleteOldWordSuggestionsConfirmationModal
+        isOpen={isOpen}
+        onCancel={onClose}
+        onClose={handleDeleteWordSuggestions}
+        isLoading={isLoading}
+      />
+      <Button colorScheme="red" onClick={onOpen} isLoading={isLoading}>
+        Delete old Word Suggestions
+      </Button>
+    </>
+  );
+};
+
+export default DeleteOldWordSuggestionsButton;

--- a/src/shared/components/actions/components/DeleteOldWordSuggestionsConfirmationModal.tsx
+++ b/src/shared/components/actions/components/DeleteOldWordSuggestionsConfirmationModal.tsx
@@ -1,0 +1,53 @@
+import React, { ReactElement } from 'react';
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+  chakra,
+} from '@chakra-ui/react';
+import moment from 'moment';
+
+const DeleteOldWordSuggestionsConfirmationModal = ({
+  isOpen,
+  onClose,
+  onCancel,
+  isLoading,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}): ReactElement => (
+  <Modal isOpen={isOpen} onClose={onCancel}>
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader>Delete Old Word Suggestions</ModalHeader>
+      <ModalCloseButton onClick={onCancel} />
+      <ModalBody className="space-y-2">
+        <Text>
+          {/* eslint-disable-next-line max-len */}
+          You will be <chakra.span fontWeight="bold">permanently</chakra.span> deleting Word Suggestions created before{' '}
+          <chakra.span fontWeight="bold">{moment().subtract(1, 'year').format('MMMM DD, YYYY')}</chakra.span>.
+        </Text>
+        <Text fontSize="sm" color="gray.600" fontStyle="italic">
+          This excludes Word Suggestions submitted by Nkọwa okwu users.
+        </Text>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button colorScheme="red" mr={3} onClick={onClose} isLoading={isLoading}>
+          Delete word suggestions
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+);
+export default DeleteOldWordSuggestionsConfirmationModal;

--- a/src/shared/components/actions/components/__tests__/DeleteOldWordSuggestionsButton.test.tsx
+++ b/src/shared/components/actions/components/__tests__/DeleteOldWordSuggestionsButton.test.tsx
@@ -1,0 +1,32 @@
+// Testing react-select dropdown: https://stackoverflow.com/a/61551935
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TestContext from 'src/__tests__/components/TestContext';
+import DeleteOldWordSuggestionsButton from '../DeleteOldWordSuggestionsButton';
+
+describe('DeleteOldWordSuggestionsButton', () => {
+  it('render delete old word suggestions button', async () => {
+    const { findByText } = render(
+      <TestContext>
+        <DeleteOldWordSuggestionsButton />
+      </TestContext>,
+    );
+
+    await findByText('Delete old Word Suggestions');
+  });
+
+  it('open and close confirmation modal', async () => {
+    const { queryByText, findByText } = render(
+      <TestContext>
+        <DeleteOldWordSuggestionsButton />
+      </TestContext>,
+    );
+
+    expect(queryByText('Delete Old Word Suggestions')).toBeNull();
+    fireEvent.click(await findByText('Delete old Word Suggestions'));
+    await findByText('Delete Old Word Suggestions');
+    fireEvent.click(await findByText('Cancel'));
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(queryByText('Delete Old Word Suggestions')).toBeNull();
+  });
+});

--- a/src/shared/components/actions/components/__tests__/DeleteOldWordSuggestionsConfirmationModal.test.tsx
+++ b/src/shared/components/actions/components/__tests__/DeleteOldWordSuggestionsConfirmationModal.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { noop } from 'lodash';
+import { render, fireEvent } from '@testing-library/react';
+import TestContext from 'src/__tests__/components/TestContext';
+import DeleteOldWordSuggestionsConfirmationModal from '../DeleteOldWordSuggestionsConfirmationModal';
+
+describe('DeleteOldWordSuggestionsConfirmationModal', () => {
+  it('render content in modal', async () => {
+    const { findByText } = render(
+      <TestContext>
+        <DeleteOldWordSuggestionsConfirmationModal isOpen onClose={noop} onCancel={noop} isLoading={false} />
+      </TestContext>,
+    );
+
+    await findByText('Delete Old Word Suggestions');
+    await findByText(/You will be/);
+    await findByText(/This excludes/);
+    await findByText('Cancel');
+    await findByText('Delete word suggestions');
+  });
+
+  it('closes the modal', async () => {
+    const onCloseMock = jest.fn();
+    const onCancelMock = jest.fn();
+    const { findByText } = render(
+      <TestContext>
+        <DeleteOldWordSuggestionsConfirmationModal
+          isOpen
+          onClose={onCloseMock}
+          onCancel={onCancelMock}
+          isLoading={false}
+        />
+      </TestContext>,
+    );
+
+    fireEvent.click(await findByText('Cancel'));
+    fireEvent.click(await findByText('Delete word suggestions'));
+
+    expect(onCloseMock).toBeCalled();
+    expect(onCancelMock).toBeCalled();
+  });
+});

--- a/src/shared/constants/Collections.ts
+++ b/src/shared/constants/Collections.ts
@@ -11,6 +11,7 @@ enum Collections {
   NOTIFICATIONS = 'notifications',
   NSIBIDI_CHARACTERS = 'nsibidiCharacters',
   DATA_DUMP = 'dataDump',
-};
+  LEADERBOARDS = 'leaderboards',
+}
 
 export default Collections;

--- a/src/shared/primitives/__tests__/Card.test.tsx
+++ b/src/shared/primitives/__tests__/Card.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import TestContext from 'src/__tests__/components/TestContext';
 import * as reactAdmin from 'react-admin';
-
+import UserRoles from 'src/backend/shared/constants/UserRoles';
 import Card from '../Card';
 
 describe('Card', () => {
@@ -18,7 +18,7 @@ describe('Card', () => {
   });
 
   it('render card with text with link as admin', async () => {
-    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: 'admin' } });
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.ADMIN } });
 
     const text = 'Testing text';
     const href = 'href';
@@ -33,7 +33,7 @@ describe('Card', () => {
   });
 
   it('render card with text with link as crowdsourcer', async () => {
-    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: 'crowdsourcer' } });
+    jest.spyOn(reactAdmin, 'usePermissions').mockReturnValue({ permissions: { role: UserRoles.CROWDSOURCER } });
 
     const text = 'Testing text';
     const href = 'href';


### PR DESCRIPTION
## Background
* A new admin-only Delete old Word Suggestions button is available at the top of the word suggestions list
    * This will delete word suggestions that are older than a year from the date the Admin attempts to delete the word suggestions
* A new Get more words button is available only to admins to create new word suggestions from word documents that do not have Igbo definitions
    * An admin is able to create up to 10 new word suggestions per click
    * This feature will be rolled out to the general public after dog food for about a week

### Screenshots
![Xnapper-2023-09-14-01 19 44](https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/339008e5-e92b-4545-afdb-b8f65cb81144)
![Xnapper-2023-09-14-01 18 24](https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/10f6da4f-e654-43a9-aedf-e68544b67086)
![Xnapper-2023-09-14-01 18 17](https://github.com/nkowaokwu/igbo-api-admin/assets/16169291/73a80ab8-9dfe-4a99-a2cf-4514bbc132a2)
