### PR TITLE
chore: replace yup with joi

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -54,8 +54,7 @@
     "twit": "^2.2.11",
     "twitter-api-v2": "^1.12.2",
     "urlencode": "^1.1.0",
-    "wave-visualizer": "^1.0.6",
-    "yup": "^0.32.8"
+    "wave-visualizer": "^1.0.6"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -135,8 +135,7 @@
     "twit": "^2.2.11",
     "twitter-api-v2": "^1.12.2",
     "urlencode": "^1.1.0",
-    "wave-visualizer": "^1.0.6",
-    "yup": "^0.32.8"
+    "wave-visualizer": "^1.0.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/src/shared/components/views/components/CorpusEditForm/CorpusEditFormResolver.ts
+++ b/src/shared/components/views/components/CorpusEditForm/CorpusEditFormResolver.ts
@@ -1,17 +1,17 @@
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
+import { joiResolver } from '@hookform/resolvers/joi';
+import Joi from 'joi';
 
-const schema = yup.object().shape({
-  title: yup.string(),
-  annotations: yup.array().of(yup.object()).optional(),
-  body: yup.string().optional(),
-  media: yup.string().nullable(),
-  tags: yup.array().min(0).of(yup.string()),
-  id: yup.string().optional(),
+const schema = Joi.object({
+  title: Joi.string(),
+  annotations: Joi.array().items(Joi.object()).optional(),
+  body: Joi.string().optional(),
+  media: Joi.string().allow(null),
+  tags: Joi.array().min(0).items(Joi.string()),
+  id: Joi.string().optional(),
 });
 
 const resolver = {
-  resolver: yupResolver(schema),
+  resolver: joiResolver(schema),
 };
 
 export default resolver;

--- a/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
+++ b/src/shared/components/views/components/ExampleEditForm/ExampleEditFormResolver.ts
@@ -1,53 +1,48 @@
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
+import { joiResolver } from '@hookform/resolvers/joi';
+import Joi from 'joi';
 import ExampleStyle from 'src/backend/shared/constants/ExampleStyle';
 
-export const ExampleEditFormSchema = yup.object().shape({
-  igbo: yup.string().required(),
-  english: yup.string(),
-  meaning: yup.string().optional(),
-  nsibidi: yup.string().optional(),
-  nsibidiCharacters: yup
-    .array()
+export const ExampleEditFormSchema = Joi.object({
+  igbo: Joi.string().required(),
+  english: Joi.string(),
+  meaning: Joi.string().optional(),
+  nsibidi: Joi.string().optional(),
+  nsibidiCharacters: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        id: yup.string(),
+    .items(
+      Joi.object({
+        id: Joi.string(),
       }),
     )
     .optional(),
-  style: yup
-    .object()
-    .shape({
-      value: yup.mixed().oneOf(Object.values(ExampleStyle).map(({ value }) => value)),
-      label: yup.mixed().oneOf(Object.values(ExampleStyle).map(({ label }) => label)),
-    })
-    .required(),
-  associatedWords: yup
-    .array()
+  style: Joi.object({
+    value: Joi.alternatives().try(...Object.values(ExampleStyle).map(({ value }) => value)),
+    label: Joi.alternatives().try(...Object.values(ExampleStyle).map(({ label }) => label)),
+  }).required(),
+  associatedWords: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        id: yup.string(),
+    .items(
+      Joi.object({
+        id: Joi.string(),
       }),
     ),
-  associatedDefinitionsSchemas: yup.array().min(0).of(yup.string()),
-  id: yup.string().optional(),
-  exampleId: yup.string().optional(),
-  originalExampleId: yup.string().nullable().optional(),
-  pronunciations: yup.array().of(
-    yup.object().shape({
-      audio: yup.string(),
-      speaker: yup.string().optional(),
-      approvals: yup.string().optional(),
-      denials: yup.string().optional(),
-      archived: yup.boolean(),
+  associatedDefinitionsSchemas: Joi.array().min(0).items(Joi.string()),
+  id: Joi.string().optional(),
+  exampleId: Joi.string().optional(),
+  originalExampleId: Joi.string().allow(null).optional(),
+  pronunciations: Joi.array().items(
+    Joi.object({
+      audio: Joi.string(),
+      speaker: Joi.string().optional(),
+      approvals: Joi.string().optional(),
+      denials: Joi.string().optional(),
+      archived: Joi.boolean(),
     }),
   ),
 });
 
 const resolver = {
-  resolver: yupResolver(ExampleEditFormSchema),
+  resolver: joiResolver(ExampleEditFormSchema),
 };
 
 export default resolver;

--- a/src/shared/components/views/components/NsibidiCharacterEditForm/NsibidiCharacterEditFormResolver.ts
+++ b/src/shared/components/views/components/NsibidiCharacterEditForm/NsibidiCharacterEditFormResolver.ts
@@ -1,31 +1,30 @@
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
+import { joiResolver } from '@hookform/resolvers/joi';
+import Joi from 'joi';
 import NsibidiCharacterAttributes from 'src/backend/shared/constants/NsibidiCharacterAttributes';
 
-const schema = yup.object().shape({
-  nsibidi: yup.string().required(),
-  attributes: yup.object().shape(
+const schema = Joi.object({
+  nsibidi: Joi.string().required(),
+  attributes: Joi.object(
     Object.entries(NsibidiCharacterAttributes).reduce(
       (finalAttributes, [, { value }]) => ({
         ...finalAttributes,
-        [value]: yup.boolean(),
+        [value]: Joi.boolean(),
       }),
       {},
     ),
   ),
-  radicals: yup
-    .array()
+  radicals: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        id: yup.string(),
+    .items(
+      Joi.object({
+        id: Joi.string(),
       }),
     )
     .optional(),
 });
 
 const resolver = (): any => ({
-  resolver: yupResolver(schema),
+  resolver: joiResolver(schema),
 });
 
 export default resolver;

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -1,5 +1,5 @@
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
+import { joiResolver } from '@hookform/resolvers/joi';
+import Joi from 'joi';
 import Tense from 'src/backend/shared/constants/Tense';
 import WordAttributes from 'src/backend/shared/constants/WordAttributes';
 import WordClass from 'src/backend/shared/constants/WordClass';
@@ -7,72 +7,63 @@ import WordAttributeEnum from 'src/backend/shared/constants/WordAttributeEnum';
 import WordTagEnum from 'src/backend/shared/constants/WordTagEnum';
 import { ExampleEditFormSchema } from '../ExampleEditForm/ExampleEditFormResolver';
 
-const schema = yup.object().shape({
-  attributes: yup.object().shape(
+const schema = Joi.object({
+  attributes: Joi.object(
     Object.entries(WordAttributes).reduce(
       (finalAttributes, [, { value }]) => ({
         ...finalAttributes,
         [value]:
           value === WordAttributeEnum.IS_SLANG || value === WordAttributeEnum.IS_CONSTRUCTED_TERM
-            ? yup.boolean().optional()
-            : yup.boolean(),
+            ? Joi.boolean().optional()
+            : Joi.boolean(),
       }),
       {},
     ),
   ),
-  word: yup.string().required(),
-  tags: yup
-    .array()
+  word: Joi.string().required(),
+  tags: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        value: yup.mixed().oneOf(Object.values(WordTagEnum)),
-        label: yup.string(),
+    .items(
+      Joi.object({
+        value: Joi.alternatives().try(...Object.values(WordTagEnum)),
+        label: Joi.string(),
       }),
     ),
-  definitions: yup
-    .array()
+  definitions: Joi.array()
     .min(1)
-    .of(
-      yup.object().shape({
-        wordClass: yup
-          .object()
-          .shape({
-            value: yup.mixed().oneOf(Object.values(WordClass).map(({ value }) => value)),
-            label: yup.mixed().oneOf(Object.values(WordClass).map(({ label }) => label)),
-          })
-          .required(),
-        nsibidi: yup.string().optional(),
-        nsibidiCharacters: yup
-          .array()
+    .items(
+      Joi.object({
+        wordClass: Joi.object({
+          value: Joi.alternatives().try(...Object.values(WordClass).map(({ value }) => value)),
+          label: Joi.alternatives().try(...Object.values(WordClass).map(({ label }) => label)),
+        }).required(),
+        nsibidi: Joi.string().optional(),
+        nsibidiCharacters: Joi.array()
           .min(0)
-          .of(
-            yup.object().shape({
-              id: yup.string(),
+          .items(
+            Joi.object({
+              id: Joi.string(),
             }),
           )
           .optional(),
-        definitions: yup
-          .array()
+        definitions: Joi.array()
           .min(0)
-          .of(
-            yup.object().shape({
-              text: yup.string(),
+          .items(
+            Joi.object({
+              text: Joi.string(),
             }),
           ),
-        igboDefinitions: yup
-          .array()
+        igboDefinitions: Joi.array()
           .min(0)
-          .of(
-            yup.object().shape({
-              igbo: yup.string().optional(),
-              nsibidi: yup.string().optional(),
-              nsibidiCharacters: yup
-                .array()
+          .items(
+            Joi.object({
+              igbo: Joi.string().optional(),
+              nsibidi: Joi.string().optional(),
+              nsibidiCharacters: Joi.array()
                 .min(0)
-                .of(
-                  yup.object().shape({
-                    id: yup.string(),
+                .items(
+                  Joi.object({
+                    id: Joi.string(),
                   }),
                 )
                 .optional(),
@@ -81,61 +72,54 @@ const schema = yup.object().shape({
           .optional(),
       }),
     ),
-  variations: yup
-    .array()
+  variations: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        text: yup.string(),
+    .items(
+      Joi.object({
+        text: Joi.string(),
       }),
     ),
-  dialects: yup
-    .array()
+  dialects: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        dialects: yup.array().min(1).of(yup.string()),
-        variations: yup.array().min(0).of(yup.string()).optional(),
-        pronunciation: yup.string().optional(),
-        word: yup.string(),
+    .items(
+      Joi.object({
+        dialects: Joi.array().min(1).items(Joi.string()),
+        variations: Joi.array().min(0).items(Joi.string()).optional(),
+        pronunciation: Joi.string().optional(),
+        word: Joi.string(),
       }),
     ),
-  tenses: yup
-    .object()
-    .shape(
-      Object.values(Tense).reduce(
-        (finalSchema, tenseValue) => ({
-          ...finalSchema,
-          [tenseValue.value]: yup.string().optional(),
-        }),
-        {},
-      ),
-    )
-    .optional(),
-  stems: yup
-    .array()
+  tenses: Joi.object(
+    Object.values(Tense).reduce(
+      (finalSchema, tenseValue) => ({
+        ...finalSchema,
+        [tenseValue.value]: Joi.string().optional(),
+      }),
+      {},
+    ),
+  ).optional(),
+  stems: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        id: yup.string(),
+    .items(
+      Joi.object({
+        id: Joi.string(),
       }),
     ),
-  relatedTerms: yup
-    .array()
+  relatedTerms: Joi.array()
     .min(0)
-    .of(
-      yup.object().shape({
-        id: yup.string(),
+    .items(
+      Joi.object({
+        id: Joi.string(),
       }),
     ),
-  pronunciation: yup.string().optional(),
-  twitterPollId: yup.string().optional(),
-  frequency: yup.number().min(1).max(5),
-  examples: yup.array().min(0).of(ExampleEditFormSchema),
+  pronunciation: Joi.string().optional(),
+  twitterPollId: Joi.string().optional(),
+  frequency: Joi.number().min(1).max(5),
+  examples: Joi.array().min(0).items(ExampleEditFormSchema),
 });
 
 const resolver = (): any => ({
-  resolver: yupResolver(schema),
+  resolver: joiResolver(schema),
 });
 
 export default resolver;


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready | Refactor | No | Closes #308 |

## Problem

We currently have 2 validation libraries in the codebase. yup for the frontend and Joi for the backend. This means an unnecessarily larger bundle size


## Solution

Remove yup and use Joi for all validation
 
## QA
<!-- How did you test your solution? -->
  
[ ] Wrote or updated Jest or Cypress test(s)?
[x] Manually QA'd the solution
[ ] etc.


## Other changes (e.g. bug fixes, UI tweaks, small refactors)
 
uninstalled yup