### PR TITLE
Send Merged and Denied Emails to Only Nkọwa okwu Users

### DIFF
--- a/src/backend/controllers/email/index.ts
+++ b/src/backend/controllers/email/index.ts
@@ -15,6 +15,7 @@ import {
   AUDIO_PRONUNCIATION_DELETION_NOTIFICATION,
 } from 'src/backend/config';
 import constructMessage from 'src/backend/controllers/email/utils/constructMessage';
+import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
 import { findAdminUserEmails } from '../users';
 import * as Interfaces from '../utils/interfaces';
 
@@ -60,6 +61,10 @@ export const sendDeniedEmail = (data): Promise<void> => {
 
 /* Email sent when suggestion gets merged */
 export const sendMergedEmail = (data: Interfaces.MergedOrRejectedEmailData): Promise<void> => {
+  if (data.source !== SuggestionSourceEnum.COMMUNITY) {
+    return Promise.resolve();
+  }
+
   const message = constructMessage({
     to: data.to,
     templateId: MERGED_SUGGESTION_TEMPLATE,
@@ -77,6 +82,9 @@ export const sendMergedEmail = (data: Interfaces.MergedOrRejectedEmailData): Pro
 
 /* Email sent when a suggestion has been deleted without getting merged */
 export const sendRejectedEmail = (data: Interfaces.MergedOrRejectedEmailData): Promise<void> => {
+  if (data.source !== SuggestionSourceEnum.COMMUNITY) {
+    return Promise.resolve();
+  }
   const message = constructMessage({
     to: data.to,
     templateId: REJECTED_SUGGESTION_TEMPLATE,

--- a/src/backend/controllers/examples/index.ts
+++ b/src/backend/controllers/examples/index.ts
@@ -124,7 +124,14 @@ export const executeMergeExample = async (
 };
 
 /* Sends confirmation merged email to user if they provided an email */
-const handleSendingMergedEmail = async (result, mongooseConnection): Promise<void> => {
+const handleSendingMergedEmail = async (
+  result: Interfaces.ExampleSuggestionData & {
+    authorEmail: string;
+    word: Interfaces.WordData;
+    associatedWords: string[];
+  },
+  mongooseConnection,
+): Promise<void> => {
   try {
     const Word = mongooseConnection.model('Word', wordSchema);
     if (result.authorEmail) {

--- a/src/backend/controllers/utils/interfaces/emailInterfaces.ts
+++ b/src/backend/controllers/utils/interfaces/emailInterfaces.ts
@@ -1,7 +1,10 @@
+import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
+
 export interface MergedOrRejectedEmailData {
   to: [string];
   suggestionType: string;
   submissionLink?: string;
+  source: SuggestionSourceEnum;
   [key: string]: any;
 }
 

--- a/src/backend/controllers/words/index.ts
+++ b/src/backend/controllers/words/index.ts
@@ -14,6 +14,7 @@ import { DICTIONARY_APP_URL } from 'src/backend/config';
 import { assignExampleSuggestionToExampleData } from 'src/backend/controllers/utils/nestedExampleSuggestionUtils';
 import createExample from 'src/backend/controllers/examples/helpers/createExample';
 import findExampleByAssociatedWordId from 'src/backend/controllers/examples/helpers/findExampleByAssociatedWordId';
+import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
 import { sortDocsBy, packageResponse, handleQueries, updateDocumentMerge } from '../utils';
 import {
   searchIgboTextSearch,
@@ -330,7 +331,9 @@ const createWordFromSuggestion = (
     });
 
 /* Sends confirmation merged email to user if they provided an email */
-const handleSendingMergedEmail = async (result: Interfaces.Word): Promise<void> => {
+const handleSendingMergedEmail = async (
+  result: Interfaces.WordData & { authorEmail: string; source: SuggestionSourceEnum; word: string },
+): Promise<void> => {
   try {
     if (result.authorEmail) {
       sendMergedEmail({
@@ -363,6 +366,7 @@ export const mergeWord = async (
     await handleSyncingAntonyms(mergedWord, mongooseConnection);
     await handleSendingMergedEmail({
       ...(mergedWord.toObject ? mergedWord.toObject() : mergedWord),
+      source: suggestionDoc.source,
       wordClass: WordClass[suggestionDoc.wordClass]?.label || 'No word class',
       authorEmail: suggestionDoc.authorEmail,
       authorId: suggestionDoc.authorId,


### PR DESCRIPTION
## Background
To prevent a confusing experience with IgboSpeech, we want to prevent sending confirmation emails concerning merging and denying Example and Word suggestions for Nkọwa okwu users. The Igbo API Editor Platform is responsible for sending emails for several reasons. However, it doesn't have any logic to check whether the recipient should receive their email based on the product they were using.

## Solution
Check to see if the Word or Example suggestion has the `source: SuggestionSourceEnum.COMMUNITY` value living on it. If it does, then we want to send the email since the source of the suggestion came from Nkọwa okwu.