### PR TITLE
Fix fetching speaker id for recorded audio

### DIFF
--- a/src/backend/controllers/users.ts
+++ b/src/backend/controllers/users.ts
@@ -175,10 +175,12 @@ export const getUserProfile = async (
 ): Promise<Response | void> => {
   try {
     const {
-      user: { uid },
+      user: { uid: userId, role },
+      params: { uid },
       mongooseConnection,
     } = await handleQueries(req);
-    const user = await findUser(uid);
+    const id = role === UserRoles.ADMIN ? uid : userId;
+    const user = await findUser(id);
     const Crowdsourcer = mongooseConnection.model<Interfaces.Crowdsourcer>('Crowdsourcer', crowdsourcerSchema);
     let crowdsourcer: Partial<Interfaces.Crowdsourcer> = await Crowdsourcer.findOne({
       firebaseId: uid,
@@ -197,7 +199,7 @@ export const getUserProfile = async (
     return res.status(200).send(userProfile);
   } catch (err) {
     console.log(err);
-    return next(new Error('An error occurred while getting the user profile'));
+    return next(new Error(`An error occurred while getting the user profile: ${err.message}`));
   }
 };
 

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -40,7 +40,7 @@ export interface HandleQueries {
 
 // @ts-expect-error EditorRequest
 export interface EditorRequest extends Request {
-  user: UserRecord;
+  user: UserRecord & { role: UserRoles };
   query: {
     keyword?: string;
     page?: number | string;

--- a/src/backend/routers/adminRouter.ts
+++ b/src/backend/routers/adminRouter.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getUserProfile, getUsers, testGetUsers } from '../controllers/users';
+import { getUsers, testGetUsers } from '../controllers/users';
 import { onSubmitConstructedTermPoll } from '../controllers/polls';
 import authentication from '../middleware/authentication';
 import authorization from '../middleware/authorization';
@@ -9,7 +9,6 @@ const adminRouter = express.Router();
 
 adminRouter.use(authentication, authorization([UserRoles.ADMIN]));
 adminRouter.get('/users', process.env.NODE_ENV === 'test' ? testGetUsers : getUsers);
-adminRouter.get('/users/:uid', getUserProfile);
 adminRouter.post('/twitter_poll', onSubmitConstructedTermPoll);
 
 export default adminRouter;

--- a/src/hooks/useFetchSpeakers.ts
+++ b/src/hooks/useFetchSpeakers.ts
@@ -20,7 +20,7 @@ const useFetchSpeakers = ({
       if (isAdmin) {
         setIsLoading(true);
         try {
-          const speakerProfiles = await Promise.all(speakerIds.map((speakerId) => getUserProfile(speakerId)));
+          const speakerProfiles = await Promise.all(speakerIds.map(getUserProfile));
           speakersRef.current = speakerProfiles;
         } catch (err) {
           speakersRef.current = [];


### PR DESCRIPTION
## Background
Handles the role field for the `user` request object field to be able to fetch the relevant user information for the speaker section for the example sentence audio.