### PR TITLE
Lock firebase-tools to v12.9.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '18'
+          node-version: '16'
       - name: Install Project Dependencies
         run: |
           yarn install
-          npm install -g firebase-tools
+          npm install -g firebase-tools@12.9.1
       - name: Build Staging Project
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '18'
+          node-version: '16'
       - name: Install Project Dependencies 🛠
         run: |
           yarn install
-          npm install -g firebase-tools
+          npm install -g firebase-tools@12.9.1
       - name: Log into Docker Account 🐳
         run: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       - name: Run Igbo API Docker Instance 🇳🇬

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "18"
+    "node": "16"
   },
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "precommit": "lint-staged"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "author": "",
   "husky": {


### PR DESCRIPTION
## Background
`firebase-tools >= 13` no longer supports Node v16. This PR locks `firebase-tools` to `v12.9.1` to ensure that we can continue to test and deploy the project.

We are currently unable to simply upgrade Node to v18 because the version of `react-admin-firebase` that we use relies on Node v16: https://github.com/nkowaokwu/igbo-api-admin/actions/runs/7410286793/job/20162239916#step:6:58