### PR TITLE
bug: try fixing github actions builld

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: CI Integration
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 env:
   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Ticket |
| :---: | :---: | :---: | :--: |
| Ready| Tooling | No | Closes #519 |

## Problem

Github actions build fails when trying to merge a PR from a fork. Apparently environment secrets are not avaiable when running a build for PRs from forks.


## Solution
Change `pull_request` event to `pull_request_target` in .github's integrations.yml file


## QA
How did you test your solution?
  
[ ] Wrote or updated Jest or Cypress test(s)?
[x] Manually QA'd the solution
[ ] etc.