### PR TITLE
Stop updating leaderboard stats to avoid throwing error

### DIFF
--- a/src/Core/Collections/IgboSoundbox/RecordSentenceAudio.tsx
+++ b/src/Core/Collections/IgboSoundbox/RecordSentenceAudio.tsx
@@ -84,7 +84,6 @@ const RecordSentenceAudio = ({
         isClosable: true,
       });
     } catch (err) {
-      console.log('Unable to submit audio', err);
       toast({
         title: 'Unable to save points',
         position: 'top-right',

--- a/src/Core/Collections/IgboSoundbox/VerifySentenceAudio.tsx
+++ b/src/Core/Collections/IgboSoundbox/VerifySentenceAudio.tsx
@@ -94,7 +94,6 @@ const VerifySentenceAudio = ({
         isClosable: true,
       });
     } catch (err) {
-      console.log('Unable to upload submit review', err);
       toast({
         title: 'Unable to save points',
         position: 'top-right',

--- a/src/Login/__tests__/LoginModal.test.tsx
+++ b/src/Login/__tests__/LoginModal.test.tsx
@@ -7,7 +7,7 @@ import UserLoginState from 'src/backend/shared/constants/UserLoginState';
 import LoginModal from '../components/LoginModal';
 
 describe('LoginModal', () => {
-  it('renders the create account form with phone number', async () => {
+  it('renders the create account form with email', async () => {
     const setUserLoginStateMock = jest.fn();
     const setErrorMessageMock = jest.fn();
     const { findByText } = render(
@@ -24,27 +24,52 @@ describe('LoginModal', () => {
     await findByText('Create an account');
     await findByText('Full name');
     await findByText('Phone number');
-    await findByText('Use email instead');
+    await findByText('Use phone instead');
     await findByText('Password');
   });
 
-  it('fill out create account form for phone number', async () => {
-    const setUserLoginStateMock = jest.fn();
-    const setErrorMessageMock = jest.fn();
-    const { findByText, findByPlaceholderText } = render(
-      <TestContext>
-        <LoginModal
-          isOpen
-          onClose={noop}
-          userLoginState={UserLoginState.SIGN_UP}
-          setUserLoginState={setUserLoginStateMock}
-          setErrorMessage={setErrorMessageMock}
-        />
-      </TestContext>,
-    );
-    userEvent.type(await findByPlaceholderText('Full name'), 'Full name');
-    userEvent.type(await findByPlaceholderText('1 (702) 123-4567'), '15555555555');
-    userEvent.type(await findByPlaceholderText('Password'), 'password');
-    userEvent.click(await findByText('Next'));
+  describe('Phone number', () => {
+    it('renders the create account form with phone number', async () => {
+      const setUserLoginStateMock = jest.fn();
+      const setErrorMessageMock = jest.fn();
+      const { findByText } = render(
+        <TestContext>
+          <LoginModal
+            isOpen
+            onClose={noop}
+            userLoginState={UserLoginState.SIGN_UP}
+            setUserLoginState={setUserLoginStateMock}
+            setErrorMessage={setErrorMessageMock}
+          />
+        </TestContext>,
+      );
+      userEvent.click(await findByText('Use phone instead'));
+      await findByText('Create an account');
+      await findByText('Full name');
+      await findByText('Phone number');
+      await findByText('Use email instead');
+      await findByText('Password');
+    });
+
+    it('fill out create account form for phone number', async () => {
+      const setUserLoginStateMock = jest.fn();
+      const setErrorMessageMock = jest.fn();
+      const { findByText, findByPlaceholderText } = render(
+        <TestContext>
+          <LoginModal
+            isOpen
+            onClose={noop}
+            userLoginState={UserLoginState.SIGN_UP}
+            setUserLoginState={setUserLoginStateMock}
+            setErrorMessage={setErrorMessageMock}
+          />
+        </TestContext>,
+      );
+      userEvent.click(await findByText('Use phone instead'));
+      userEvent.type(await findByPlaceholderText('Full name'), 'Full name');
+      userEvent.type(await findByPlaceholderText('1 (702) 123-4567'), '15555555555');
+      userEvent.type(await findByPlaceholderText('Password'), 'password');
+      userEvent.click(await findByText('Next'));
+    });
   });
 });

--- a/src/Login/components/LoginModal.tsx
+++ b/src/Login/components/LoginModal.tsx
@@ -65,7 +65,7 @@ const LoginModal = ({
   userLoginState: UserLoginState;
   setUserLoginState: (value: UserLoginState) => void;
 }): ReactElement => {
-  const [identifierType, setIdentifierType] = useState(IdentifierType.PHONE);
+  const [identifierType, setIdentifierType] = useState(IdentifierType.EMAIL);
   const [displayName, setDisplayName] = useState<string>('');
   const [userIdentifier, setUserIdentifier] = useState<string>('');
   const [password, setPassword] = useState<string>('');

--- a/src/backend/controllers/exampleSuggestions/index.ts
+++ b/src/backend/controllers/exampleSuggestions/index.ts
@@ -632,7 +632,7 @@ export const putAudioForRandomExampleSuggestions = async (
           // console.log(`No example suggestion with the id: ${id}`);
           return null;
         }
-        const userInteractions = new Set(exampleSuggestion.userInteractions);
+        const userInteractions = new Set(exampleSuggestion.userInteractions || []);
         if (pronunciation) {
           // @ts-expect-error _id is missing
           exampleSuggestion.pronunciations.push({

--- a/src/backend/controllers/leaderboard/index.ts
+++ b/src/backend/controllers/leaderboard/index.ts
@@ -157,10 +157,10 @@ export const calculateRecordingExampleLeaderboard = async (
   next: NextFunction,
 ): Promise<any> => {
   const {
-    user: { uid },
+    // user,
     error,
     response,
-    mongooseConnection,
+    // mongooseConnection,
   } = req;
 
   if (error) {
@@ -168,13 +168,13 @@ export const calculateRecordingExampleLeaderboard = async (
   }
 
   try {
-    const user = (await findUser(uid)) as Interfaces.FormattedUser;
-    await updateUserLeaderboardStat({
-      leaderboardType: LeaderboardType.RECORD_EXAMPLE_AUDIO,
-      mongooseConnection,
-      user,
-    });
-
+    // 🚨 Uncomment this section to start updating leaderboard stats. Be careful this code is broken. 🚨
+    // const user = (await findUser(uid)) as Interfaces.FormattedUser;
+    // await updateUserLeaderboardStat({
+    //   leaderboardType: LeaderboardType.RECORD_EXAMPLE_AUDIO,
+    //   mongooseConnection,
+    //   user,
+    // });
     return res.send(response);
   } catch (err) {
     return next(err);

--- a/src/backend/controllers/utils/interfaces/exampleSuggestionInterfaces.ts
+++ b/src/backend/controllers/utils/interfaces/exampleSuggestionInterfaces.ts
@@ -1,4 +1,3 @@
-import { Document } from 'mongoose';
 import { ExampleData } from 'src/backend/controllers/utils/interfaces/exampleInterfaces';
 import { SuggestionData } from 'src/backend/controllers/utils/interfaces/suggestionInterfaces';
 import SuggestionSourceEnum from 'src/backend/shared/constants/SuggestionSourceEnum';
@@ -9,4 +8,4 @@ export interface ExampleSuggestionData extends ExampleData, SuggestionData {
   source: SuggestionSourceEnum;
 }
 
-export interface ExampleSuggestion extends Document<ExampleSuggestionData, any, any> {}
+export interface ExampleSuggestion extends ExampleSuggestionData {}


### PR DESCRIPTION
## Background
Audio recorders were getting error messages when they attempt to submit their recorded audio from reading example suggestions. This led to the team-wide concern that their audio recordings weren't getting saved and tracked on the platform.

## Solution
Example suggestion recordings were getting saved in our database. The issue started after saving those audio recordings and attempted to update the leaderboard stats. Because we aren't using the leaderboard at this moment, we will just comment out the code in the meantime to prevent this error from appearing again.

### Errors
![image](https://github.com/user-attachments/assets/d8f135d5-f22e-486b-b9e9-bc3f76a1f2ac)
![image](https://github.com/user-attachments/assets/145e82a8-3c6a-4f39-92b7-58892ef26110)

