### PR TITLE
refactor: use scheduler to copy firebase users

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -70,7 +70,6 @@ server.use(errorHandler);
 // Firebase Functions
 export const createUserAccount = onCreateUserAccount;
 export const updatePermissions = onUpdatePermissions;
-export const copyFirebaseUsers = onCopyFirebaseUsers;
 export const requestDeleteDocument = onRequestDeleteDocument;
 export const deleteConstructedTermPoll = onDeleteConstructedTermPoll;
 export const deleteUser = onDeleteUser;
@@ -102,6 +101,11 @@ export const calculateTotalAudioHours = functions
   .pubsub.schedule('0 6 * * *')
   .timeZone('America/Los_Angeles')
   .onRun(onUpdateTotalAudioDashboardStats);
+
+export const copyFirebaseUsers = functions.pubsub
+  .schedule('0 6 10 10 *')
+  .timeZone('Europe/London')
+  .onRun(onCopyFirebaseUsers);
 
 /**
  * Determines whether or not in a backend testing environment or in a

--- a/src/backend/functions/__tests__/users.test.ts
+++ b/src/backend/functions/__tests__/users.test.ts
@@ -1,0 +1,60 @@
+import { onCopyFirebaseUsers } from '../users';
+import * as userController from '../../controllers/users';
+import * as database from '../../utils/database';
+import { FormattedUser } from '../../controllers/utils/interfaces';
+
+const mockReferralCode = 'ABCD1234';
+
+jest.mock('../utils', () => ({
+  generateId: () => mockReferralCode,
+}));
+
+describe('users', () => {
+  const mockDb = jest.spyOn(database, 'connectDatabase');
+  const mockFindUsers = jest.spyOn(userController, 'findUsers');
+
+  const fixtures = [
+    {
+      existingUsersMock: [{ id: '1' }, { id: '2' }, { id: '3' }],
+      firebaseUsersMock: [{ id: '1' }, { id: '2' }, { id: '4' }, { id: '5' }],
+      expectedUsers: [
+        { firebaseId: '4', referralCode: mockReferralCode },
+        { firebaseId: '5', referralCode: mockReferralCode },
+      ],
+      testCase: 'should copy 2 users to mongodb',
+    },
+    {
+      existingUsersMock: [{ id: '1' }, { id: '2' }],
+      firebaseUsersMock: [{ id: '1' }, { id: '2' }],
+      expectedUsers: [],
+      testCase: 'should copy 0 users to mongodb',
+    },
+  ];
+
+  describe.each(fixtures)('onCopyFirebaseUsers', (fixture) => {
+    it(fixture.testCase, async () => {
+      // arrange
+      const insetManyMock = jest.fn();
+
+      mockDb.mockImplementationOnce(
+        () =>
+          Promise.resolve({
+            model: () => ({
+              find: () => fixture.existingUsersMock,
+              insertMany: insetManyMock,
+            }),
+          }) as any,
+      );
+
+      mockFindUsers.mockResolvedValueOnce(fixture.firebaseUsersMock as FormattedUser[]);
+
+      // act
+      const result = await onCopyFirebaseUsers();
+
+      // assert
+      expect(result).toMatch('Successfully copied firebase users');
+      expect(insetManyMock.mock.calls[0][0]).toHaveLength(fixture.expectedUsers.length);
+      expect(insetManyMock).toBeCalledWith(fixture.expectedUsers);
+    });
+  });
+});

--- a/src/backend/functions/__tests__/utils.test.ts
+++ b/src/backend/functions/__tests__/utils.test.ts
@@ -1,10 +1,34 @@
+import nanoid from 'nanoid';
 import UserRoles from 'src/backend/shared/constants/UserRoles';
-import { assignUserRole } from '../utils';
+import { assignUserRole, generateId } from '../utils';
+
+const mockGeneratedId = 'EFABDQ';
+const customAlphabetMock = jest.spyOn(nanoid, 'customAlphabet');
 
 describe('utils', () => {
-  it('assigns the user role of admin', () => {
-    const user = { email: 'admin@example.com' };
+  describe('assignUserRole', () => {
+    it('assigns the user role of admin', () => {
+      const user = { email: 'admin@example.com' };
 
-    expect(assignUserRole(user)).toEqual({ role: UserRoles.ADMIN });
+      expect(assignUserRole(user)).toEqual({ role: UserRoles.ADMIN });
+    });
+  });
+
+  describe('generateId', () => {
+    // arrange
+    const characters = 'ABCDEF';
+    customAlphabetMock.mockImplementation(() => () => mockGeneratedId);
+
+    it('should generate a random id with the default length', () => {
+      // act and assert
+      expect(generateId(characters)).toMatch(mockGeneratedId);
+      expect(customAlphabetMock).toBeCalledWith(characters, 6);
+    });
+
+    it.each([4, 8, 16, 21, 13])('should generate a random id for the given sizes', (size) => {
+      // act and assert
+      expect(generateId(characters, size)).toMatch(mockGeneratedId);
+      expect(customAlphabetMock).toBeCalledWith(characters, size);
+    });
   });
 });

--- a/src/backend/functions/users.ts
+++ b/src/backend/functions/users.ts
@@ -15,8 +15,6 @@ import * as Interfaces from '../controllers/utils/interfaces';
 import { UserSchema } from '../models/User';
 
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const topic = 'copy-firebase-users';
-
 const db = admin.firestore();
 
 /**
@@ -125,11 +123,9 @@ export const onUpdatePermissions = functions.https.onCall(async (data: UpdatePer
 /**
  * Copies existing firebase users to MongoDB
  *
- * @returns {Promise<String>}
+ * @returns {Promise<string>}
  */
-export const onCopyFirebaseUsers = functions.pubsub.topic(topic).onPublish(async () => {
-  const characters = `${alphabet}${new Date().valueOf()}`;
-
+export const onCopyFirebaseUsers = async (): Promise<string> => {
   const connection = await connectDatabase();
   const User = connection.model<Interfaces.User>('User', UserSchema);
 
@@ -139,6 +135,7 @@ export const onCopyFirebaseUsers = functions.pubsub.topic(topic).onPublish(async
   const newUsers = compact(
     firebaseUsers.map((user) => {
       if (!existingMongoUsers.some(({ id }) => id === user.id)) {
+        const characters = `${alphabet}${new Date().valueOf()}`;
         return { firebaseId: user.id, referralCode: generateId(characters) };
       }
       return null;
@@ -147,4 +144,4 @@ export const onCopyFirebaseUsers = functions.pubsub.topic(topic).onPublish(async
 
   await User.insertMany(newUsers);
   return Promise.resolve('Successfully copied firebase users');
-});
+};


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Refactor | No | N/A |

## Problem
A means to copy firebase users over to mongodb

## Solution
Configured firebase scheduler to run at 06:00 on day-of-month 10 in October [0 6 10 10 *](https://crontab.guru/#0_6_10_10_*).
  
## QA

- [x] Unit testing with jest

