### PR TITLE
feat: display crowdsourcer referral code in profile section

### DIFF
--- a/src/Core/Collections/iconography/Copy.tsx
+++ b/src/Core/Collections/iconography/Copy.tsx
@@ -1,0 +1,27 @@
+import { chakra } from '@chakra-ui/react';
+import React from 'react';
+import { IconProps } from './types';
+
+export const Copy: React.FC<IconProps> = ({ className, height = 8, stroke = 'gray.500', styles, width = 8 }) => (
+  <chakra.svg
+    className={className}
+    sx={{
+      ...styles,
+      '& path': {
+        stroke,
+      },
+    }}
+    width={width}
+    height={height}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.06699 2.16699C2.56994 2.16699 2.16699 2.56994 2.16699 3.06699V9.60032C2.16699 10.0974 2.56994 10.5003 3.06699 10.5003H5.50033V12.9337C5.50033 13.4307 5.90327 13.8337 6.40033 13.8337H12.9337C13.4307 13.8337 13.8337 13.4307 13.8337 12.9337V6.40033C13.8337 5.90327 13.4307 5.50033 12.9337 5.50033H10.5003V3.06699C10.5003 2.56994 10.0974 2.16699 9.60032 2.16699H3.06699ZM9.50033 5.50033V3.16699H3.16699V9.50033H5.50033V6.40033C5.50033 5.90327 5.90327 5.50033 6.40033 5.50033H9.50033ZM6.50033 10.0003V12.8337H12.8337V6.50033H10.0003H6.50033V10.0003Z"
+      fill={stroke}
+    />
+  </chakra.svg>
+);

--- a/src/Core/Collections/iconography/index.ts
+++ b/src/Core/Collections/iconography/index.ts
@@ -1,5 +1,6 @@
 export { ArrowBack } from './ArrowBack';
 export { Conflict } from './Conflict';
+export { Copy } from './Copy';
 export { Done } from './Done';
 export { Maginifier } from './Magnifier';
 export { Microphone } from './Microphone';

--- a/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
+++ b/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
@@ -8,20 +8,24 @@ export const RefferalCode = (): React.ReactElement => {
   const [referralCode, setReferralCode] = React.useState('');
   const ref = React.useRef<HTMLParagraphElement>();
 
+  const onCopyReferralCode = () => {
+    const { textContent: referralCode } = ref.current;
+
+    if (referralCode) {
+      const range = window.document.createRange();
+      range.selectNode(ref.current);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+
+      copyToClipboard({
+        copyText: referralCode,
+      });
+    }
+  };
+
   React.useEffect(() => {
     getReferralCode().then(setReferralCode);
   }, []);
-
-  const onCopyReferralCode = () => {
-    const range = window.document.createRange();
-    range.selectNode(ref.current);
-    window.getSelection().removeAllRanges();
-    window.getSelection().addRange(range);
-
-    copyToClipboard({
-      copyText: ref.current.textContent,
-    });
-  };
 
   return (
     <Box bg="gray.100" borderRadius="lg" w="100%" p={4} color="gray.700">

--- a/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
+++ b/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { getReferralCode } from '../../../../shared/CrowdsourcerAPI';
+
+export const RefferalCode = (): React.ReactElement => {
+  const [referralCode, setReferralCode] = React.useState('');
+  const ref = React.useRef<HTMLParagraphElement>();
+
+  React.useEffect(() => {
+    getReferralCode().then(setReferralCode);
+  }, []);
+
+  const onCopyReferralCode = () => {
+    const range = window.document.createRange();
+    range.selectNode(ref.current);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    window.navigator.clipboard.writeText(ref.current.textContent);
+  };
+
+  return (
+    <Box bg="gray.100" borderRadius="lg" w="100%" p={4} color="gray.700">
+      <Flex justifyContent="space-between">
+        <Flex direction="column" rowGap="2">
+          <Text ref={ref} fontWeight="700">
+            {referralCode}
+          </Text>
+          <Text fontWeight="400">This is your referral code</Text>
+        </Flex>
+        <Flex alignItems="center">
+          <Button backgroundColor="green.100" onClick={onCopyReferralCode}>
+            copy
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};

--- a/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
+++ b/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import { getReferralCode } from '../../../../shared/CrowdsourcerAPI';
 import copyToClipboard from '../../../../shared/utils/copyToClipboard';
+import * as Icons from '../../../Collections/iconography';
 
 export const RefferalCode = (): React.ReactElement => {
   const [referralCode, setReferralCode] = React.useState('');
@@ -32,7 +33,7 @@ export const RefferalCode = (): React.ReactElement => {
           <Text fontWeight="400">This is your referral code</Text>
         </Flex>
         <Flex alignItems="center">
-          <Button backgroundColor="green.100" onClick={onCopyReferralCode}>
+          <Button leftIcon={<Icons.Copy />} backgroundColor="green.100" onClick={onCopyReferralCode}>
             copy
           </Button>
         </Flex>

--- a/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
+++ b/src/Core/Dashboard/components/RefferalCode/RefferalCode.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import { getReferralCode } from '../../../../shared/CrowdsourcerAPI';
+import copyToClipboard from '../../../../shared/utils/copyToClipboard';
 
 export const RefferalCode = (): React.ReactElement => {
   const [referralCode, setReferralCode] = React.useState('');
@@ -15,7 +16,10 @@ export const RefferalCode = (): React.ReactElement => {
     range.selectNode(ref.current);
     window.getSelection().removeAllRanges();
     window.getSelection().addRange(range);
-    window.navigator.clipboard.writeText(ref.current.textContent);
+
+    copyToClipboard({
+      copyText: ref.current.textContent,
+    });
   };
 
   return (

--- a/src/Core/Dashboard/components/RefferalCode/index.ts
+++ b/src/Core/Dashboard/components/RefferalCode/index.ts
@@ -1,0 +1,1 @@
+export { RefferalCode } from './RefferalCode';

--- a/src/Core/Dashboard/components/UserStat/UserStat.tsx
+++ b/src/Core/Dashboard/components/UserStat/UserStat.tsx
@@ -13,6 +13,7 @@ import UserCard from 'src/shared/components/UserCard';
 import network from '../../network';
 import PersonalStats from '../PersonalStats/PersonalStats';
 import IgboSoundboxStats from '../IgboSoundboxStats';
+import { RefferalCode } from '../RefferalCode';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
@@ -64,6 +65,7 @@ const UserStat = ({
             <Box className="space-y-3 w-full">
               <IgboSoundboxStats recordingStats={recordingStats} audioStats={audioStats} />
               {!isCrowdsourcer ? <PersonalStats userStats={userStats} /> : null}
+              <RefferalCode />
             </Box>
           </Box>
         </Box>

--- a/src/shared/CrowdsourcerAPI.ts
+++ b/src/shared/CrowdsourcerAPI.ts
@@ -1,0 +1,14 @@
+import { Crowdsourcer } from 'src/backend/controllers/utils/interfaces';
+import Collection from './constants/Collection';
+import { request } from './utils/request';
+
+export const getReferralCode = async () => {
+  const {
+    data: { referralCode },
+  } = await request<Crowdsourcer>({
+    method: 'GET',
+    url: `${Collection.USERS}/referral`,
+  });
+
+  return referralCode;
+};

--- a/src/shared/CrowdsourcerAPI.ts
+++ b/src/shared/CrowdsourcerAPI.ts
@@ -2,7 +2,7 @@ import { Crowdsourcer } from 'src/backend/controllers/utils/interfaces';
 import Collection from './constants/Collection';
 import { request } from './utils/request';
 
-export const getReferralCode = async () => {
+export const getReferralCode = async (): Promise<string> => {
   const {
     data: { referralCode },
   } = await request<Crowdsourcer>({

--- a/src/shared/__tests__/CrowdsourcerAPI.test.ts
+++ b/src/shared/__tests__/CrowdsourcerAPI.test.ts
@@ -1,0 +1,24 @@
+import { getReferralCode } from '../CrowdsourcerAPI';
+import * as request from '../utils/request';
+
+const mockRequest = jest.spyOn(request, 'request');
+
+describe('CrowdsourcerAPI', () => {
+  describe('getReferralCode', () => {
+    it('should call request client with correct params', async () => {
+      // arrange
+      const referralCode = 'awesome-referral-code';
+      mockRequest.mockResolvedValueOnce({ data: { referralCode } } as any);
+
+      // act
+      const response = await getReferralCode();
+
+      // assert
+      expect(mockRequest).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'users/referral',
+      });
+      expect(response).toEqual(referralCode);
+    });
+  });
+});

--- a/src/shared/utils/copyToClipboard.ts
+++ b/src/shared/utils/copyToClipboard.ts
@@ -1,10 +1,13 @@
-const copyToClipboard = ({
-  copyText,
-  successMessage,
-} : {
-  copyText: string,
-  successMessage: string,
-}, toast: (value: any) => void): void => {
+const copyToClipboard = (
+  {
+    copyText,
+    successMessage,
+  }: {
+    copyText: string;
+    successMessage?: string;
+  },
+  toast?: (value: any) => void,
+): void => {
   if (window.navigator) {
     window.navigator.clipboard.writeText(copyText);
     if (toast) {

--- a/src/shared/utils/request.ts
+++ b/src/shared/utils/request.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { getAuth } from 'firebase/auth';
 import { API_ROUTE } from '../constants/index';
 
@@ -16,9 +16,9 @@ const createHeaders = async () => ({
   Authorization: await createAuthorizationHeader(),
 });
 
-export const request = async (requestObject: AxiosRequestConfig): Promise<any> => {
+export const request = async <T = any>(requestObject: AxiosRequestConfig): Promise<AxiosResponse<T>> => {
   const headers = await createHeaders();
-  return axios.request({
+  return axios.request<T>({
     ...requestObject,
     url: `${API_ROUTE}/${requestObject.url}`,
     headers,


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | Closes #482  |

## Problem

Give user's access to their referral code

## Solution

Rendered referral code in user's profile page and provided a `copy` functionality for UX purposes.

## Before & After Screenshots

![Screenshot 2023-11-05 at 18 04 25](https://github.com/nkowaokwu/igbo-api-admin/assets/15639127/581f5abf-7243-4509-b52e-f08890157544)

## QA
- [x] Manually QA'd the solution

## Other changes (e.g. bug fixes, UI tweaks, small refactors)
  
Made `axios instance` client flexible enough to return an actual response data type if specified.


