### PR TITLE
Fix bug where admin is seeing their own stats instead of current user stats

### DIFF
--- a/src/backend/controllers/__tests__/stats.test.ts
+++ b/src/backend/controllers/__tests__/stats.test.ts
@@ -14,215 +14,365 @@ import ReviewActions from 'src/backend/shared/constants/ReviewActions';
 import StatTypes from 'src/backend/shared/constants/StatTypes';
 import { connectDatabase, disconnectDatabase } from 'src/backend/utils/database';
 import { dropMongoDBCollections } from 'src/__tests__/shared';
-import { putReviewForRandomExampleSuggestions, suggestNewExample } from 'src/__tests__/shared/commands';
+import {
+  putReviewForRandomExampleSuggestions,
+  suggestNewExample,
+  getUserAudioStats as getUserAudioStatsCommand,
+} from 'src/__tests__/shared/commands';
 import { AUTH_TOKEN } from 'src/__tests__/shared/constants';
 import { exampleSuggestionData } from 'src/__tests__/__mocks__/documentData';
 import { allUsers } from 'src/__tests__/__mocks__/user_data';
 import * as Interfaces from '../utils/interfaces';
 
 describe('Stats', () => {
-  beforeEach(async () => {
-    // Clear out database to start with a clean slate
-    await dropMongoDBCollections();
-    jest.spyOn(admin, 'auth').mockReturnValue({
-      listUsers: jest.fn(async () => ({ users: allUsers })),
-      getUser: jest.fn(async (uid: string) => allUsers.find(({ uid: userId }) => userId === uid)),
+  describe('Stats Controller', () => {
+    beforeEach(async () => {
+      // Clear out database to start with a clean slate
+      await dropMongoDBCollections();
+      jest.spyOn(admin, 'auth').mockReturnValue({
+        listUsers: jest.fn(async () => ({ users: allUsers })),
+        getUser: jest.fn(async (uid: string) => allUsers.find(({ uid: userId }) => userId === uid)),
+      });
     });
-  });
-  it('calculates the total number of hours of example audio', async () => {
-    const connection = await connectDatabase();
-    const Example = connection.model<Interfaces.Example>('Example', exampleSchema);
-    const AudioPronunciation = connection.model<Interfaces.AudioPronunciation>(
-      'AudioPronunciation',
-      audioPronunciationSchema,
-    );
+    it('calculates the total number of hours of example audio', async () => {
+      const connection = await connectDatabase();
+      const Example = connection.model<Interfaces.Example>('Example', exampleSchema);
+      const AudioPronunciation = connection.model<Interfaces.AudioPronunciation>(
+        'AudioPronunciation',
+        audioPronunciationSchema,
+      );
 
-    const example = new Example({
-      exampleSuggestionData,
-      pronunciations: [{ audio: 'https://test.com/audio-pronunciations/first-audio.mp3', speaker: '' }],
-    });
-    await example.save();
-    const audioPronunciation = new AudioPronunciation({
-      objectId: 'audio-pronunciations/first-audio.mp3',
-      size: 160000000,
-    });
+      const example = new Example({
+        exampleSuggestionData,
+        pronunciations: [{ audio: 'https://test.com/audio-pronunciations/first-audio.mp3', speaker: '' }],
+      });
+      await example.save();
+      const audioPronunciation = new AudioPronunciation({
+        objectId: 'audio-pronunciations/first-audio.mp3',
+        size: 160000000,
+      });
 
-    await audioPronunciation.save();
-    expect((await onUpdateTotalAudioDashboardStats())[0].totalExampleAudio).toBeGreaterThanOrEqual(1);
-    expect((await onUpdateTotalAudioDashboardStats())[1].totalExampleSuggestionAudio).toBeLessThanOrEqual(0);
-    await disconnectDatabase();
-  });
-
-  it('calculates the total number of hours of example suggestion audio', async () => {
-    const connection = await connectDatabase();
-    const ExampleSuggestion = connection.model<Interfaces.ExampleSuggestion>(
-      'ExampleSuggestion',
-      exampleSuggestionSchema,
-    );
-    const AudioPronunciation = connection.model<Interfaces.AudioPronunciation>(
-      'AudioPronunciation',
-      audioPronunciationSchema,
-    );
-
-    const example = new ExampleSuggestion({
-      exampleSuggestionData,
-      pronunciations: [{ audio: 'https://test.com/audio-pronunciations/first-audio.mp3', speaker: '', review: true }],
-    });
-    const response = await example.save();
-    const audioPronunciation = new AudioPronunciation({
-      objectId: response.pronunciations[0].audio.split(/.com\//)[1],
-      size: 160000000,
+      await audioPronunciation.save();
+      expect((await onUpdateTotalAudioDashboardStats())[0].totalExampleAudio).toBeGreaterThanOrEqual(1);
+      expect((await onUpdateTotalAudioDashboardStats())[1].totalExampleSuggestionAudio).toBeLessThanOrEqual(0);
+      await disconnectDatabase();
     });
 
-    await audioPronunciation.save();
-    expect((await onUpdateTotalAudioDashboardStats())[0].totalExampleAudio).toBeLessThanOrEqual(0);
-    expect((await onUpdateTotalAudioDashboardStats())[1].totalExampleSuggestionAudio).toBeGreaterThanOrEqual(1);
-  });
+    it('calculates the total number of hours of example suggestion audio', async () => {
+      const connection = await connectDatabase();
+      const ExampleSuggestion = connection.model<Interfaces.ExampleSuggestion>(
+        'ExampleSuggestion',
+        exampleSuggestionSchema,
+      );
+      const AudioPronunciation = connection.model<Interfaces.AudioPronunciation>(
+        'AudioPronunciation',
+        audioPronunciationSchema,
+      );
 
-  it('returns all the login stats', async () => {
-    const mongooseConnection = await connectDatabase();
-    const sendMock = jest.fn();
-    const Stat = mongooseConnection.model<Interfaces.Stat>('Stat', statSchema);
-    const userStat = new Stat({ type: StatTypes.TOTAL_USERS, value: 0 });
-    const exampleAudioStat = new Stat({ type: StatTypes.TOTAL_EXAMPLE_AUDIO, value: 50 });
-    const exampleSuggestionStat = new Stat({ type: StatTypes.TOTAL_EXAMPLE_SUGGESTION_AUDIO, value: 50 });
-    await userStat.save();
-    await exampleAudioStat.save();
-    await exampleSuggestionStat.save();
+      const example = new ExampleSuggestion({
+        exampleSuggestionData,
+        pronunciations: [{ audio: 'https://test.com/audio-pronunciations/first-audio.mp3', speaker: '', review: true }],
+      });
+      const response = await example.save();
+      const audioPronunciation = new AudioPronunciation({
+        objectId: response.pronunciations[0].audio.split(/.com\//)[1],
+        size: 160000000,
+      });
 
-    await incrementTotalUserStat();
-    // @ts-expect-error mongooseConnection
-    await getLoginStats({ mongooseConnection }, { send: sendMock }, () => null);
-    expect(sendMock).toBeCalledWith({
-      hours: 100,
-      volunteers: 1,
+      await audioPronunciation.save();
+      expect((await onUpdateTotalAudioDashboardStats())[0].totalExampleAudio).toBeLessThanOrEqual(0);
+      expect((await onUpdateTotalAudioDashboardStats())[1].totalExampleSuggestionAudio).toBeGreaterThanOrEqual(1);
     });
-    await disconnectDatabase();
-  });
 
-  it('increments the total number of users', async () => {
-    const connection = await connectDatabase();
-    const Stat = connection.model<Interfaces.Stat>('Stat', statSchema);
-    const newStat = new Stat({ type: StatTypes.TOTAL_USERS, value: 0 });
-    await newStat.save();
-    const stat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
-    expect(stat.value).toEqual(0);
-    await incrementTotalUserStat();
-    const updatedStat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
-    expect(updatedStat.value).toEqual(1);
-    await disconnectDatabase();
-  });
+    it('returns all the login stats', async () => {
+      const mongooseConnection = await connectDatabase();
+      const sendMock = jest.fn();
+      const Stat = mongooseConnection.model<Interfaces.Stat>('Stat', statSchema);
+      const userStat = new Stat({ type: StatTypes.TOTAL_USERS, value: 0 });
+      const exampleAudioStat = new Stat({ type: StatTypes.TOTAL_EXAMPLE_AUDIO, value: 50 });
+      const exampleSuggestionStat = new Stat({ type: StatTypes.TOTAL_EXAMPLE_SUGGESTION_AUDIO, value: 50 });
+      await userStat.save();
+      await exampleAudioStat.save();
+      await exampleSuggestionStat.save();
 
-  it('decrements the total number of users', async () => {
-    const connection = await connectDatabase();
-    const Stat = connection.model<Interfaces.Stat>('Stat', statSchema);
-    const newStat = new Stat({ type: StatTypes.TOTAL_USERS, value: 0 });
-    await newStat.save();
-    const stat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
-    expect(stat.value).toEqual(0);
-    await decrementTotalUserStat();
-    const updatedStat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
-    expect(updatedStat.value).toEqual(0);
-    await incrementTotalUserStat();
-    await incrementTotalUserStat();
-    const finalStat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
-    expect(finalStat.value).toEqual(2);
-    await disconnectDatabase();
-  });
-
-  it("gets the user's approved audio stats", async () => {
-    const mongooseConnection = await connectDatabase();
-    const exampleSuggestionRes = await suggestNewExample({
-      ...exampleSuggestionData,
-      pronunciations: [
-        {
-          audio: 'first audio',
-          speaker: AUTH_TOKEN.ADMIN_AUTH_TOKEN,
-        },
-      ],
+      await incrementTotalUserStat();
+      // @ts-expect-error mongooseConnection
+      await getLoginStats({ mongooseConnection }, { send: sendMock }, () => null);
+      expect(sendMock).toBeCalledWith({
+        hours: 100,
+        volunteers: 1,
+      });
+      await disconnectDatabase();
     });
-    expect(exampleSuggestionRes.status).toEqual(200);
-    const mergerRes = await putReviewForRandomExampleSuggestions(
-      [
-        {
-          id: exampleSuggestionRes.body.id,
-          reviews: {
-            [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.APPROVE,
+
+    it('increments the total number of users', async () => {
+      const connection = await connectDatabase();
+      const Stat = connection.model<Interfaces.Stat>('Stat', statSchema);
+      const newStat = new Stat({ type: StatTypes.TOTAL_USERS, value: 0 });
+      await newStat.save();
+      const stat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
+      expect(stat.value).toEqual(0);
+      await incrementTotalUserStat();
+      const updatedStat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
+      expect(updatedStat.value).toEqual(1);
+      await disconnectDatabase();
+    });
+
+    it('decrements the total number of users', async () => {
+      const connection = await connectDatabase();
+      const Stat = connection.model<Interfaces.Stat>('Stat', statSchema);
+      const newStat = new Stat({ type: StatTypes.TOTAL_USERS, value: 0 });
+      await newStat.save();
+      const stat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
+      expect(stat.value).toEqual(0);
+      await decrementTotalUserStat();
+      const updatedStat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
+      expect(updatedStat.value).toEqual(0);
+      await incrementTotalUserStat();
+      await incrementTotalUserStat();
+      const finalStat = await Stat.findOne({ type: StatTypes.TOTAL_USERS });
+      expect(finalStat.value).toEqual(2);
+      await disconnectDatabase();
+    });
+
+    it("gets the user's approved audio stats", async () => {
+      const mongooseConnection = await connectDatabase();
+      const exampleSuggestionRes = await suggestNewExample({
+        ...exampleSuggestionData,
+        pronunciations: [
+          {
+            audio: 'first audio',
+            speaker: AUTH_TOKEN.ADMIN_AUTH_TOKEN,
           },
-        },
-      ],
-      { token: AUTH_TOKEN.MERGER_AUTH_TOKEN },
-    );
-    expect(mergerRes.status).toEqual(200);
-    const editorRes = await putReviewForRandomExampleSuggestions(
-      [
-        {
-          id: exampleSuggestionRes.body.id,
-          reviews: {
-            [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.APPROVE,
+        ],
+      });
+      expect(exampleSuggestionRes.status).toEqual(200);
+      const mergerRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.APPROVE,
+            },
           },
-        },
-      ],
-      { token: AUTH_TOKEN.EDITOR_AUTH_TOKEN },
-    );
-    expect(editorRes.status).toEqual(200);
+        ],
+        { token: AUTH_TOKEN.MERGER_AUTH_TOKEN },
+      );
+      expect(mergerRes.status).toEqual(200);
+      const editorRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.APPROVE,
+            },
+          },
+        ],
+        { token: AUTH_TOKEN.EDITOR_AUTH_TOKEN },
+      );
+      expect(editorRes.status).toEqual(200);
 
-    const mockRes = {
-      send: jest.fn(),
-    };
-    const mockNext = jest.fn();
-    await getUserAudioStats(
-      // @ts-expect-error
-      { mongooseConnection, user: { uid: AUTH_TOKEN.ADMIN_AUTH_TOKEN } },
-      mockRes,
-      mockNext,
-    );
-    expect(mockRes.send).toBeCalledWith({
-      audioApprovalsCount: 1,
-      audioDenialsCount: 0,
+      const mockRes = {
+        send: jest.fn(),
+      };
+      const mockNext = jest.fn();
+      await getUserAudioStats(
+        // @ts-expect-error
+        { mongooseConnection, user: { uid: AUTH_TOKEN.ADMIN_AUTH_TOKEN } },
+        mockRes,
+        mockNext,
+      );
+      expect(mockRes.send).toBeCalledWith({
+        audioApprovalsCount: 1,
+        audioDenialsCount: 0,
+      });
+      await disconnectDatabase();
     });
-    await disconnectDatabase();
+
+    it("gets the user's denied audio stats", async () => {
+      const mongooseConnection = await connectDatabase();
+      const exampleSuggestionRes = await suggestNewExample({
+        ...exampleSuggestionData,
+        pronunciations: [
+          {
+            audio: 'first audio',
+            speaker: AUTH_TOKEN.ADMIN_AUTH_TOKEN,
+          },
+        ],
+      });
+      expect(exampleSuggestionRes.status).toEqual(200);
+      const mergerRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.DENY,
+            },
+          },
+        ],
+        { token: AUTH_TOKEN.MERGER_AUTH_TOKEN },
+      );
+      expect(mergerRes.status).toEqual(200);
+
+      const mockRes = {
+        send: jest.fn(),
+      };
+      const mockNext = jest.fn();
+      await getUserAudioStats(
+        // @ts-expect-error
+        { mongooseConnection, user: { uid: AUTH_TOKEN.ADMIN_AUTH_TOKEN } },
+        mockRes,
+        mockNext,
+      );
+      expect(mockRes.send).toBeCalledWith({
+        audioApprovalsCount: 0,
+        audioDenialsCount: 1,
+      });
+      await disconnectDatabase();
+    });
+
+    it("gets another user's denied audio stats as the admin", async () => {
+      const mongooseConnection = await connectDatabase();
+      const exampleSuggestionRes = await suggestNewExample({
+        ...exampleSuggestionData,
+        pronunciations: [
+          {
+            audio: 'first audio',
+            speaker: AUTH_TOKEN.MERGER_AUTH_TOKEN,
+          },
+        ],
+      });
+      expect(exampleSuggestionRes.status).toEqual(200);
+      const mergerRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.DENY,
+            },
+          },
+        ],
+        { token: AUTH_TOKEN.ADMIN_AUTH_TOKEN },
+      );
+      expect(mergerRes.status).toEqual(200);
+
+      const mockRes = {
+        send: jest.fn(),
+      };
+      const mockNext = jest.fn();
+      await getUserAudioStats(
+        {
+          mongooseConnection,
+          params: { uid: AUTH_TOKEN.MERGER_AUTH_TOKEN },
+          // @ts-expect-error
+          user: { uid: AUTH_TOKEN.ADMIN_AUTH_TOKEN },
+        },
+        mockRes,
+        mockNext,
+      );
+      expect(mockRes.send).toBeCalledWith({
+        audioApprovalsCount: 0,
+        audioDenialsCount: 1,
+      });
+      await disconnectDatabase();
+    });
   });
 
-  it("gets the user's denied audio stats", async () => {
-    const mongooseConnection = await connectDatabase();
-    const exampleSuggestionRes = await suggestNewExample({
-      ...exampleSuggestionData,
-      pronunciations: [
-        {
-          audio: 'first audio',
-          speaker: AUTH_TOKEN.ADMIN_AUTH_TOKEN,
-        },
-      ],
+  // TODO: write test for network request getUserMergeStats
+  describe('Stats Network', () => {
+    beforeEach(async () => {
+      // Clear out database to start with a clean slate
+      await dropMongoDBCollections();
+      jest.spyOn(admin, 'auth').mockReturnValue({
+        listUsers: jest.fn(async () => ({ users: allUsers })),
+        getUser: jest.fn(async (uid: string) => allUsers.find(({ uid: userId }) => userId === uid)),
+      });
     });
-    expect(exampleSuggestionRes.status).toEqual(200);
-    const mergerRes = await putReviewForRandomExampleSuggestions(
-      [
-        {
-          id: exampleSuggestionRes.body.id,
-          reviews: {
-            [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.DENY,
-          },
-        },
-      ],
-      { token: AUTH_TOKEN.MERGER_AUTH_TOKEN },
-    );
-    expect(mergerRes.status).toEqual(200);
 
-    const mockRes = {
-      send: jest.fn(),
-    };
-    const mockNext = jest.fn();
-    await getUserAudioStats(
-      // @ts-expect-error
-      { mongooseConnection, user: { uid: AUTH_TOKEN.ADMIN_AUTH_TOKEN } },
-      mockRes,
-      mockNext,
-    );
-    expect(mockRes.send).toBeCalledWith({
-      audioApprovalsCount: 0,
-      audioDenialsCount: 1,
+    it('fetches user audio stats', async () => {
+      const exampleSuggestionRes = await suggestNewExample({
+        ...exampleSuggestionData,
+        pronunciations: [
+          {
+            audio: 'first audio',
+            speaker: AUTH_TOKEN.MERGER_AUTH_TOKEN,
+          },
+        ],
+      });
+      expect(exampleSuggestionRes.status).toEqual(200);
+      const mergerRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.DENY,
+            },
+          },
+        ],
+        { token: AUTH_TOKEN.ADMIN_AUTH_TOKEN },
+      );
+      expect(mergerRes.status).toEqual(200);
+
+      const res = await getUserAudioStatsCommand(AUTH_TOKEN.MERGER_AUTH_TOKEN, { token: AUTH_TOKEN.MERGER_AUTH_TOKEN });
+      expect(res.status).toEqual(200);
+      expect(res.body).toEqual({ audioApprovalsCount: 0, audioDenialsCount: 1 });
     });
-    await disconnectDatabase();
+
+    it('fetches another user audio stats as admin', async () => {
+      const exampleSuggestionRes = await suggestNewExample({
+        ...exampleSuggestionData,
+        pronunciations: [
+          {
+            audio: 'first audio',
+            speaker: AUTH_TOKEN.MERGER_AUTH_TOKEN,
+          },
+        ],
+      });
+      expect(exampleSuggestionRes.status).toEqual(200);
+      const mergerRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.DENY,
+            },
+          },
+        ],
+        { token: AUTH_TOKEN.ADMIN_AUTH_TOKEN },
+      );
+      expect(mergerRes.status).toEqual(200);
+
+      const res = await getUserAudioStatsCommand(AUTH_TOKEN.MERGER_AUTH_TOKEN);
+      expect(res.status).toEqual(200);
+      expect(res.body).toEqual({ audioApprovalsCount: 0, audioDenialsCount: 1 });
+    });
+
+    it('fails to fetch another user audio stats as editor', async () => {
+      const exampleSuggestionRes = await suggestNewExample({
+        ...exampleSuggestionData,
+        pronunciations: [
+          {
+            audio: 'first audio',
+            speaker: AUTH_TOKEN.MERGER_AUTH_TOKEN,
+          },
+        ],
+      });
+      expect(exampleSuggestionRes.status).toEqual(200);
+      const mergerRes = await putReviewForRandomExampleSuggestions(
+        [
+          {
+            id: exampleSuggestionRes.body.id,
+            reviews: {
+              [exampleSuggestionRes.body.pronunciations[0]._id]: ReviewActions.DENY,
+            },
+          },
+        ],
+        { token: AUTH_TOKEN.ADMIN_AUTH_TOKEN },
+      );
+      expect(mergerRes.status).toEqual(200);
+
+      const res = await getUserAudioStatsCommand(AUTH_TOKEN.MERGER_AUTH_TOKEN, { token: AUTH_TOKEN.EDITOR_AUTH_TOKEN });
+      expect(res.status).toEqual(403);
+    });
   });
 });

--- a/src/backend/controllers/exampleSuggestions/index.ts
+++ b/src/backend/controllers/exampleSuggestions/index.ts
@@ -709,11 +709,6 @@ export const putReviewForRandomExampleSuggestions = async (
           return null;
         });
         const savedExampleSuggestion = await exampleSuggestion.save();
-        console.log(
-          'saved',
-          savedExampleSuggestion.pronunciations[0].approvals,
-          savedExampleSuggestion.pronunciations[0].denials,
-        );
 
         // Automatically merge ExampleSuggestion
         await automaticallyMergeExampleSuggestion({

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -477,7 +477,7 @@ export const getUserAudioStats = async (
 ): Promise<Response<any> | void> => {
   const {
     mongooseConnection,
-    user: { uid },
+    params: { uid },
   } = req;
   try {
     const ExampleSuggestion = await mongooseConnection.model<Interfaces.ExampleSuggestion>(

--- a/src/backend/middleware/resourcePermission.ts
+++ b/src/backend/middleware/resourcePermission.ts
@@ -3,13 +3,9 @@ import * as Interfaces from 'src/backend/controllers/utils/interfaces';
 import UserRoles from '../shared/constants/UserRoles';
 
 /* Checks if the provided uid's resources can be accessed by the current requesting user */
-const resourcePermission = (
-  req: Interfaces.EditorRequest,
-  res: Response,
-  next: NextFunction,
-): Response | void => {
-  const { user = {}, query } = req;
-  const uidQuery = query.uid;
+const resourcePermission = (req: Interfaces.EditorRequest, res: Response, next: NextFunction): Response | void => {
+  const { user = {}, query, params } = req;
+  const uidQuery = query.uid || params.uid;
 
   // The requesting user is attempt to access their own resources
   if (uidQuery && user.uid === uidQuery) {
@@ -26,9 +22,7 @@ const resourcePermission = (
     return next();
   }
 
-  return res
-    .status(403)
-    .send({ error: 'Unauthorized. Invalid user permissions to view the requested resource.' });
+  return res.status(403).send({ error: 'Unauthorized. Invalid user permissions to view the requested resource.' });
 };
 
 export default resourcePermission;

--- a/src/backend/routers/crowdsourcerRouter.ts
+++ b/src/backend/routers/crowdsourcerRouter.ts
@@ -106,8 +106,8 @@ crowdsourcerRouter.post(`/${Collection.TEXT_IMAGES}`, validateTextImages, postTe
 // TODO: use the new resourcePermission middleware to only grant
 // access to stats to the user who owns the stats or the admin
 crowdsourcerRouter.get(`/${Collection.STATS}/user`, cacheControl, getUserStats);
-crowdsourcerRouter.get(`/${Collection.STATS}/users/:uid/merge`, getUserMergeStats);
-crowdsourcerRouter.get(`/${Collection.STATS}/users/:uid/audio`, getUserAudioStats);
+crowdsourcerRouter.get(`/${Collection.STATS}/users/:uid/merge`, resourcePermission, getUserMergeStats);
+crowdsourcerRouter.get(`/${Collection.STATS}/users/:uid/audio`, resourcePermission, getUserAudioStats);
 crowdsourcerRouter.get(`/${Collection.STATS}/users/:uid`, cacheControl, getUserStats);
 
 // Leaderboard


### PR DESCRIPTION
## Background
Admins have been seeing their Community Reviews stats instead of the current user's stats. This PR fixes this bug and introduces tests to make sure that this bug doesn't happen again.