### PR TITLE
Handle calculations for users and search by Firebase id

### DIFF
--- a/src/Core/Collections/IgboSoundbox/__tests__/SandboxAudioReviewer.test.tsx
+++ b/src/Core/Collections/IgboSoundbox/__tests__/SandboxAudioReviewer.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import * as reactAdmin from 'react-admin';
 import TestContext from 'src/__tests__/components/TestContext';
+import UserRoles from 'src/backend/shared/constants/UserRoles';
 import SandboxAudioReviewer from '../SandboxAudioReviewer';
 
 const examplePronunciations = [
@@ -15,7 +16,7 @@ describe('SandboxAudioReviewer', () => {
   it('render the speaker name for admin', async () => {
     jest
       .spyOn(reactAdmin, 'usePermissions')
-      .mockReturnValue({ loading: false, loaded: true, permissions: { role: 'admin' } });
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.ADMIN } });
     const mockOnApprove = jest.fn();
     const mockOnDeny = jest.fn();
     const { findByText } = render(
@@ -26,7 +27,7 @@ describe('SandboxAudioReviewer', () => {
         onDeny={mockOnDeny}
       >
         <SandboxAudioReviewer />
-      </TestContext>
+      </TestContext>,
     );
     await findByText('Admin Account');
     await findByText('Merger Account');
@@ -36,7 +37,7 @@ describe('SandboxAudioReviewer', () => {
   it('does not render the speaker name for merger', async () => {
     jest
       .spyOn(reactAdmin, 'usePermissions')
-      .mockReturnValue({ loading: false, loaded: true, permissions: { role: 'merger' } });
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.MERGER } });
     const mockOnApprove = jest.fn();
     const mockOnDeny = jest.fn();
     const { queryByText } = render(
@@ -47,7 +48,7 @@ describe('SandboxAudioReviewer', () => {
         onDeny={mockOnDeny}
       >
         <SandboxAudioReviewer />
-      </TestContext>
+      </TestContext>,
     );
     expect(await queryByText('Admin Account')).toBeNull();
     expect(await queryByText('Merger Account')).toBeNull();
@@ -57,7 +58,7 @@ describe('SandboxAudioReviewer', () => {
   it('does not render the speaker name for editor', async () => {
     jest
       .spyOn(reactAdmin, 'usePermissions')
-      .mockReturnValue({ loading: false, loaded: true, permissions: { role: 'editor' } });
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.EDITOR } });
     const mockOnApprove = jest.fn();
     const mockOnDeny = jest.fn();
     const { queryByText } = render(
@@ -68,7 +69,7 @@ describe('SandboxAudioReviewer', () => {
         onDeny={mockOnDeny}
       >
         <SandboxAudioReviewer />
-      </TestContext>
+      </TestContext>,
     );
     expect(await queryByText('Admin Account')).toBeNull();
     expect(await queryByText('Merger Account')).toBeNull();
@@ -78,7 +79,7 @@ describe('SandboxAudioReviewer', () => {
   it('does not render the speaker name for transcriber', async () => {
     jest
       .spyOn(reactAdmin, 'usePermissions')
-      .mockReturnValue({ loading: false, loaded: true, permissions: { role: 'transcriber' } });
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.TRANSCRIBER } });
     const mockOnApprove = jest.fn();
     const mockOnDeny = jest.fn();
     const { queryByText } = render(
@@ -89,7 +90,7 @@ describe('SandboxAudioReviewer', () => {
         onDeny={mockOnDeny}
       >
         <SandboxAudioReviewer />
-      </TestContext>
+      </TestContext>,
     );
     expect(await queryByText('Admin Account')).toBeNull();
     expect(await queryByText('Merger Account')).toBeNull();
@@ -99,7 +100,7 @@ describe('SandboxAudioReviewer', () => {
   it('does not render the speaker name for crowdsourcer', async () => {
     jest
       .spyOn(reactAdmin, 'usePermissions')
-      .mockReturnValue({ loading: false, loaded: true, permissions: { role: 'crowdsourcer' } });
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.CROWDSOURCER } });
     const mockOnApprove = jest.fn();
     const mockOnDeny = jest.fn();
     const { queryByText } = render(
@@ -110,7 +111,7 @@ describe('SandboxAudioReviewer', () => {
         onDeny={mockOnDeny}
       >
         <SandboxAudioReviewer />
-      </TestContext>
+      </TestContext>,
     );
     expect(await queryByText('Admin Account')).toBeNull();
     expect(await queryByText('Merger Account')).toBeNull();

--- a/src/Core/Dashboard/components/IgboSoundboxStats/IgboSoundboxStats.tsx
+++ b/src/Core/Dashboard/components/IgboSoundboxStats/IgboSoundboxStats.tsx
@@ -1,11 +1,24 @@
 import React, { ReactElement, useState } from 'react';
 import moment from 'moment';
-import { Box, Button } from '@chakra-ui/react';
+import { isNaN } from 'lodash';
+import { Box, Button, Text, chakra } from '@chakra-ui/react';
+import { usePermissions } from 'react-admin';
 import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';
 import ThumbDownOffAltIcon from '@mui/icons-material/ThumbDownOffAlt';
+import { hasAdminPermissions } from 'src/shared/utils/permissions';
+import { PRICE_PER_VERIFIED_RECORDING } from 'src/Core/constants';
 import LinearProgressCard from '../LinearProgressCard';
 
 const GOAL = 4000;
+
+/** Calculates the payment for the provided count */
+export const calculatePayment = (count: number): string => {
+  if (count <= 0 || isNaN(count) || typeof count !== 'number') {
+    return '$0.00';
+  }
+  return `$${((count || 0) * PRICE_PER_VERIFIED_RECORDING).toFixed(2)}`;
+};
+
 const IgboSoundboxStats = ({
   recordingStats,
   audioStats,
@@ -17,6 +30,8 @@ const IgboSoundboxStats = ({
   };
   audioStats: { audioApprovalsCount: number; audioDenialsCount: number };
 }): ReactElement => {
+  const permissions = usePermissions();
+  const showPaymentCalculations = hasAdminPermissions(permissions?.permissions, true);
   const [currentMonth, setCurrentMonth] = useState(moment().startOf('month').format('MMM, YYYY'));
   const stats = [
     {
@@ -82,7 +97,14 @@ const IgboSoundboxStats = ({
         stats={monthlyRecordedStat}
         isLoaded
         isGeneric
-      />
+      >
+        {showPaymentCalculations ? (
+          <Box>
+            <Text fontFamily="heading">Price to be paid to the user:</Text>
+            <chakra.span fontFamily="heading">{calculatePayment(monthlyRecordedStat[0].totalCount)}</chakra.span>
+          </Box>
+        ) : null}
+      </LinearProgressCard>
     </Box>
   );
 };

--- a/src/Core/Dashboard/components/IgboSoundboxStats/__tests__/IgboSoundboxStats.test.tsx
+++ b/src/Core/Dashboard/components/IgboSoundboxStats/__tests__/IgboSoundboxStats.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import moment from 'moment';
+import { render } from '@testing-library/react';
+import TestContext from 'src/__tests__/components/TestContext';
+import * as reactAdmin from 'react-admin';
+import UserRoles from 'src/backend/shared/constants/UserRoles';
+import IgboSoundboxStats, { calculatePayment } from '../IgboSoundboxStats';
+
+describe('IgboSoundboxStats', () => {
+  it('render the Igbo soundbox stats component as admin', async () => {
+    jest
+      .spyOn(reactAdmin, 'usePermissions')
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.ADMIN } });
+    const recordingStats = {
+      recorded: 10,
+      verified: 15,
+      allRecorded: {},
+    };
+    const audioStats = { audioApprovalsCount: 20, audioDenialsCount: 25 };
+    const { findByText } = render(
+      <TestContext>
+        <IgboSoundboxStats recordingStats={recordingStats} audioStats={audioStats} />
+      </TestContext>,
+    );
+
+    await findByText('Recorded example sentences');
+    await findByText('Verified example sentences');
+    await findByText('Approved audio recordings');
+    await findByText('Denied audio recordings');
+    await findByText('Monthly recorded example sentences');
+    await findByText('The number of recorded example sentences for each month');
+    await findByText('Previous month');
+    await findByText('Next month');
+    await findByText(`Total recorded audio for ${moment().format('MMM, YYYY')}`);
+    await findByText('Price to be paid to the user:');
+    await findByText('$0.00');
+    await findByText('10');
+    await findByText('15');
+    await findByText('20');
+    await findByText('25');
+    await findByText('-1');
+  });
+
+  it('hides the payment calculation for non admins', async () => {
+    jest
+      .spyOn(reactAdmin, 'usePermissions')
+      .mockReturnValue({ loading: false, loaded: true, permissions: { role: UserRoles.CROWDSOURCER } });
+    const recordingStats = {
+      recorded: 10,
+      verified: 15,
+      allRecorded: {},
+    };
+    const audioStats = { audioApprovalsCount: 20, audioDenialsCount: 25 };
+    const { findByText, queryByText } = render(
+      <TestContext>
+        <IgboSoundboxStats recordingStats={recordingStats} audioStats={audioStats} />
+      </TestContext>,
+    );
+
+    await findByText('Recorded example sentences');
+    await findByText('Verified example sentences');
+    await findByText('Approved audio recordings');
+    await findByText('Denied audio recordings');
+    await findByText('Monthly recorded example sentences');
+    await findByText('The number of recorded example sentences for each month');
+    await findByText('Previous month');
+    await findByText('Next month');
+    await findByText(`Total recorded audio for ${moment().format('MMM, YYYY')}`);
+    await findByText('10');
+    await findByText('15');
+    await findByText('20');
+    await findByText('25');
+    await findByText('-1');
+    expect(queryByText('Price to be paid to the user:')).toBeNull();
+    expect(queryByText('$0.00')).toBeNull();
+  });
+
+  it('calculates the expected payment', () => {
+    const count = 100;
+    expect(calculatePayment(count)).toEqual('$2.00');
+  });
+  it('returns no dollars for invalid string input', () => {
+    // @ts-expect-error
+    expect(calculatePayment('invalid')).toEqual('$0.00');
+  });
+  it('returns no dollars for invalid NaN input', () => {
+    expect(calculatePayment(parseInt('invalid', 10))).toEqual('$0.00');
+  });
+});

--- a/src/Core/Dashboard/components/LinearProgressCard/LinearProgressCard.tsx
+++ b/src/Core/Dashboard/components/LinearProgressCard/LinearProgressCard.tsx
@@ -9,6 +9,7 @@ const LinearProgressCard = ({
   stats,
   isLoaded,
   isGeneric = false,
+  children,
 }: LinearProgressCardInterface): ReactElement => (
   <Skeleton isLoaded={isLoaded}>
     <Box className="border bg-white space-y-3" borderRadius="md" borderColor="gray.300" p={5}>
@@ -24,6 +25,7 @@ const LinearProgressCard = ({
       {stats.map((stat) => (
         <StatBody key={stat.heading} isGeneric={isGeneric} {...stat} />
       ))}
+      {children}
     </Box>
   </Skeleton>
 );

--- a/src/Core/Dashboard/components/LinearProgressCard/LinearProgressCardInterface.ts
+++ b/src/Core/Dashboard/components/LinearProgressCard/LinearProgressCardInterface.ts
@@ -8,10 +8,11 @@ interface LinearProgressCard {
     goal: number;
     heading: string;
     description: string;
-    leftIcon: ReactElement;
+    leftIcon?: ReactElement;
   }[];
   isLoaded: boolean;
   isGeneric?: boolean;
+  children?: JSX.Element;
 }
 
 export default LinearProgressCard;

--- a/src/Core/Dashboard/components/LinearProgressCard/StatBody.tsx
+++ b/src/Core/Dashboard/components/LinearProgressCard/StatBody.tsx
@@ -17,7 +17,7 @@ const StatBody = ({
   description: string;
   heading: string;
   isGeneric: boolean;
-  leftIcon: ReactElement;
+  leftIcon?: ReactElement;
 }): ReactElement => {
   const totalCount = (rawTotalCount || 0).toLocaleString(undefined, { minimumFractionDigits: 0 });
   const goal = (rawGoal || 0).toLocaleString(undefined, { minimumFractionDigits: 0 });

--- a/src/Core/constants.ts
+++ b/src/Core/constants.ts
@@ -38,3 +38,6 @@ export const TOTAL_EXAMPLE_AUDIO_GOAL = 2000;
 export const TOTAL_EXAMPLE_SUGGESTION_AUDIO_GOAL = 100;
 
 export const BULK_UPLOAD_LIMIT = 500;
+
+/** Calculating payment prices */
+export const PRICE_PER_VERIFIED_RECORDING = 0.02;

--- a/src/backend/controllers/users.ts
+++ b/src/backend/controllers/users.ts
@@ -88,11 +88,11 @@ export const getUsers = async (
   try {
     const { skip, limit, filters } = await handleQueries(req);
     const users = (await findUsers()).filter((user) =>
-      // eslint-disable-next-line
-      Object.values(filters).every((value: string = '') => {
+      Object.values(filters).every((value: string) => {
         const displayName = (user.displayName || '').toLowerCase();
-        const { email } = user;
-        return displayName.includes(value.toLowerCase()) || email.includes(value.toLowerCase());
+        const { email, uid } = user;
+        // Finds users where the value matches their name, email, or Firebase id
+        return displayName.includes(value?.toLowerCase()) || email.includes(value?.toLowerCase()) || uid === value;
       }),
     );
     const paginatedUsers = users.slice(skip, skip + 1 + limit);


### PR DESCRIPTION
## Background
Admins are able to see how much the crowdsourcer should be getting per month. Additionally, admins are able to search for users by their Firebase id. 