### PR TITLE
chore: delete associated user and referral document upon deleting firebase user account

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -24,6 +24,7 @@ import {
   onCopyFirebaseUsers,
   onCreateUserAccount,
   onDeleteUser,
+  onDeleteUserAccount,
   onUpdatePermissions,
 } from './src/backend/functions/users';
 import { onRequestDeleteDocument, onUpdateDocument } from './src/backend/functions/documents';
@@ -68,6 +69,7 @@ server.get('**', (_, res) => {
 server.use(errorHandler);
 
 // Firebase Functions
+export const deleteUserAccount = onDeleteUserAccount;
 export const createUserAccount = onCreateUserAccount;
 export const updatePermissions = onUpdatePermissions;
 export const requestDeleteDocument = onRequestDeleteDocument;


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Feature |No | Closes #483 |

## Problem

Delete associated mongodb user and referral documents upon deleting the referenced firebase user


## Solution

Implementing a firebase trigger that is executed upon deleting a user account.
  
## QA
  
[x] Manually QA'd the solution
