### PR TITLE
Optimize bulk uploading logic to improve upload times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ cypress/videos
 
 # ESLint
 .eslintcache
+
+# NVM
+.nvmrc

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "firebase": "9.8.4",
     "firebase-admin": "10.3.0",
     "firebase-functions": "3.19.0",
-    "firebase-tools": "11.1.0",
+    "firebase-tools": "11.30.0",
     "framer-motion": "^4",
     "functions": "^1.0.9",
     "joi": "^17.7.0",

--- a/src/backend/controllers/exampleSuggestions/__tests__/index.test.ts
+++ b/src/backend/controllers/exampleSuggestions/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import {
   getTotalRecordedExampleSuggestions,
   getTotalMergedRecordedExampleSuggestions,
   getRandomExampleSuggestionsToReview,
+  postBulkUploadExampleSuggestions,
 } from 'src/backend/controllers/exampleSuggestions';
 import updateExampleSuggestion from 'src/backend/controllers/exampleSuggestions/helpers/updateExampleSuggestion';
 import * as Interfaces from 'src/backend/controllers/utils/interfaces';
@@ -566,6 +567,35 @@ describe('exampleSuggestions controller', () => {
 
       await getRandomExampleSuggestionsToReview(reqMock, resMock, nextMock);
       expect(resMock.send).toBeCalledWith([]);
+    });
+  });
+
+  describe('Bulk Uploading Example Suggestions', () => {
+    it('bulk uploads 500 example suggestions', async () => {
+      const exampleSentenceData = times(500, (index) => ({
+        igbo: `random-sentence-${index}`,
+      }));
+      const result = times(500, (index) => ({
+        message: 'Success',
+        meta: {
+          sentenceData: `random-sentence-${index}`,
+        },
+        success: true,
+      }));
+      const mongooseConnection = await connectDatabase();
+      const reqMock = {
+        user: { uid: AUTH_TOKEN.ADMIN_AUTH_TOKEN },
+        body: exampleSentenceData,
+        mongooseConnection,
+      };
+
+      const resMock = {
+        send: jest.fn(),
+        setHeader: jest.fn(),
+      };
+      const nextMock = jest.fn();
+      await postBulkUploadExampleSuggestions(reqMock, resMock, nextMock);
+      expect(resMock.send.mock.calls[0][0]).toMatchObject(result);
     });
   });
 });


### PR DESCRIPTION
## Background
Bulk uploading to MongoDB is very slow. This PR improves the logic so that it uses Mongoose's `insertMany`